### PR TITLE
Fix 400 error in Project Health Report(#148)

### DIFF
--- a/lib/redmine_ai_helper/tools/project_tools.rb
+++ b/lib/redmine_ai_helper/tools/project_tools.rb
@@ -253,7 +253,6 @@ module RedmineAiHelper
             update_frequency_metrics: calculate_update_frequency_metrics(issues),
             estimation_accuracy_metrics: calculate_estimation_accuracy_metrics(issues),
             attachment_metrics: calculate_attachment_metrics(issues),
-            issue_list: extract_issue_list(issues),
           }
 
           ai_helper_logger.info "get_metrics returning: #{metrics.to_json}"


### PR DESCRIPTION
Removed the issue list from the health report prompt to reduce token usage and prevent 400 errors.
Fixes #148 