### PR TITLE
Fix: Use 'system' role instead of 'developer' for OpenAI-compatible providers

### DIFF
--- a/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
@@ -33,6 +33,7 @@ module RedmineAiHelper
         RubyLLM.context do |config|
           config.openai_api_key = profile.access_key
           config.openai_api_base = profile.base_uri
+          config.openai_use_system_role = true
         end
       end
     end

--- a/test/unit/llm_client/open_ai_compatible_provider_test.rb
+++ b/test/unit/llm_client/open_ai_compatible_provider_test.rb
@@ -100,5 +100,11 @@ class RedmineAiHelper::LlmClient::OpenAiCompatibleProviderTest < ActiveSupport::
 
       @provider.create_chat(tools: [tool_class])
     end
+
+    should "set openai_use_system_role to true in context config" do
+      context = @provider.context
+      assert_equal true, context.config.openai_use_system_role,
+        "openai_use_system_role should be true for OpenAI-compatible providers to avoid sending 'developer' role"
+    end
   end
 end


### PR DESCRIPTION
fix #242 