### PR TITLE
Update Ruby and Redmine versions in configuration files

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,10 +9,10 @@ services:
         # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.2, 3.3, 3.4
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        RUBY_VERSION: "${RUBY_VERSION:-3.4}"
+        RUBY_VERSION: "${RUBY_VERSION:-4.0}"
         # Optional Node.js version to install
         NODE_VERSION: "lts/*"
-        REDMINE_VERSION: "${REDMINE_VERSION:-6.1-stable}"
+        REDMINE_VERSION: "${REDMINE_VERSION:-7.0-stable}"
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.2, 3.3, 3.4
+        # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.2, 3.3, 3.4, 4.0
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         RUBY_VERSION: "${RUBY_VERSION:-4.0}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,19 @@ jobs:
       max-parallel: 10
       matrix:
         db: [sqlite3, mysql, postgres]
-        ruby_version: ["3.1", "3.2", "3.3", "3.4"]
-        redmine_version: [6.0-stable, 6.1-stable, master]
+        ruby_version: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        redmine_version: [6.0-stable, 6.1-stable, 7.0-stable, master]
         exclude:
           - ruby_version: "3.4"
             redmine_version: 6.0-stable
+          - ruby_version: "4.0"
+            redmine_version: 6.0-stable
           - ruby_version: "3.1"
             redmine_version: 6.1-stable
+          - ruby_version: "4.0"
+            redmine_version: 6.1-stable
+          - ruby_version: "3.1"
+            redmine_version: 7.0-stable
           - ruby_version: "3.1"
             redmine_version: master
     services:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,8 @@ jobs:
     # Supported Matrix:
     # Redmine 6.0-stable: Ruby 3.1, 3.2, 3.3
     # Redmine 6.1-stable: Ruby 3.2, 3.3, 3.4
-    # Redmine master: Ruby 3.2, 3.3, 3.4
+    # Redmine 7.0-stable: Ruby 3.2, 3.3, 3.4, 4.0
+    # Redmine master: Ruby 3.2, 3.3, 3.4, 4.0
     strategy:
       max-parallel: 10
       matrix:

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ require "langfuse"
 require "ruby_llm"
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
-load File.expand_path("version.rb", __dir__)
+require File.expand_path("version", __dir__)
 require "redmine_ai_helper/logger"
 
 # Initialize RubyLLM with minimal configuration.

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ require "langfuse"
 require "ruby_llm"
 $LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 
-require_relative "version"
+load File.expand_path("version.rb", __dir__)
 require "redmine_ai_helper/logger"
 
 # Initialize RubyLLM with minimal configuration.


### PR DESCRIPTION
## Changes

- Add Ruby 4.0 and Redmine 7.0-stable to CI build matrix, with corresponding exclusions
- Update devcontainer defaults to Ruby 4.0 and Redmine 7.0-stable
- Load `version.rb` via `File.expand_path` instead of `require_relative` in `init.rb`