### PR TITLE
Fix OpenAI compatible embedings

### DIFF
--- a/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
@@ -24,6 +24,23 @@ module RedmineAiHelper
         chat
       end
 
+      # Generate embeddings via an OpenAI-compatible endpoint (e.g. Ollama).
+      # Overrides BaseProvider#embed to pass provider: :openai and
+      # assume_model_exists: true, so RubyLLM skips its built-in model-catalog
+      # lookup (which doesn't know local models like nomic-embed-text).
+      # @param text [String] text to embed
+      # @return [Array<Float>] embedding vector
+      def embed(text)
+        setting = AiHelperSetting.find_or_create
+        embedding_model = setting.embedding_model.presence || model_name
+        context.embed(
+          text,
+          model: embedding_model,
+          provider: :openai,
+          assume_model_exists: true
+        ).vectors
+      end
+
       protected
 
       # Build a RubyLLM::Context with custom API base URL and key.

--- a/test/unit/llm_client/open_ai_compatible_provider_test.rb
+++ b/test/unit/llm_client/open_ai_compatible_provider_test.rb
@@ -108,6 +108,50 @@ class RedmineAiHelper::LlmClient::OpenAiCompatibleProviderTest < ActiveSupport::
       @provider.create_chat(tools: [ tool_class ])
     end
 
+    should "embed with provider and assume_model_exists options, using AiHelperSetting#embedding_model" do
+      original_embedding_model = @setting.embedding_model
+      @setting.embedding_model = "nomic-embed-text:latest"
+      @setting.save!
+
+      mock_context = mock("RubyLLM::Context")
+      mock_embedding = mock("RubyLLM::Embedding")
+      mock_embedding.expects(:vectors).returns([ 0.1, 0.2, 0.3 ])
+      mock_context.expects(:embed).with(
+        "hello world",
+        model: "nomic-embed-text:latest",
+        provider: :openai,
+        assume_model_exists: true
+      ).returns(mock_embedding)
+      @provider.expects(:build_context).returns(mock_context)
+
+      assert_equal [ 0.1, 0.2, 0.3 ], @provider.embed("hello world")
+    ensure
+      @setting.embedding_model = original_embedding_model
+      @setting.save!
+    end
+
+    should "embed falls back to the profile model when embedding_model is blank" do
+      original_embedding_model = @setting.embedding_model
+      @setting.embedding_model = nil
+      @setting.save!
+
+      mock_context = mock("RubyLLM::Context")
+      mock_embedding = mock("RubyLLM::Embedding")
+      mock_embedding.expects(:vectors).returns([ 1.0 ])
+      mock_context.expects(:embed).with(
+        "text",
+        model: @compatible_profile.llm_model,
+        provider: :openai,
+        assume_model_exists: true
+      ).returns(mock_embedding)
+      @provider.expects(:build_context).returns(mock_context)
+
+      assert_equal [ 1.0 ], @provider.embed("text")
+    ensure
+      @setting.embedding_model = original_embedding_model
+      @setting.save!
+    end
+
     should "set openai_use_system_role to true in context config" do
       context = @provider.context
 


### PR DESCRIPTION
Vector search / embeddings fail when using an OpenAI‑compatible endpoint (e.g. Ollama/local models). 

OpenAiCompatibleProvider#create_chat passes `provider: :openai, assume_model_exists: true`, but there is no embed override, so `BaseProvider#embed` runs `context.embed(model:)` without those options  RubyLLM's catalog lookup rejects local models like nomic-embed-text.

 Fix: Add an embed override mirroring create_chat, passing `provider: :openai, assume_model_exists: true`.

Testing: Verified end‑to‑end against Ollama (nomic-embed-text, OpenAI‑compatible /api)  embeddings and Qdrant indexing/search now work.