### PR TITLE
feat: implement per-user token injection for MCP Redmine tools

### DIFF
--- a/lib/redmine_ai_helper/tools/mcp_tools.rb
+++ b/lib/redmine_ai_helper/tools/mcp_tools.rb
@@ -12,10 +12,12 @@ module RedmineAiHelper
         # Return MCP tools directly from the client.
         # @param mcp_server_name [String] MCP server name
         # @param mcp_client [RubyLLM::MCP::Client] MCP client instance
+        # @param cache_key [String, nil] Optional cache key (e.g. per-user)
         # @return [Array<RubyLLM::MCP::Tool>] array of tool instances
-        def generate_tool_classes(mcp_server_name:, mcp_client:)
+        def generate_tool_classes(mcp_server_name:, mcp_client:, cache_key: nil)
           @mcp_tool_cache ||= {}
-          @mcp_tool_cache[mcp_server_name] ||= begin
+          key = cache_key ? "#{mcp_server_name}:#{cache_key}" : mcp_server_name
+          @mcp_tool_cache[key] ||= begin
             tools = mcp_client.tools
             RedmineAiHelper::CustomLogger.instance.info "Loaded #{tools.size} tools from MCP server '#{mcp_server_name}'"
             tools

--- a/lib/redmine_ai_helper/util/mcp_server_loader.rb
+++ b/lib/redmine_ai_helper/util/mcp_server_loader.rb
@@ -39,11 +39,8 @@ module RedmineAiHelper
               next
             end
 
-            # Create MCP client
-            mcp_client = create_mcp_client(server_name, server_config)
-
             # Create dynamic subclass
-            create_mcp_agent_subclass(class_name, server_name, mcp_client)
+            create_mcp_agent_subclass(class_name, server_name, server_config)
 
             ai_helper_logger.info "Successfully created MCP agent: #{class_name} for server '#{server_name}'"
           rescue => e
@@ -112,18 +109,20 @@ module RedmineAiHelper
       end
 
       # Create MCP client
-      def create_mcp_client(server_name, server_config)
+      def create_mcp_client(server_name, server_config, current_user: User.current)
+        resolved_server_config = resolve_dynamic_auth_config(server_name, server_config, current_user: current_user)
+
         # Allow implicit type inference
-        server_type = server_config["type"] || infer_server_type(server_config)
+        server_type = resolved_server_config["type"] || infer_server_type(resolved_server_config)
         case server_type
         when "stdio"
-          create_stdio_client(server_name, server_config)
+          create_stdio_client(server_name, resolved_server_config)
         when "http"
-          create_http_client(server_name, server_config)
+          create_http_client(server_name, resolved_server_config)
         when "sse"
-          create_sse_client(server_name, server_config)
+          create_sse_client(server_name, resolved_server_config)
         else
-          raise ArgumentError, "Unsupported MCP server type: #{server_config["type"] || "unknown"}"
+          raise ArgumentError, "Unsupported MCP server type: #{resolved_server_config["type"] || "unknown"}"
         end
       end
 
@@ -176,14 +175,78 @@ module RedmineAiHelper
         end
       end
 
+      # Resolve dynamic auth placeholders and apply Redmine defaults.
+      # @param server_name [String] MCP server name
+      # @param server_config [Hash] Original MCP server config
+      # @param current_user [User, nil] Current user context
+      # @return [Hash] Resolved MCP server config
+      def resolve_dynamic_auth_config(server_name, server_config, current_user:)
+        config = (server_config || {}).deep_dup
+        api_key = current_user_api_key(current_user)
+
+        if config["headers"].is_a?(Hash)
+          config["headers"] = config["headers"].transform_values { |value| replace_dynamic_placeholders(value, api_key) }
+        end
+
+        if config["env"].is_a?(Hash)
+          config["env"] = config["env"].transform_values { |value| replace_dynamic_placeholders(value, api_key) }
+        end
+
+        inject_redmine_api_key!(server_name, config, api_key)
+        config
+      end
+
+      # Returns current user's API key, generating one if needed.
+      # @param current_user [User, nil]
+      # @return [String, nil]
+      def current_user_api_key(current_user)
+        return nil unless current_user&.logged?
+
+        current_user.generate_api_key if current_user.api_key.blank?
+        current_user.api_key
+      rescue => e
+        ai_helper_logger.warn "Failed to resolve current user API key: #{e.message}"
+        nil
+      end
+
+      # Replace known API key placeholders with the resolved value.
+      # @param value [Object]
+      # @param api_key [String, nil]
+      # @return [Object]
+      def replace_dynamic_placeholders(value, api_key)
+        return value unless value.is_a?(String)
+
+        value.gsub(/\$\{current_user_api_key\}|\{\{current_user_api_key\}\}|__CURRENT_USER_API_KEY__/i, api_key.to_s)
+      end
+
+      # Inject default Redmine auth headers/envs for Redmine MCP servers.
+      # @param server_name [String]
+      # @param config [Hash]
+      # @param api_key [String, nil]
+      # @return [void]
+      def inject_redmine_api_key!(server_name, config, api_key)
+        return unless api_key.present?
+        return unless server_name.to_s.downcase.include?("redmine")
+
+        if config["url"]
+          config["headers"] ||= {}
+          config["headers"]["X-Redmine-API-Key"] ||= api_key
+        end
+
+        if config["command"] || config["args"] || config["type"] == "stdio"
+          config["env"] ||= {}
+          config["env"]["REDMINE_API_KEY"] ||= api_key
+        end
+      end
+
       # Dynamically create MCP agent subclass
-      def create_mcp_agent_subclass(class_name, server_name, mcp_client)
+      def create_mcp_agent_subclass(class_name, server_name, server_config)
         sub_agent_class = Class.new(RedmineAiHelper::BaseAgent) do
           @server_name = server_name
-          @mcp_client = mcp_client
+          @server_config = server_config
 
           class << self
-            attr_reader :server_name, :mcp_client
+            attr_reader :server_name, :server_config
           end
 
           define_method :role do
@@ -204,10 +267,22 @@ module RedmineAiHelper
           end
 
           define_method :available_tool_classes do
-            return @cached_tool_classes if @cached_tool_classes
-            @cached_tool_classes = RedmineAiHelper::Tools::McpTools.generate_tool_classes(
+            cache_key = User.current&.id || "anonymous"
+            @cached_tool_classes ||= {}
+            return @cached_tool_classes[cache_key] if @cached_tool_classes.key?(cache_key)
+
+            @mcp_clients ||= {}
+            mcp_client = @mcp_clients[cache_key] ||= RedmineAiHelper::Util::McpServerLoader.instance.send(
+              :create_mcp_client,
+              server_name,
+              server_config,
+              current_user: User.current,
+            )
+
+            @cached_tool_classes[cache_key] = RedmineAiHelper::Tools::McpTools.generate_tool_classes(
               mcp_server_name: server_name,
               mcp_client: mcp_client,
+              cache_key: cache_key,
             )
           rescue => e
             ai_helper_logger.error "Error loading tools for MCP server '#{server_name}': #{e.message}"

--- a/test/unit/util/mcp_server_loader_test.rb
+++ b/test/unit/util/mcp_server_loader_test.rb
@@ -132,7 +132,7 @@ class McpServerLoaderTest < ActiveSupport::TestCase
       mock_logger = create_mock_logger
 
       @loader.stubs(:load_config).returns(config)
-      @loader.expects(:create_mcp_client).with("filesystem", server_config).returns(fake_client)
+      @loader.expects(:create_mcp_client).with("filesystem", server_config, current_user: nil).returns(fake_client)
       RedmineAiHelper::CustomLogger.stubs(:instance).returns(mock_logger)
 
       # Build fake tool instances (as ruby_llm-mcp returns)
@@ -140,6 +140,7 @@ class McpServerLoaderTest < ActiveSupport::TestCase
       RedmineAiHelper::Tools::McpTools.expects(:generate_tool_classes).with(
         mcp_server_name: "filesystem",
         mcp_client: fake_client,
+        cache_key: "anonymous",
       ).once.returns(fake_tools)
 
       stub_llm_provider
@@ -187,7 +188,7 @@ class McpServerLoaderTest < ActiveSupport::TestCase
       mock_logger.expects(:error).with(includes("Error loading tools for MCP server 'filesystem': boom"))
 
       @loader.stubs(:load_config).returns(config)
-      @loader.expects(:create_mcp_client).with("filesystem", server_config).returns(fake_client)
+      @loader.expects(:create_mcp_client).with("filesystem", server_config, current_user: nil).returns(fake_client)
       RedmineAiHelper::CustomLogger.stubs(:instance).returns(mock_logger)
 
       stub_llm_provider
@@ -216,7 +217,7 @@ class McpServerLoaderTest < ActiveSupport::TestCase
       mock_logger.expects(:error).with(includes("Error retrieving tools information for 'filesystem': tool failure"))
 
       @loader.stubs(:load_config).returns(config)
-      @loader.expects(:create_mcp_client).returns(fake_client)
+      @loader.stubs(:create_mcp_client).with("filesystem", config["mcpServers"]["filesystem"], current_user: nil).returns(fake_client)
       RedmineAiHelper::CustomLogger.stubs(:instance).returns(mock_logger)
       RedmineAiHelper::Tools::McpTools.stubs(:generate_tool_classes).returns(build_fake_tool_instances)
 
@@ -261,6 +262,45 @@ class McpServerLoaderTest < ActiveSupport::TestCase
       http_config = { "url" => "https://example.com" }
       assert @loader.send(:valid_server_config?, http_config)
       assert_equal "http", http_config["type"]
+    end
+
+    should "replace current user api key placeholders in headers and env" do
+      config = {
+        "type" => "http",
+        "url" => "https://example.com/mcp",
+        "headers" => {
+          "X-Redmine-API-Key" => "${current_user_api_key}",
+          "Authorization" => "Bearer {{current_user_api_key}}",
+        },
+        "env" => {
+          "REDMINE_API_KEY" => "__CURRENT_USER_API_KEY__",
+        },
+      }
+
+      user = mock("user")
+      user.stubs(:logged?).returns(true)
+      user.stubs(:api_key).returns("abc123")
+
+      resolved = @loader.send(:resolve_dynamic_auth_config, "custom", config, current_user: user)
+
+      assert_equal "abc123", resolved["headers"]["X-Redmine-API-Key"]
+      assert_equal "Bearer abc123", resolved["headers"]["Authorization"]
+      assert_equal "abc123", resolved["env"]["REDMINE_API_KEY"]
+    end
+
+    should "inject current user redmine api key for redmine servers when missing" do
+      config = {
+        "type" => "http",
+        "url" => "https://redmine.example.com/mcp",
+      }
+
+      user = mock("user")
+      user.stubs(:logged?).returns(true)
+      user.stubs(:api_key).returns("redmine_user_key")
+
+      resolved = @loader.send(:resolve_dynamic_auth_config, "redmine_search", config, current_user: user)
+
+      assert_equal "redmine_user_key", resolved["headers"]["X-Redmine-API-Key"]
     end
   end
 


### PR DESCRIPTION
- Add user-aware MCP client creation with dynamic token resolution
- Support multiple placeholder patterns (${current_user_api_key}, {{current_user_api_key}}, __CURRENT_USER_API_KEY__)
- Auto-inject X-Redmine-API-Key header for Redmine servers
- Implement per-user tool caching to prevent token leakage across sessions
- Update tests to verify user-specific token handling