### PR TITLE
Allow OpenAI organization ID to be specified(#15)

### DIFF
--- a/app/views/ai_helper_model_profiles/_form.html.erb
+++ b/app/views/ai_helper_model_profiles/_form.html.erb
@@ -15,7 +15,9 @@
   <p id="ai-helper-model-llm-model">
     <%= f.text_field :temperature, size: 60, required: true %>
   </p>
-
+  <p id="ai-helper-model-organization-id">
+    <%= f.text_field :organization_id, size: 60 %>
+  </p>
   <p id="ai-helper-model-base-uri">
     <%= f.text_field :base_uri, size: 60, required: true %>
   </p>
@@ -34,6 +36,12 @@
       } else {
         $('#ai-helper-model-base-uri').hide();
         $('#ai-helper-mode-access-key .required').show();
+      }
+
+      if (selectedValue == '<%= RedmineAiHelper::LlmProvider::LLM_OPENAI %>') {
+        $('#ai-helper-model-organization-id').show();
+      } else {
+        $('#ai-helper-model-organization-id').hide();
       }
     });
 

--- a/app/views/ai_helper_model_profiles/_show.html.erb
+++ b/app/views/ai_helper_model_profiles/_show.html.erb
@@ -21,6 +21,12 @@
   <%= label_tag AiHelperModelProfile.human_attribute_name(:temperature) %>
   <%= @model_profile.temperature %>
 </p>
+<% if@model_profile.llm_type == RedmineAiHelper::LlmProvider::LLM_OPENAI %>
+<p>
+  <%= label_tag AiHelperModelProfile.human_attribute_name(:organization_id) %>
+  <%= @model_profile.organization_id %>
+</p>
+<% end %>
 <% if@model_profile.llm_type == RedmineAiHelper::LlmProvider::LLM_OPENAI_COMPATIBLE %>
 <p>
   <%= label_tag AiHelperModelProfile.human_attribute_name(:base_uri) %>

--- a/lib/redmine_ai_helper/llm_client/open_ai_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/open_ai_provider.rb
@@ -15,6 +15,7 @@ module RedmineAiHelper
         llm_options = {}
         llm_options[:organization_id] = model_profile.organization_id if model_profile.organization_id
         llm_options[:embedding_model] = setting.embedding_model unless setting.embedding_model.blank?
+        llm_options[:organization_id] = model_profile.organization_id if model_profile.organization_id
         default_options = {
           model: model_profile.llm_model,
           temperature: model_profile.temperature,


### PR DESCRIPTION
Enable to specify an Organization ID when configuring OpenAI in the settings screen.