### PR TITLE
Fix Template Error in Redmine 6.0.0–6.0.4(#25)

### DIFF
--- a/app/views/ai_helper/_issue_bottom.html.erb
+++ b/app/views/ai_helper/_issue_bottom.html.erb
@@ -47,7 +47,7 @@
 <% end %>
 <fieldset id="ai-helper-summary-fields" class="collapsible collapsed">
     <legend onclick="toggleFieldset(this);" class="icon icon-collapsed">
-    <%= sprite_icon("angle-right", rtl: true) %>
+    <%= sprite_icon("angle-right") %>
     <strong>
         <%= sprite_icon("ai-helper-robot", plugin: :redmine_ai_helper)%>
         <%= l(:ai_helper_summary) %>

--- a/app/views/ai_helper/_issue_form.html.erb
+++ b/app/views/ai_helper/_issue_form.html.erb
@@ -2,7 +2,7 @@
 
 <fieldset id="ai-helper-reply-fields" class="collapsible collapsed">
     <legend onclick="toggleFieldset(this);" class="icon icon-collapsed">
-    <%= sprite_icon("angle-right", rtl: true) %>
+    <%= sprite_icon("angle-right") %>
     <strong>
         <%= sprite_icon("ai-helper-robot", plugin: :redmine_ai_helper)%>
         <%= l('ai_helper.generate_issue_reply.title') %>


### PR DESCRIPTION
Fix issue where tickets could not be displayed in Redmine 6.0.0–6.0.4

Removed sprite_icon function's rtl parameter.
It's option is availables only on 6.0.5 or later.

Fixes #25.