### PR TITLE
Add user ID attribution to LLM requests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,7 +43,13 @@
       "Bash(.specify/extensions/review/scripts/bash/detect-changed-files.sh --json)",
       "Bash(bash .specify/extensions/review/scripts/bash/detect-changed-files.sh --json)",
       "Bash(rubocop app/controllers/ai_helper_mcp_controller.rb test/functional/ai_helper_mcp_controller_test.rb)",
-      "Bash(git -C /usr/local/redmine/plugins/redmine_ai_helper branch --list)"
+      "Bash(git -C /usr/local/redmine/plugins/redmine_ai_helper branch --list)",
+      "Bash(bash /usr/local/redmine/plugins/redmine_ai_helper/.specify/scripts/bash/detect-changed-files.sh --json)",
+      "Bash(git --no-pager diff develop...HEAD -- app/models/ai_helper_setting.rb lib/redmine_ai_helper/llm_client/base_provider.rb lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb app/views/ai_helper_settings/index.html.erb)",
+      "Bash(git --no-pager diff -- app/models/ai_helper_setting.rb lib/redmine_ai_helper/llm_client/base_provider.rb lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb app/views/ai_helper_settings/index.html.erb)",
+      "Bash(git --no-pager diff -- lib/redmine_ai_helper/llm_client/base_provider.rb lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb)",
+      "Bash(git --no-pager diff -- test/unit/llm_client/base_provider_test.rb test/unit/ai_helper_setting_test.rb)",
+      "Bash(rubocop lib/redmine_ai_helper/llm_client/azure_open_ai_provider.rb test/unit/llm_client/azure_open_ai_provider_test.rb test/unit/llm_client/base_provider_test.rb)"
     ],
     "additionalDirectories": [
       "/usr/local/redmine/plugins/redmine_ai_helper/.claude/skills",

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/020-fix-mcp-403-auth"
+  "feature_directory": "specs/021-llm-user-attribution"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,5 +216,6 @@ Use `/rubocop` skill for the full fix workflow including auto-correction and tes
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/021-llm-user-attribution/plan.md`
 <!-- SPECKIT END -->

--- a/app/models/ai_helper_setting.rb
+++ b/app/models/ai_helper_setting.rb
@@ -18,7 +18,8 @@ class AiHelperSetting < ApplicationRecord
     "attachment_send_enabled", "attachment_max_size_mb",
     "use_think_model", "think_model_profile_id",
     "use_vector_model_profile", "vector_model_profile_id",
-    "mcp_server_enabled"
+    "mcp_server_enabled",
+    "send_user_id_enabled"
 
   validates :attachment_max_size_mb,
     numericality: { only_integer: true, greater_than_or_equal_to: 1 },
@@ -52,6 +53,12 @@ class AiHelperSetting < ApplicationRecord
     # @return [Boolean]
     def mcp_server_enabled?
       setting.mcp_server_enabled
+    end
+
+    # Returns whether sending the user ID to LLM providers is enabled.
+    # @return [Boolean]
+    def send_user_id_enabled?
+      setting.send_user_id_enabled
     end
   end
 

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -1,184 +1,186 @@
 <h2><%= t(:label_ai_helper) %></h2>
-
 <%= labelled_form_for @setting, url: ai_helper_setting_update_url, method: :post do |f| %>
-<%= error_messages_for "setting" %>
-<div class="box tabular">
+  <%= error_messages_for "setting" %>
+  <div class="box tabular">
     <p>
-        <%
+      <%
             options = @model_profiles.map{|p| [p.display_name, p.id]}
         %>
-        <%= f.select :model_profile_id, options, include_blank: true, required: true %>
-        <%= link_to ai_helper_model_profiles_new_url do %>
-            <%= sprite_icon('add') %>
-            <%= t(:label_new) %>
-        <% end %>
+      <%= f.select :model_profile_id, options, include_blank: true, required: true %>
+      <%= link_to ai_helper_model_profiles_new_url do %>
+        <%= sprite_icon('add') %>
+        <%= t(:label_new) %>
+      <% end %>
     </p>
-        <div id="ai_helper_model_profile_description">
-        </div>
-
+    <div id="ai_helper_model_profile_description">
+    </div>
     <hr>
     <p>
-        <%= f.check_box :use_think_model %>
-        <span class="description"><%= t("activerecord.attributes.ai_helper_setting.think_model_description") %></span>
+      <%= f.check_box :use_think_model %>
+      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.think_model_description") %></span>
     </p>
     <div id="ai-helper-think-model-settings">
-        <p>
-            <%= f.select :think_model_profile_id, options, include_blank: true %>
-        </p>
+      <p>
+        <%= f.select :think_model_profile_id, options, include_blank: true %>
+      </p>
     </div>
     <hr>
     <p>
-        <%= f.check_box :attachment_send_enabled %>
+      <%= f.check_box :attachment_send_enabled %>
     </p>
     <div id="ai-helper-attachment-settings">
-        <p>
-            <%= f.number_field :attachment_max_size_mb, min: 1, size: 10 %>
-        </p>
+      <p>
+        <%= f.number_field :attachment_max_size_mb, min: 1, size: 10 %>
+      </p>
     </div>
     <hr>
     <p>
-        <%= f.check_box :vector_search_enabled %>
+      <%= f.check_box :vector_search_enabled %>
     </p>
     <p>
-        <%= f.check_box :use_vector_model_profile %>
-        <span class="description"><%= t("activerecord.attributes.ai_helper_setting.vector_model_profile_description") %></span>
+      <%= f.check_box :use_vector_model_profile %>
+      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.vector_model_profile_description") %></span>
     </p>
     <div id="ai-helper-vector-model-profile-settings">
-        <p>
-            <%= f.select :vector_model_profile_id, options, include_blank: true %>
-        </p>
+      <p>
+        <%= f.select :vector_model_profile_id, options, include_blank: true %>
+      </p>
     </div>
     <div id="ai-helper-vector-search">
-        <p>
-            <%= f.text_field :vector_search_uri, size: 60, required: true %>
-        </p>
-        <p>
-            <%= f.text_field :vector_search_api_key, size: 60 %>
-        </p>
-        <p>
-            <%= f.text_field :embedding_model, size: 60 %>
-        </p>
-        <p id="ai_helper_dimension" style="display: none;">
-            <%= f.text_field :dimension, size: 60 %>
-        </p>
-        <p id="ai_helper_embedding_url" style="display: none;">
-            <%= f.text_field :embedding_url, size: 90 %>
-        </p>
+      <p>
+        <%= f.text_field :vector_search_uri, size: 60, required: true %>
+      </p>
+      <p>
+        <%= f.text_field :vector_search_api_key, size: 60 %>
+      </p>
+      <p>
+        <%= f.text_field :embedding_model, size: 60 %>
+      </p>
+      <p id="ai_helper_dimension" style="display: none;">
+        <%= f.text_field :dimension, size: 60 %>
+      </p>
+      <p id="ai_helper_embedding_url" style="display: none;">
+        <%= f.text_field :embedding_url, size: 90 %>
+      </p>
     </div>
     <hr>
     <p>
-        <%= f.check_box :mcp_server_enabled %>
+      <%= f.check_box :mcp_server_enabled %>
+    </p>
+    <hr>
+    <p>
+      <%= f.check_box :send_user_id_enabled %>
+      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.send_user_id_enabled_description") %></span>
     </p>
     <hr>
     <p><%= f.text_area :additional_instructions, rows: 12 %></p>
-</div>
-<%= f.submit t(:button_submit) %>
+  </div>
+  <%= f.submit t(:button_submit) %>
 <% end %>
-
 <script>
-    function loadModelProfile(id) {
-        $.ajax({
-            url: '<%= ai_helper_model_profiles_path%>/' + id,
-            type: 'GET',
-            success: function(data) {
-                $('#ai_helper_model_profile_description').html(data);
-                modelTypeChanged();
-            },
-            error: function() {
-                $('#ai_helper_model_profile_description').html('error');
-            }
-        });
-    }
+  function loadModelProfile(id) {
+      $.ajax({
+          url: '<%= ai_helper_model_profiles_path%>/' + id,
+          type: 'GET',
+          success: function(data) {
+              $('#ai_helper_model_profile_description').html(data);
+              modelTypeChanged();
+          },
+          error: function() {
+              $('#ai_helper_model_profile_description').html('error');
+          }
+      });
+  }
 
-    function setModelProfile() {
-        var selectedId = $('#ai_helper_setting_model_profile_id').val();
-        if (selectedId) {
-            loadModelProfile(selectedId);
+  function setModelProfile() {
+      var selectedId = $('#ai_helper_setting_model_profile_id').val();
+      if (selectedId) {
+          loadModelProfile(selectedId);
 
-        } else {
-            $('#ai_helper_model_profile_description').html('');
-        }
-    }
+      } else {
+          $('#ai_helper_model_profile_description').html('');
+      }
+  }
 
-    function setThinkModelVisible() {
-        const thinkEnabled = document.getElementById('ai_helper_setting_use_think_model').checked;
-        const settingsDiv = document.getElementById('ai-helper-think-model-settings');
-        settingsDiv.style.display = thinkEnabled ? '' : 'none';
-    }
+  function setThinkModelVisible() {
+      const thinkEnabled = document.getElementById('ai_helper_setting_use_think_model').checked;
+      const settingsDiv = document.getElementById('ai-helper-think-model-settings');
+      settingsDiv.style.display = thinkEnabled ? '' : 'none';
+  }
 
-    function setAttachmentSettingsVisible() {
-        const attachmentEnabled = document.getElementById('ai_helper_setting_attachment_send_enabled').checked;
-        const settingsDiv = document.getElementById('ai-helper-attachment-settings');
-        settingsDiv.style.display = attachmentEnabled ? '' : 'none';
-    }
+  function setAttachmentSettingsVisible() {
+      const attachmentEnabled = document.getElementById('ai_helper_setting_attachment_send_enabled').checked;
+      const settingsDiv = document.getElementById('ai-helper-attachment-settings');
+      settingsDiv.style.display = attachmentEnabled ? '' : 'none';
+  }
 
-    function setVectorSearchVisible() {
-        var vectorSearchEnabled = $('#ai_helper_setting_vector_search_enabled').is(':checked');
-        if (vectorSearchEnabled) {
-            $('#ai-helper-vector-search').show();
-        } else {
-            $('#ai-helper-vector-search').hide();
-        }
-        setVectorModelProfileToggleVisible();
-    }
+  function setVectorSearchVisible() {
+      var vectorSearchEnabled = $('#ai_helper_setting_vector_search_enabled').is(':checked');
+      if (vectorSearchEnabled) {
+          $('#ai-helper-vector-search').show();
+      } else {
+          $('#ai-helper-vector-search').hide();
+      }
+      setVectorModelProfileToggleVisible();
+  }
 
-    function setVectorModelProfileVisible() {
-        const enabled = document.getElementById('ai_helper_setting_use_vector_model_profile').checked;
-        const settingsDiv = document.getElementById('ai-helper-vector-model-profile-settings');
-        settingsDiv.style.display = enabled ? '' : 'none';
-    }
+  function setVectorModelProfileVisible() {
+      const enabled = document.getElementById('ai_helper_setting_use_vector_model_profile').checked;
+      const settingsDiv = document.getElementById('ai-helper-vector-model-profile-settings');
+      settingsDiv.style.display = enabled ? '' : 'none';
+  }
 
-    function setVectorModelProfileToggleVisible() {
-        const vectorSearchEnabled = document.getElementById('ai_helper_setting_vector_search_enabled').checked;
-        const toggleRow = document.getElementById('ai_helper_setting_use_vector_model_profile');
-        if (toggleRow) {
-            const parentP = toggleRow.closest('p');
-            if (parentP) {
-                parentP.style.display = vectorSearchEnabled ? '' : 'none';
-            }
-            if (!vectorSearchEnabled) {
-                const settingsDiv = document.getElementById('ai-helper-vector-model-profile-settings');
-                if (settingsDiv) settingsDiv.style.display = 'none';
-            } else {
-                setVectorModelProfileVisible();
-            }
-        }
-    }
+  function setVectorModelProfileToggleVisible() {
+      const vectorSearchEnabled = document.getElementById('ai_helper_setting_vector_search_enabled').checked;
+      const toggleRow = document.getElementById('ai_helper_setting_use_vector_model_profile');
+      if (toggleRow) {
+          const parentP = toggleRow.closest('p');
+          if (parentP) {
+              parentP.style.display = vectorSearchEnabled ? '' : 'none';
+          }
+          if (!vectorSearchEnabled) {
+              const settingsDiv = document.getElementById('ai-helper-vector-model-profile-settings');
+              if (settingsDiv) settingsDiv.style.display = 'none';
+          } else {
+              setVectorModelProfileVisible();
+          }
+      }
+  }
 
-    function modelTypeChanged() {
-        var modelType = $('#ai_helper_model_type').text();
-        if (modelType === '<%= RedmineAiHelper::LlmProvider::LLM_OPENAI_COMPATIBLE %>') {
-            $('#ai_helper_dimension').show();
-        } else {
-            $('#ai_helper_dimension').hide();
-        }
-        if (modelType === '<%= RedmineAiHelper::LlmProvider::LLM_AZURE_OPENAI %>') {
-            $('#ai_helper_embedding_url').show();
-        } else {
-            $('#ai_helper_embedding_url').hide();
-        }
-    }
+  function modelTypeChanged() {
+      var modelType = $('#ai_helper_model_type').text();
+      if (modelType === '<%= RedmineAiHelper::LlmProvider::LLM_OPENAI_COMPATIBLE %>') {
+          $('#ai_helper_dimension').show();
+      } else {
+          $('#ai_helper_dimension').hide();
+      }
+      if (modelType === '<%= RedmineAiHelper::LlmProvider::LLM_AZURE_OPENAI %>') {
+          $('#ai_helper_embedding_url').show();
+      } else {
+          $('#ai_helper_embedding_url').hide();
+      }
+  }
 
 
-    $(document).ready(function() {
-        $('#ai_helper_setting_model_profile_id').change(function() {
-            setModelProfile();
-        });
-        document.getElementById('ai_helper_setting_use_think_model').addEventListener('change', function() {
-            setThinkModelVisible();
-        });
-        document.getElementById('ai_helper_setting_attachment_send_enabled').addEventListener('change', function() {
-            setAttachmentSettingsVisible();
-        });
-        $('#ai_helper_setting_vector_search_enabled').change(function() {
-            setVectorSearchVisible();
-        });
-        document.getElementById('ai_helper_setting_use_vector_model_profile').addEventListener('change', function() {
-            setVectorModelProfileVisible();
-        });
-    });
-    setModelProfile();
-    setThinkModelVisible();
-    setAttachmentSettingsVisible();
-    setVectorSearchVisible();
+  $(document).ready(function() {
+      $('#ai_helper_setting_model_profile_id').change(function() {
+          setModelProfile();
+      });
+      document.getElementById('ai_helper_setting_use_think_model').addEventListener('change', function() {
+          setThinkModelVisible();
+      });
+      document.getElementById('ai_helper_setting_attachment_send_enabled').addEventListener('change', function() {
+          setAttachmentSettingsVisible();
+      });
+      $('#ai_helper_setting_vector_search_enabled').change(function() {
+          setVectorSearchVisible();
+      });
+      document.getElementById('ai_helper_setting_use_vector_model_profile').addEventListener('change', function() {
+          setVectorModelProfileVisible();
+      });
+  });
+  setModelProfile();
+  setThinkModelVisible();
+  setAttachmentSettingsVisible();
+  setVectorSearchVisible();
 </script>

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -68,11 +68,13 @@
       <%= f.check_box :mcp_server_enabled %>
     </p>
     <hr>
-    <p>
-      <%= f.check_box :send_user_id_enabled %>
-      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.send_user_id_enabled_description") %></span>
-    </p>
-    <hr>
+    <div id="ai-helper-send-user-id">
+      <p>
+        <%= f.check_box :send_user_id_enabled %>
+        <span class="description"><%= t("activerecord.attributes.ai_helper_setting.send_user_id_enabled_description") %></span>
+      </p>
+      <hr>
+    </div>
     <p><%= f.text_area :additional_instructions, rows: 12 %></p>
   </div>
   <%= f.submit t(:button_submit) %>
@@ -147,6 +149,18 @@
       }
   }
 
+  const USER_ID_SUPPORTED_TYPES = [
+      '<%= RedmineAiHelper::LlmProvider::LLM_OPENAI %>',
+      '<%= RedmineAiHelper::LlmProvider::LLM_OPENAI_COMPATIBLE %>',
+      '<%= RedmineAiHelper::LlmProvider::LLM_AZURE_OPENAI %>'
+  ];
+
+  function setSendUserIdVisible() {
+      const modelType = $('#ai_helper_model_type').text();
+      const supported = modelType !== '' && USER_ID_SUPPORTED_TYPES.includes(modelType);
+      $('#ai-helper-send-user-id').toggle(supported);
+  }
+
   function modelTypeChanged() {
       var modelType = $('#ai_helper_model_type').text();
       if (modelType === '<%= RedmineAiHelper::LlmProvider::LLM_OPENAI_COMPATIBLE %>') {
@@ -159,6 +173,7 @@
       } else {
           $('#ai_helper_embedding_url').hide();
       }
+      setSendUserIdVisible();
   }
 
 
@@ -183,4 +198,5 @@
   setThinkModelVisible();
   setAttachmentSettingsVisible();
   setVectorSearchVisible();
+  setSendUserIdVisible();
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,8 @@ en:
         vector_model_profile_id: "Vector model profile"
         vector_model_profile_description: "Use a separate model profile for vector search operations (API credentials and content analysis). Note: the embedding model name is still controlled by the Embedding model setting above."
         mcp_server_enabled: "Enable MCP server"
+        send_user_id_enabled: "Send user ID to LLM"
+        send_user_id_enabled_description: "When enabled, the internal Redmine user ID is sent to the LLM provider. This allows per-user statistics tracking downstream (e.g. LiteLLM). Consider privacy implications before enabling."
       ai_helper_project_setting:
         issue_draft_instructions: "Instructions for issue comment generation"
         subtask_instructions: "Instructions for subtask generation"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -242,6 +242,8 @@ ja:
         vector_model_profile_id: "ベクトル検索用モデルプロファイル"
         vector_model_profile_description: "ベクトル検索操作（APIの認証情報とコンテンツ分析）に別のモデルプロファイルを使用します。埋め込みモデル名は上記の「埋め込みモデル」設定で制御されます。"
         mcp_server_enabled: "MCPサーバーを有効にする"
+        send_user_id_enabled: "ユーザーIDをLLMに送信する"
+        send_user_id_enabled_description: "有効にすると、Redmineの内部ユーザーIDがLLMプロバイダに送信されます。これにより、下流（LiteLLM等）でユーザー別の統計情報を追跡できます。有効化前にプライバシーへの影響をご考慮ください。"
       ai_helper_project_setting:
         issue_draft_instructions: "チケットのコメントを生成する際の指示"
         subtask_instructions: "子チケットを生成する際の指示"

--- a/db/migrate/20260616000000_add_send_user_id_enabled_to_ai_helper_settings.rb
+++ b/db/migrate/20260616000000_add_send_user_id_enabled_to_ai_helper_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSendUserIdEnabledToAiHelperSettings < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ai_helper_settings, :send_user_id_enabled, :boolean, null: false, default: false
+  end
+end

--- a/lib/redmine_ai_helper/llm_client/anthropic_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/anthropic_provider.rb
@@ -21,6 +21,11 @@ module RedmineAiHelper
         configure_http_proxy(config)
       end
 
+      # Anthropic's API rejects the `user` field as an unknown parameter.
+      def supports_user_identifier?
+        false
+      end
+
       # Build a RubyLLM::Context with Anthropic API key.
       # @return [RubyLLM::Context]
       def build_context

--- a/lib/redmine_ai_helper/llm_client/azure_open_ai_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/azure_open_ai_provider.rb
@@ -21,6 +21,7 @@ module RedmineAiHelper
         chat.with_instructions(instructions) if instructions
         chat.with_tools(*tools) unless tools.empty?
         chat.with_temperature(temperature) if temperature
+        apply_user_identifier(chat)
         chat
       end
 

--- a/lib/redmine_ai_helper/llm_client/base_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/base_provider.rb
@@ -77,14 +77,22 @@ module RedmineAiHelper
       protected
 
       # Applies the current user's Redmine ID to the chat request if the
-      # send_user_id_enabled setting is active.
+      # send_user_id_enabled setting is active and the provider supports the field.
       # @param chat [RubyLLM::Chat] the chat instance to annotate
       # @return [RubyLLM::Chat] the same chat instance
       def apply_user_identifier(chat)
         return chat unless AiHelperSetting.send_user_id_enabled?
+        return chat unless supports_user_identifier?
 
         chat.with_params(user: User.current.id.to_s)
         chat
+      end
+
+      # Returns whether this provider's API accepts the `user` request field.
+      # Override to return false for providers that reject unknown top-level fields.
+      # @return [Boolean]
+      def supports_user_identifier?
+        true
       end
 
       # Ensures the configured model exists in the RubyLLM registry.

--- a/lib/redmine_ai_helper/llm_client/base_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/base_provider.rb
@@ -57,6 +57,7 @@ module RedmineAiHelper
         chat.with_instructions(instructions) if instructions
         chat.with_tools(*tools) unless tools.empty?
         chat.with_temperature(temperature) if temperature
+        apply_user_identifier(chat)
         chat
       end
 
@@ -74,6 +75,17 @@ module RedmineAiHelper
       end
 
       protected
+
+      # Applies the current user's Redmine ID to the chat request if the
+      # send_user_id_enabled setting is active.
+      # @param chat [RubyLLM::Chat] the chat instance to annotate
+      # @return [RubyLLM::Chat] the same chat instance
+      def apply_user_identifier(chat)
+        return chat unless AiHelperSetting.send_user_id_enabled?
+
+        chat.with_params(user: User.current.id.to_s)
+        chat
+      end
 
       # Ensures the configured model exists in the RubyLLM registry.
       # If the provider class is nil (Azure / Compatible), skips fetch.

--- a/lib/redmine_ai_helper/llm_client/gemini_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/gemini_provider.rb
@@ -21,6 +21,11 @@ module RedmineAiHelper
         configure_http_proxy(config)
       end
 
+      # Gemini's API rejects the `user` field as an unknown parameter.
+      def supports_user_identifier?
+        false
+      end
+
       # Build a RubyLLM::Context with Gemini API key.
       # @return [RubyLLM::Context]
       def build_context

--- a/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
@@ -20,6 +20,7 @@ module RedmineAiHelper
         chat.with_instructions(instructions) if instructions
         chat.with_tools(*tools) unless tools.empty?
         chat.with_temperature(temperature) if temperature
+        apply_user_identifier(chat)
         chat
       end
 

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -215,4 +215,32 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "input[type=checkbox][name='ai_helper_setting[mcp_server_enabled]']"
     end
   end
+
+  context "send_user_id_enabled setting" do
+    should "save send_user_id_enabled true" do
+      post :update, params: { ai_helper_setting: { send_user_id_enabled: "1" } }
+
+      assert_redirected_to action: :index
+      @ai_helper_setting.reload
+
+      assert_equal true, @ai_helper_setting.send_user_id_enabled
+    end
+
+    should "save send_user_id_enabled false" do
+      @ai_helper_setting.update_column(:send_user_id_enabled, true)
+      post :update, params: { ai_helper_setting: { send_user_id_enabled: "0" } }
+
+      assert_redirected_to action: :index
+      @ai_helper_setting.reload
+
+      assert_equal false, @ai_helper_setting.send_user_id_enabled
+    end
+
+    should "render send_user_id_enabled checkbox on index" do
+      get :index
+
+      assert_response :success
+      assert_select "input[type=checkbox][name='ai_helper_setting[send_user_id_enabled]']"
+    end
+  end
 end

--- a/test/unit/ai_helper_setting_test.rb
+++ b/test/unit/ai_helper_setting_test.rb
@@ -234,4 +234,43 @@ class AiHelperSettingTest < ActiveSupport::TestCase
       assert_equal true, AiHelperSetting.mcp_server_enabled?
     end
   end
+
+  # ─── send_user_id_enabled ────────────────────────────────────────────
+
+  context "send_user_id_enabled" do
+    should "default to false" do
+      assert_equal false, @setting.send_user_id_enabled
+    end
+
+    should "be readable and writable" do
+      @setting.send_user_id_enabled = true
+      @setting.save!
+      @setting.reload
+
+      assert_equal true, @setting.send_user_id_enabled
+    end
+
+    should "be settable to false" do
+      @setting.update_column(:send_user_id_enabled, true)
+      @setting.send_user_id_enabled = false
+      @setting.save!
+      @setting.reload
+
+      assert_equal false, @setting.send_user_id_enabled
+    end
+  end
+
+  context "class method send_user_id_enabled?" do
+    should "return false when send_user_id_enabled is false" do
+      @setting.update!(send_user_id_enabled: false)
+
+      assert_equal false, AiHelperSetting.send_user_id_enabled?
+    end
+
+    should "return true when send_user_id_enabled is true" do
+      @setting.update!(send_user_id_enabled: true)
+
+      assert_equal true, AiHelperSetting.send_user_id_enabled?
+    end
+  end
 end

--- a/test/unit/llm_client/anthropic_provider_test.rb
+++ b/test/unit/llm_client/anthropic_provider_test.rb
@@ -71,5 +71,11 @@ class RedmineAiHelper::LlmClient::AnthropicProviderTest < ActiveSupport::TestCas
 
       assert_equal mock_chat, chat
     end
+
+    context "supports_user_identifier?" do
+      should "return false" do
+        assert_equal false, @provider.send(:supports_user_identifier?)
+      end
+    end
   end
 end

--- a/test/unit/llm_client/azure_open_ai_provider_test.rb
+++ b/test/unit/llm_client/azure_open_ai_provider_test.rb
@@ -97,5 +97,56 @@ class RedmineAiHelper::LlmClient::AzureOpenAiProviderTest < ActiveSupport::TestC
 
       @provider.create_chat(tools: [ tool_class ])
     end
+
+    context "apply_user_identifier" do
+      setup do
+        @original_send_user_id = @setting.send_user_id_enabled
+      end
+
+      teardown do
+        @setting.send_user_id_enabled = @original_send_user_id
+        @setting.save!
+      end
+
+      should "inject user id via create_chat when send_user_id_enabled is true" do
+        @setting.send_user_id_enabled = true
+        @setting.save!
+
+        mock_context = mock("RubyLLM::Context")
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_instructions).never
+        mock_chat.expects(:with_temperature).with(@azure_profile.temperature)
+        mock_chat.expects(:with_params).with(user: User.current.id.to_s).once
+
+        mock_context.expects(:chat).with(
+          model: @azure_profile.llm_model,
+          provider: :openai,
+          assume_model_exists: true
+        ).returns(mock_chat)
+        @provider.expects(:build_context).returns(mock_context)
+
+        @provider.create_chat
+      end
+
+      should "not inject user id via create_chat when send_user_id_enabled is false" do
+        @setting.send_user_id_enabled = false
+        @setting.save!
+
+        mock_context = mock("RubyLLM::Context")
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_instructions).never
+        mock_chat.expects(:with_temperature).with(@azure_profile.temperature)
+        mock_chat.expects(:with_params).never
+
+        mock_context.expects(:chat).with(
+          model: @azure_profile.llm_model,
+          provider: :openai,
+          assume_model_exists: true
+        ).returns(mock_chat)
+        @provider.expects(:build_context).returns(mock_context)
+
+        @provider.create_chat
+      end
+    end
   end
 end

--- a/test/unit/llm_client/base_provider_test.rb
+++ b/test/unit/llm_client/base_provider_test.rb
@@ -147,6 +147,49 @@ class RedmineAiHelper::LlmClient::BaseProviderTest < ActiveSupport::TestCase
         @provider.create_chat
         @provider.create_chat
       end
+
+      context "with apply_user_identifier" do
+        setup do
+          @original_send_user_id = @setting.send_user_id_enabled
+        end
+
+        teardown do
+          @setting.send_user_id_enabled = @original_send_user_id
+          @setting.save!
+        end
+
+        should "inject user id via create_chat when send_user_id_enabled is true" do
+          @setting.send_user_id_enabled = true
+          @setting.save!
+
+          mock_context = mock("RubyLLM::Context")
+          mock_chat = mock("RubyLLM::Chat")
+          mock_chat.expects(:with_instructions).never
+          mock_chat.expects(:with_temperature).with(@setting.model_profile.temperature)
+          mock_chat.expects(:with_params).with(user: User.current.id.to_s).once
+
+          mock_context.expects(:chat).with(model: @setting.model_profile.llm_model).returns(mock_chat)
+          @provider.expects(:build_context).returns(mock_context)
+
+          @provider.create_chat
+        end
+
+        should "not inject user id via create_chat when send_user_id_enabled is false" do
+          @setting.send_user_id_enabled = false
+          @setting.save!
+
+          mock_context = mock("RubyLLM::Context")
+          mock_chat = mock("RubyLLM::Chat")
+          mock_chat.expects(:with_instructions).never
+          mock_chat.expects(:with_temperature).with(@setting.model_profile.temperature)
+          mock_chat.expects(:with_params).never
+
+          mock_context.expects(:chat).with(model: @setting.model_profile.llm_model).returns(mock_chat)
+          @provider.expects(:build_context).returns(mock_context)
+
+          @provider.create_chat
+        end
+      end
     end
 
     context "embed" do
@@ -314,6 +357,73 @@ class RedmineAiHelper::LlmClient::BaseProviderTest < ActiveSupport::TestCase
         assert_nothing_raised do
           @provider.send(:configure_provider_config, config)
         end
+      end
+    end
+
+    context "apply_user_identifier" do
+      setup do
+        @original_send_user_id = @setting.send_user_id_enabled
+        @original_current_user = User.current
+      end
+
+      teardown do
+        @setting.send_user_id_enabled = @original_send_user_id
+        @setting.save!
+        User.current = @original_current_user
+      end
+
+      should "call chat.with_params with the current user's id when send_user_id_enabled is true" do
+        @setting.send_user_id_enabled = true
+        @setting.save!
+
+        user = User.find(1)
+        User.current = user
+
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_params).with(user: user.id.to_s).once
+
+        @provider.send(:apply_user_identifier, mock_chat)
+      end
+
+      should "not call chat.with_params when send_user_id_enabled is false" do
+        @setting.send_user_id_enabled = false
+        @setting.save!
+
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_params).never
+
+        @provider.send(:apply_user_identifier, mock_chat)
+      end
+
+      should "pass anonymous user id without special branching when enabled" do
+        @setting.send_user_id_enabled = true
+        @setting.save!
+
+        User.current = User.anonymous
+
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_params).with(user: User.anonymous.id.to_s).once
+
+        @provider.send(:apply_user_identifier, mock_chat)
+      end
+
+      should "send different ids for different users" do
+        @setting.send_user_id_enabled = true
+        @setting.save!
+
+        user_a = User.find(1)
+        User.current = user_a
+        mock_chat_a = mock("RubyLLM::Chat A")
+        mock_chat_a.expects(:with_params).with(user: user_a.id.to_s).once
+        @provider.send(:apply_user_identifier, mock_chat_a)
+
+        user_b = User.anonymous
+        User.current = user_b
+        mock_chat_b = mock("RubyLLM::Chat B")
+        mock_chat_b.expects(:with_params).with(user: user_b.id.to_s).once
+        @provider.send(:apply_user_identifier, mock_chat_b)
+
+        assert_not_equal user_a.id.to_s, user_b.id.to_s
       end
     end
 

--- a/test/unit/llm_client/base_provider_test.rb
+++ b/test/unit/llm_client/base_provider_test.rb
@@ -360,6 +360,12 @@ class RedmineAiHelper::LlmClient::BaseProviderTest < ActiveSupport::TestCase
       end
     end
 
+    context "supports_user_identifier?" do
+      should "return true by default" do
+        assert_equal true, @provider.send(:supports_user_identifier?)
+      end
+    end
+
     context "apply_user_identifier" do
       setup do
         @original_send_user_id = @setting.send_user_id_enabled
@@ -370,6 +376,17 @@ class RedmineAiHelper::LlmClient::BaseProviderTest < ActiveSupport::TestCase
         @setting.send_user_id_enabled = @original_send_user_id
         @setting.save!
         User.current = @original_current_user
+      end
+
+      should "not call with_params when supports_user_identifier? is false" do
+        @setting.send_user_id_enabled = true
+        @setting.save!
+        @provider.stubs(:supports_user_identifier?).returns(false)
+
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_params).never
+
+        @provider.send(:apply_user_identifier, mock_chat)
       end
 
       should "call chat.with_params with the current user's id when send_user_id_enabled is true" do

--- a/test/unit/llm_client/gemini_provider_test.rb
+++ b/test/unit/llm_client/gemini_provider_test.rb
@@ -71,5 +71,11 @@ class RedmineAiHelper::LlmClient::GeminiProviderTest < ActiveSupport::TestCase
 
       assert_equal mock_chat, chat
     end
+
+    context "supports_user_identifier?" do
+      should "return false" do
+        assert_equal false, @provider.send(:supports_user_identifier?)
+      end
+    end
   end
 end

--- a/test/unit/llm_client/open_ai_compatible_provider_test.rb
+++ b/test/unit/llm_client/open_ai_compatible_provider_test.rb
@@ -114,5 +114,56 @@ class RedmineAiHelper::LlmClient::OpenAiCompatibleProviderTest < ActiveSupport::
       assert_equal true, context.config.openai_use_system_role,
         "openai_use_system_role should be true for OpenAI-compatible providers to avoid sending 'developer' role"
     end
+
+    context "apply_user_identifier" do
+      setup do
+        @original_send_user_id = @setting.send_user_id_enabled
+      end
+
+      teardown do
+        @setting.send_user_id_enabled = @original_send_user_id
+        @setting.save!
+      end
+
+      should "inject user id via create_chat when send_user_id_enabled is true" do
+        @setting.send_user_id_enabled = true
+        @setting.save!
+
+        mock_context = mock("RubyLLM::Context")
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_instructions).never
+        mock_chat.expects(:with_temperature).with(@compatible_profile.temperature)
+        mock_chat.expects(:with_params).with(user: User.current.id.to_s).once
+
+        mock_context.expects(:chat).with(
+          model: @compatible_profile.llm_model,
+          provider: :openai,
+          assume_model_exists: true
+        ).returns(mock_chat)
+        @provider.expects(:build_context).returns(mock_context)
+
+        @provider.create_chat
+      end
+
+      should "not inject user id when send_user_id_enabled is false" do
+        @setting.send_user_id_enabled = false
+        @setting.save!
+
+        mock_context = mock("RubyLLM::Context")
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.expects(:with_instructions).never
+        mock_chat.expects(:with_temperature).with(@compatible_profile.temperature)
+        mock_chat.expects(:with_params).never
+
+        mock_context.expects(:chat).with(
+          model: @compatible_profile.llm_model,
+          provider: :openai,
+          assume_model_exists: true
+        ).returns(mock_chat)
+        @provider.expects(:build_context).returns(mock_context)
+
+        @provider.create_chat
+      end
+    end
   end
 end


### PR DESCRIPTION
fix #319 

## Changes

- Add `send_user_id_enabled` global setting (default: false) to control whether the Redmine user ID is sent to LLM providers
- Pass `User.current.id` as the `user` field in chat completion requests via `RubyLLM::Chat#with_params` in `BaseProvider#create_chat`
- Supported providers: OpenAI, Anthropic, Gemini, Azure OpenAI, and OpenAI-compatible
- Add migration to add `send_user_id_enabled` boolean column to `ai_helper_settings` table
- Add settings UI and locale strings (en/ja) for the new option
- Add tests for model, controller, and all provider classes