### PR TITLE
Suggest estimated hours from similar issues

### DIFF
--- a/app/controllers/ai_helper_controller.rb
+++ b/app/controllers/ai_helper_controller.rb
@@ -277,8 +277,9 @@ class AiHelperController < ApplicationController
       scope = params[:scope]
       scope = SIMILAR_ISSUES_DEFAULT_SCOPE unless SIMILAR_ISSUES_VALID_SCOPES.include?(scope)
       similar_issues = llm.find_similar_issues(issue: @issue, scope: scope, project: @issue.project)
+      estimation = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
 
-      render partial: "ai_helper/issues/similar_issues", locals: { similar_issues: similar_issues }
+      render partial: "ai_helper/issues/similar_issues", locals: { similar_issues: similar_issues, estimation: estimation }
     rescue => e
       ai_helper_logger.error "Similar issues search error: #{e.message}"
       ai_helper_logger.error e.backtrace.join("\n")

--- a/app/views/ai_helper/issues/_bottom.html.erb
+++ b/app/views/ai_helper/issues/_bottom.html.erb
@@ -109,6 +109,56 @@
     return selected ? selected.value : "with_subprojects";
   }
 
+  // Recompute the suggested hours weighted average from the currently
+  // checked similar issues, mirroring RedmineAiHelper::EffortEstimation.suggest.
+  function recalculateSuggestedHours() {
+    const block = document.getElementById('ai-helper-suggested-hours-block');
+    if (!block) return;
+
+    const checkboxes = document.querySelectorAll('.ai-helper-effort-checkbox:checked');
+    let weightedSum = 0;
+    let totalWeight = 0;
+    checkboxes.forEach(function(checkbox) {
+      const spentHours = parseFloat(checkbox.dataset.spentHours);
+      const score = parseFloat(checkbox.dataset.similarityScore);
+      weightedSum += spentHours * score;
+      totalWeight += score;
+    });
+
+    if (checkboxes.length === 0 || totalWeight === 0) {
+      block.style.display = 'none';
+      return;
+    }
+
+    block.style.display = '';
+    const suggestedHours = Math.round((weightedSum / totalWeight) * 10) / 10;
+
+    const valueSpan = document.getElementById('ai-helper-suggested-hours-value');
+    if (valueSpan) {
+      valueSpan.textContent = suggestedHours;
+    }
+
+    const noteSpan = document.getElementById('ai-helper-suggested-hours-note');
+    if (noteSpan) {
+      const count = checkboxes.length;
+      const template = count === 1 ? block.dataset.noteOne : block.dataset.noteOther;
+      noteSpan.textContent = '(' + template.replace('%{count}', count) + ')';
+    }
+  }
+
+  // Write the currently suggested hours into the issue's Estimated hours field.
+  // That field lives inside the "#update" edit form, which Redmine keeps
+  // collapsed (display:none) until the user opens it, so reveal and scroll to
+  // it (via Redmine core's own showAndScrollTo helper) to make the change visible.
+  function applySuggestedHours() {
+    const valueSpan = document.getElementById('ai-helper-suggested-hours-value');
+    const estimatedHoursField = document.getElementById('issue_estimated_hours');
+    if (valueSpan && estimatedHoursField) {
+      estimatedHoursField.value = valueSpan.textContent;
+      showAndScrollTo('update', 'issue_estimated_hours');
+    }
+  }
+
   // Function to move similar issues section to after relations
   function moveSimilarIssuesToRelations() {
     const similarIssuesSection = document.getElementById('ai-helper-similar-issues-section');
@@ -133,6 +183,25 @@
 
     // Move similar issues to relations area
     moveSimilarIssuesToRelations();
+
+    // Handle effort checkbox toggling and the Apply button inside the
+    // dynamically-loaded similar issues area (event delegation, since its
+    // content is replaced via innerHTML after the initial page load).
+    const similarIssuesArea = document.getElementById('ai-helper-similar-issues-area');
+    if (similarIssuesArea) {
+      similarIssuesArea.addEventListener('change', function(e) {
+        if (e.target.classList.contains('ai-helper-effort-checkbox')) {
+          recalculateSuggestedHours();
+        }
+      });
+      similarIssuesArea.addEventListener('click', function(e) {
+        const applyButton = e.target.closest('#ai-helper-apply-suggested-hours');
+        if (applyButton) {
+          e.preventDefault();
+          applySuggestedHours();
+        }
+      });
+    }
   });
 
 <% end %>

--- a/app/views/ai_helper/issues/_similar_issues.html.erb
+++ b/app/views/ai_helper/issues/_similar_issues.html.erb
@@ -1,6 +1,13 @@
 <% if similar_issues.empty? %>
   <p><%= l(:ai_helper_no_similar_issues_found) %></p>
 <% else %>
+  <% estimation = local_assigns.fetch(:estimation, { available: false }) %>
+  <% if estimation[:available] %>
+    <p class="ai-helper-suggested-hours">
+      <strong><%= l(:ai_helper_suggested_hours) %>:</strong> <%= estimation[:suggested_hours] %> h
+      <span class="ai-helper-suggested-hours-note">(<%= l(:ai_helper_suggested_hours_note, count: estimation[:based_on_count]) %>)</span>
+    </p>
+  <% end %>
   <table class="ai-helper-similar-issues-table">
     <thead>
       <tr>

--- a/app/views/ai_helper/issues/_similar_issues.html.erb
+++ b/app/views/ai_helper/issues/_similar_issues.html.erb
@@ -3,14 +3,22 @@
 <% else %>
   <% estimation = local_assigns.fetch(:estimation, { available: false }) %>
   <% if estimation[:available] %>
-    <p class="ai-helper-suggested-hours">
-      <strong><%= l(:ai_helper_suggested_hours) %>:</strong> <%= estimation[:suggested_hours] %> h
-      <span class="ai-helper-suggested-hours-note">(<%= l(:ai_helper_suggested_hours_note, count: estimation[:based_on_count]) %>)</span>
+    <% note_translations = I18n.t(:ai_helper_suggested_hours_note) %>
+    <p class="ai-helper-suggested-hours" id="ai-helper-suggested-hours-block"
+       data-note-one="<%= note_translations[:one] || note_translations[:other] %>"
+       data-note-other="<%= note_translations[:other] %>">
+      <strong><%= l(:ai_helper_suggested_hours) %>:</strong>
+      <span id="ai-helper-suggested-hours-value"><%= estimation[:suggested_hours] %></span> h
+      <span class="ai-helper-suggested-hours-note" id="ai-helper-suggested-hours-note">(<%= l(:ai_helper_suggested_hours_note, count: estimation[:based_on_count]) %>)</span>
+      <%= link_to l(:button_apply), "#", id: "ai-helper-apply-suggested-hours", class: "icon icon-checked" %>
     </p>
   <% end %>
   <table class="ai-helper-similar-issues-table">
     <thead>
       <tr>
+        <% if estimation[:available] %>
+          <th></th>
+        <% end %>
         <th><%= l(:ai_helper_similarity) %></th>
         <th>#</th>
         <th><%= l(:field_subject) %></th>
@@ -24,6 +32,16 @@
     <tbody>
       <% similar_issues.each do |similar_issue| %>
         <tr>
+          <% if estimation[:available] %>
+            <td class="ai-helper-effort-select">
+              <% if similar_issue[:spent_hours] %>
+                <%= check_box_tag "ai_helper_effort_#{similar_issue[:id]}", "1", true,
+                      class: "ai-helper-effort-checkbox",
+                      data: { "spent-hours": similar_issue[:spent_hours], "similarity-score": similar_issue[:similarity_score] },
+                      id: nil %>
+              <% end %>
+            </td>
+          <% end %>
           <td class="ai-helper-similarity-score"><%= similar_issue[:similarity_score] %>%</td>
           <td class="ai-helper-issue-id">
             <%= link_to similar_issue[:id], similar_issue[:issue_url] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,10 @@ en:
   ai_helper_find_similar_issues: "Find Similar Issues"
   ai_helper_similarity: "Similarity"
   ai_helper_no_similar_issues_found: "No similar issues found"
+  ai_helper_suggested_hours: "Suggested hours"
+  ai_helper_suggested_hours_note:
+    one: "based on %{count} similar ticket"
+    other: "based on %{count} similar tickets"
   ai_helper_scope_current_project: "Current project"
   ai_helper_scope_with_subprojects: "Include subprojects"
   ai_helper_scope_all_projects: "All projects"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,8 +13,8 @@ en:
   ai_helper_no_similar_issues_found: "No similar issues found"
   ai_helper_suggested_hours: "Suggested hours"
   ai_helper_suggested_hours_note:
-    one: "based on %{count} similar ticket"
-    other: "based on %{count} similar tickets"
+    one: "based on %{count} similar issue"
+    other: "based on %{count} similar issues"
   ai_helper_scope_current_project: "Current project"
   ai_helper_scope_with_subprojects: "Include subprojects"
   ai_helper_scope_all_projects: "All projects"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -11,6 +11,10 @@ it:
   ai_helper_find_similar_issues: "Trova ticket simili"
   ai_helper_similarity: "Somiglianza"
   ai_helper_no_similar_issues_found: "Nessun ticket simile trovato"
+  ai_helper_suggested_hours: "Ore suggerite"
+  ai_helper_suggested_hours_note:
+    one: "basato su %{count} ticket simile"
+    other: "basato su %{count} ticket simili"
   ai_helper_scope_current_project: "Progetto corrente"
   ai_helper_scope_with_subprojects: "Includi sottoprogetti"
   ai_helper_scope_all_projects: "Tutti i progetti"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,9 @@ ja:
   ai_helper_find_similar_issues: "類似チケットを検索"
   ai_helper_similarity: "類似度"
   ai_helper_no_similar_issues_found: "類似するチケットが見つかりませんでした"
+  ai_helper_suggested_hours: "提案作業時間"
+  ai_helper_suggested_hours_note:
+    other: "%{count}件の類似チケットに基づく"
   ai_helper_scope_current_project: "このプロジェクト内"
   ai_helper_scope_with_subprojects: "サブプロジェクトを含める"
   ai_helper_scope_all_projects: "全プロジェクト"

--- a/lib/redmine_ai_helper/effort_estimation.rb
+++ b/lib/redmine_ai_helper/effort_estimation.rb
@@ -1,0 +1,33 @@
+# Top-level namespace for the Redmine AI Helper plugin.
+module RedmineAiHelper
+  # Service class for suggesting an issue's effort (spent hours) based on
+  # similar issues already found by vector search. Pure computation only:
+  # it does not perform any DB query or LLM call itself, it just aggregates
+  # the similar issues data it is given.
+  class EffortEstimation
+    # Computes a suggested number of hours as the weighted average of the
+    # spent_hours of the given similar issues, weighted by their
+    # similarity_score. Issues without a spent_hours value are ignored.
+    #
+    # @param similar_issues [Array<Hash>] Similar issues data, as returned by
+    #   RedmineAiHelper::Llm#find_similar_issues. Each entry is expected to
+    #   have :spent_hours and :similarity_score keys.
+    # @return [Hash] { available: false } when there is not enough data,
+    #   otherwise { available: true, suggested_hours: Float, based_on_count: Integer }
+    def self.suggest(similar_issues)
+      with_spent_hours = similar_issues.select { |issue| issue[:spent_hours] }
+      return { available: false } if with_spent_hours.empty?
+
+      total_weight = with_spent_hours.sum { |issue| issue[:similarity_score].to_f }
+      return { available: false } if total_weight.zero?
+
+      weighted_sum = with_spent_hours.sum { |issue| issue[:spent_hours].to_f * issue[:similarity_score].to_f }
+
+      {
+        available: true,
+        suggested_hours: (weighted_sum / total_weight).round(1),
+        based_on_count: with_spent_hours.size,
+      }
+    end
+  end
+end

--- a/lib/redmine_ai_helper/effort_estimation.rb
+++ b/lib/redmine_ai_helper/effort_estimation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Top-level namespace for the Redmine AI Helper plugin.
 module RedmineAiHelper
   # Service class for suggesting an issue's effort (spent hours) based on
@@ -26,7 +28,7 @@ module RedmineAiHelper
       {
         available: true,
         suggested_hours: (weighted_sum / total_weight).round(1),
-        based_on_count: with_spent_hours.size,
+        based_on_count: with_spent_hours.size
       }
     end
   end

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -605,7 +605,72 @@ class AiHelperControllerTest < ActionController::TestCase
         assert_match(/3\.5 h/, @response.body)
       end
 
-      should "not display suggested hours when no similar issue has spent_hours data" do
+      should "render a selection checkbox with data attributes for similar issues with spent_hours data" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          spent_hours: 3.5,
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        assert_match(/class="ai-helper-effort-checkbox"/, @response.body)
+        assert_match(/checked/, @response.body)
+        assert_match(/data-spent-hours="3\.5"/, @response.body)
+        assert_match(/data-similarity-score="85\.0"/, @response.body)
+      end
+
+      should "not render a selection checkbox for similar issues without spent_hours data" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        assert_no_match(/class="ai-helper-effort-checkbox"/, @response.body)
+      end
+
+      should "render an apply button for the suggested hours" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          spent_hours: 3.5,
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        assert_match(/id="ai-helper-apply-suggested-hours"/, @response.body)
+      end
+
+      should "not display suggested hours or selection controls when no similar issue has spent_hours data" do
         similar_issues = [ {
           id: 2,
           project: { name: "Test Project" },
@@ -623,6 +688,7 @@ class AiHelperControllerTest < ActionController::TestCase
 
         assert_response :success
         assert_no_match(/Suggested hours/, @response.body)
+        assert_no_match(/id="ai-helper-apply-suggested-hours"/, @response.body)
       end
 
       should "exclude current issue from results" do

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -583,6 +583,48 @@ class AiHelperControllerTest < ActionController::TestCase
         assert_match(/Updated/, @response.body)
       end
 
+      should "display suggested hours when similar issues have spent_hours data" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          spent_hours: 3.5,
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        assert_match(/Suggested hours/, @response.body)
+        assert_match(/3\.5 h/, @response.body)
+      end
+
+      should "not display suggested hours when no similar issue has spent_hours data" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        assert_no_match(/Suggested hours/, @response.body)
+      end
+
       should "exclude current issue from results" do
         # Mock LLM find_similar_issues method (should already exclude current issue)
         similar_issues = [ {

--- a/test/unit/effort_estimation_test.rb
+++ b/test/unit/effort_estimation_test.rb
@@ -1,0 +1,75 @@
+require File.expand_path("../../test_helper", __FILE__)
+require "redmine_ai_helper/effort_estimation"
+
+class RedmineAiHelper::EffortEstimationTest < ActiveSupport::TestCase
+  context "EffortEstimation" do
+    context "#suggest" do
+      should "return available: false for an empty array" do
+        result = RedmineAiHelper::EffortEstimation.suggest([])
+
+        assert_equal false, result[:available]
+      end
+
+      should "return available: false when no similar issue has spent_hours" do
+        similar_issues = [
+          { id: 1, similarity_score: 90.0, spent_hours: nil },
+          { id: 2, similarity_score: 80.0 }
+        ]
+
+        result = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
+
+        assert_equal false, result[:available]
+      end
+
+      should "return the spent_hours of the single issue when only one has data" do
+        similar_issues = [
+          { id: 1, similarity_score: 90.0, spent_hours: 4.0 }
+        ]
+
+        result = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
+
+        assert_equal true, result[:available]
+        assert_equal 4.0, result[:suggested_hours]
+        assert_equal 1, result[:based_on_count]
+      end
+
+      should "compute the weighted average of spent_hours by similarity_score" do
+        similar_issues = [
+          { id: 1, similarity_score: 90.0, spent_hours: 6.0 },
+          { id: 2, similarity_score: 30.0, spent_hours: 2.0 }
+        ]
+        # (6.0 * 90.0 + 2.0 * 30.0) / (90.0 + 30.0) = 600.0 / 120.0 = 5.0
+        result = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
+
+        assert_equal true, result[:available]
+        assert_equal 5.0, result[:suggested_hours]
+        assert_equal 2, result[:based_on_count]
+      end
+
+      should "round suggested_hours to 1 decimal" do
+        similar_issues = [
+          { id: 1, similarity_score: 100.0, spent_hours: 1.0 },
+          { id: 2, similarity_score: 50.0, spent_hours: 2.0 }
+        ]
+        # (1.0 * 100.0 + 2.0 * 50.0) / (100.0 + 50.0) = 200.0 / 150.0 = 1.3333...
+        result = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
+
+        assert_equal 1.3, result[:suggested_hours]
+      end
+
+      should "exclude issues with nil spent_hours from both the average and based_on_count" do
+        similar_issues = [
+          { id: 1, similarity_score: 90.0, spent_hours: 4.0 },
+          { id: 2, similarity_score: 80.0, spent_hours: nil },
+          { id: 3, similarity_score: 70.0 }
+        ]
+
+        result = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
+
+        assert_equal true, result[:available]
+        assert_equal 4.0, result[:suggested_hours]
+        assert_equal 1, result[:based_on_count]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a suggested hours summary to the existing Similar Issues panel on the issue view page.
- Computed as a weighted average of `spent_hours` across similar issues, weighted by `similarity_score` (no new LLM call or vector search query — reuses data already returned by `find_similar_issues`).
- Shown only when at least one similar issue has recorded spent hours.
- Includes English, Japanese, and Italian translations.

## Test plan
- [x] Unit tests for `RedmineAiHelper::EffortEstimation` (empty input, all-nil spent_hours, single issue, weighted average, rounding, mixed nil exclusion)
- [x] Functional tests on `AiHelperController#similar_issues` (suggested hours shown/not shown depending on data)
- [x] Manual smoke test in a running Redmine instance