### PR TITLE
Improve suggested effort UI: checkbox placement, bulk select, and label updates

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/022-vector-project-selection"
+  "feature_directory": "specs/024-suggested-hours-ui"
 }

--- a/app/views/ai_helper/issues/_bottom.html.erb
+++ b/app/views/ai_helper/issues/_bottom.html.erb
@@ -87,6 +87,8 @@
       if (xhr.status === 200) {
         if (similarIssuesArea) {
           similarIssuesArea.innerHTML = xhr.responseText;
+          recalculateSuggestedHours();
+          recalculateEffortSelectAllState();
         }
       } else {
         if (similarIssuesArea) {
@@ -135,7 +137,7 @@
 
     const valueSpan = document.getElementById('ai-helper-suggested-hours-value');
     if (valueSpan) {
-      valueSpan.textContent = suggestedHours;
+      valueSpan.textContent = suggestedHours.toFixed(1);
     }
 
     const noteSpan = document.getElementById('ai-helper-suggested-hours-note');
@@ -146,7 +148,39 @@
     }
   }
 
-  // Write the currently suggested hours into the issue's Estimated hours field.
+  // Set every row effort checkbox to match the header select-all checkbox,
+  // then recompute the suggestion.
+  function toggleAllEffortCheckboxes(checked) {
+    const checkboxes = document.querySelectorAll('.ai-helper-effort-checkbox');
+    checkboxes.forEach(function(checkbox) {
+      checkbox.checked = checked;
+    });
+    recalculateSuggestedHours();
+  }
+
+  // Recompute the header select-all checkbox's checked/indeterminate state
+  // from the current row checkboxes: all checked -> checked, none checked ->
+  // unchecked, a mix of both -> indeterminate.
+  function recalculateEffortSelectAllState() {
+    const selectAll = document.getElementById('ai-helper-effort-select-all');
+    if (!selectAll) return;
+
+    const checkboxes = document.querySelectorAll('.ai-helper-effort-checkbox');
+    const checkedCount = document.querySelectorAll('.ai-helper-effort-checkbox:checked').length;
+
+    if (checkboxes.length === 0 || checkedCount === 0) {
+      selectAll.checked = false;
+      selectAll.indeterminate = false;
+    } else if (checkedCount === checkboxes.length) {
+      selectAll.checked = true;
+      selectAll.indeterminate = false;
+    } else {
+      selectAll.checked = false;
+      selectAll.indeterminate = true;
+    }
+  }
+
+  // Write the currently suggested hours into the issue's Estimated time field.
   // That field lives inside the "#update" edit form, which Redmine keeps
   // collapsed (display:none) until the user opens it, so reveal and scroll to
   // it (via Redmine core's own showAndScrollTo helper) to make the change visible.
@@ -192,6 +226,10 @@
       similarIssuesArea.addEventListener('change', function(e) {
         if (e.target.classList.contains('ai-helper-effort-checkbox')) {
           recalculateSuggestedHours();
+          recalculateEffortSelectAllState();
+        } else if (e.target.id === 'ai-helper-effort-select-all') {
+          toggleAllEffortCheckboxes(e.target.checked);
+          recalculateEffortSelectAllState();
         }
       });
       similarIssuesArea.addEventListener('click', function(e) {
@@ -201,6 +239,8 @@
           applySuggestedHours();
         }
       });
+      recalculateSuggestedHours();
+      recalculateEffortSelectAllState();
     }
   });
 

--- a/app/views/ai_helper/issues/_bottom.html.erb
+++ b/app/views/ai_helper/issues/_bottom.html.erb
@@ -87,8 +87,7 @@
       if (xhr.status === 200) {
         if (similarIssuesArea) {
           similarIssuesArea.innerHTML = xhr.responseText;
-          recalculateSuggestedHours();
-          recalculateEffortSelectAllState();
+          refreshEffortUI();
         }
       } else {
         if (similarIssuesArea) {
@@ -120,14 +119,20 @@
     const checkboxes = document.querySelectorAll('.ai-helper-effort-checkbox:checked');
     let weightedSum = 0;
     let totalWeight = 0;
+    let includedCount = 0;
     checkboxes.forEach(function(checkbox) {
       const spentHours = parseFloat(checkbox.dataset.spentHours);
       const score = parseFloat(checkbox.dataset.similarityScore);
+      // Checkboxes for similar issues without spent_hours data carry no
+      // data-spent-hours attribute (parseFloat(undefined) is NaN); skip them
+      // so they can't poison the weighted average with NaN.
+      if (!Number.isFinite(spentHours) || !Number.isFinite(score)) return;
       weightedSum += spentHours * score;
       totalWeight += score;
+      includedCount += 1;
     });
 
-    if (checkboxes.length === 0 || totalWeight === 0) {
+    if (totalWeight === 0) {
       block.style.display = 'none';
       return;
     }
@@ -142,10 +147,17 @@
 
     const noteSpan = document.getElementById('ai-helper-suggested-hours-note');
     if (noteSpan) {
-      const count = checkboxes.length;
-      const template = count === 1 ? block.dataset.noteOne : block.dataset.noteOther;
-      noteSpan.textContent = '(' + template.replace('%{count}', count) + ')';
+      const template = includedCount === 1 ? block.dataset.noteOne : block.dataset.noteOther;
+      noteSpan.textContent = '(' + template.replace('%{count}', includedCount) + ')';
     }
+  }
+
+  // Recompute both the suggested hours and the select-all checkbox state.
+  // These two are always refreshed together whenever the checked set of
+  // effort checkboxes may have changed.
+  function refreshEffortUI() {
+    recalculateSuggestedHours();
+    recalculateEffortSelectAllState();
   }
 
   // Set every row effort checkbox to match the header select-all checkbox,
@@ -155,7 +167,7 @@
     checkboxes.forEach(function(checkbox) {
       checkbox.checked = checked;
     });
-    recalculateSuggestedHours();
+    refreshEffortUI();
   }
 
   // Recompute the header select-all checkbox's checked/indeterminate state
@@ -166,7 +178,7 @@
     if (!selectAll) return;
 
     const checkboxes = document.querySelectorAll('.ai-helper-effort-checkbox');
-    const checkedCount = document.querySelectorAll('.ai-helper-effort-checkbox:checked').length;
+    const checkedCount = Array.from(checkboxes).filter(function(checkbox) { return checkbox.checked; }).length;
 
     if (checkboxes.length === 0 || checkedCount === 0) {
       selectAll.checked = false;
@@ -218,18 +230,17 @@
     // Move similar issues to relations area
     moveSimilarIssuesToRelations();
 
-    // Handle effort checkbox toggling and the Apply button inside the
-    // dynamically-loaded similar issues area (event delegation, since its
-    // content is replaced via innerHTML after the initial page load).
+    // Handle effort checkbox toggling, the select-all header checkbox, and
+    // the Apply button inside the dynamically-loaded similar issues area
+    // (event delegation, since its content is replaced via innerHTML after
+    // the initial page load).
     const similarIssuesArea = document.getElementById('ai-helper-similar-issues-area');
     if (similarIssuesArea) {
       similarIssuesArea.addEventListener('change', function(e) {
         if (e.target.classList.contains('ai-helper-effort-checkbox')) {
-          recalculateSuggestedHours();
-          recalculateEffortSelectAllState();
+          refreshEffortUI();
         } else if (e.target.id === 'ai-helper-effort-select-all') {
           toggleAllEffortCheckboxes(e.target.checked);
-          recalculateEffortSelectAllState();
         }
       });
       similarIssuesArea.addEventListener('click', function(e) {
@@ -239,8 +250,7 @@
           applySuggestedHours();
         }
       });
-      recalculateSuggestedHours();
-      recalculateEffortSelectAllState();
+      refreshEffortUI();
     }
   });
 

--- a/app/views/ai_helper/issues/_similar_issues.html.erb
+++ b/app/views/ai_helper/issues/_similar_issues.html.erb
@@ -2,29 +2,23 @@
   <p><%= l(:ai_helper_no_similar_issues_found) %></p>
 <% else %>
   <% estimation = local_assigns.fetch(:estimation, { available: false }) %>
-  <% if estimation[:available] %>
-    <% note_translations = I18n.t(:ai_helper_suggested_hours_note) %>
-    <p class="ai-helper-suggested-hours" id="ai-helper-suggested-hours-block"
-       data-note-one="<%= note_translations[:one] || note_translations[:other] %>"
-       data-note-other="<%= note_translations[:other] %>">
-      <strong><%= l(:ai_helper_suggested_hours) %>:</strong>
-      <span id="ai-helper-suggested-hours-value"><%= estimation[:suggested_hours] %></span> h
-      <span class="ai-helper-suggested-hours-note" id="ai-helper-suggested-hours-note">(<%= l(:ai_helper_suggested_hours_note, count: estimation[:based_on_count]) %>)</span>
-      <%= link_to l(:button_apply), "#", id: "ai-helper-apply-suggested-hours", class: "icon icon-checked" %>
-    </p>
-  <% end %>
   <table class="ai-helper-similar-issues-table">
     <thead>
       <tr>
-        <% if estimation[:available] %>
-          <th></th>
-        <% end %>
         <th><%= l(:ai_helper_similarity) %></th>
         <th>#</th>
         <th><%= l(:field_subject) %></th>
         <th><%= l(:field_project) %></th>
         <th><%= l(:field_status) %></th>
-        <th><%= l(:label_spent_time) %></th>
+        <th>
+          <% if estimation[:available] %>
+            <%= check_box_tag "ai_helper_effort_select_all", "1", false,
+                  id: "ai-helper-effort-select-all",
+                  title: l(:ai_helper_effort_select_all),
+                  "aria-label": l(:ai_helper_effort_select_all) %>
+          <% end %>
+          <%= l(:label_spent_time) %>
+        </th>
         <th><%= l(:field_updated_on) %></th>
         <th><%= l(:field_assigned_to) %></th>
       </tr>
@@ -32,16 +26,6 @@
     <tbody>
       <% similar_issues.each do |similar_issue| %>
         <tr>
-          <% if estimation[:available] %>
-            <td class="ai-helper-effort-select">
-              <% if similar_issue[:spent_hours] %>
-                <%= check_box_tag "ai_helper_effort_#{similar_issue[:id]}", "1", true,
-                      class: "ai-helper-effort-checkbox",
-                      data: { "spent-hours": similar_issue[:spent_hours], "similarity-score": similar_issue[:similarity_score] },
-                      id: nil %>
-              <% end %>
-            </td>
-          <% end %>
           <td class="ai-helper-similarity-score"><%= similar_issue[:similarity_score] %>%</td>
           <td class="ai-helper-issue-id">
             <%= link_to similar_issue[:id], similar_issue[:issue_url] %>
@@ -51,11 +35,30 @@
           </td>
           <td class="ai-helper-project"><%= similar_issue[:project][:name] %></td>
           <td class="ai-helper-status"><%= similar_issue[:status][:name] %></td>
-          <td class="ai-helper-spent-hours"><%= similar_issue[:spent_hours] ? "#{similar_issue[:spent_hours]} h" : "" %></td>
+          <td class="ai-helper-spent-hours">
+            <% if estimation[:available] %>
+              <%= check_box_tag "ai_helper_effort_#{similar_issue[:id]}", "1", similar_issue[:spent_hours].to_f > 0,
+                    class: "ai-helper-effort-checkbox",
+                    data: { "spent-hours": similar_issue[:spent_hours], "similarity-score": similar_issue[:similarity_score] },
+                    id: nil %>
+            <% end %>
+            <%= similar_issue[:spent_hours] ? "#{similar_issue[:spent_hours]} h" : "" %>
+          </td>
           <td class="ai-helper-updated-on"><%= format_time(similar_issue[:updated_on]) %></td>
           <td class="ai-helper-assigned"><%= similar_issue[:assigned_to] ? similar_issue[:assigned_to][:name] : "" %></td>
         </tr>
       <% end %>
     </tbody>
   </table>
+  <% if estimation[:available] %>
+    <% note_translations = I18n.t(:ai_helper_suggested_hours_note) %>
+    <p class="ai-helper-suggested-hours" id="ai-helper-suggested-hours-block"
+       data-note-one="<%= note_translations[:one] || note_translations[:other] %>"
+       data-note-other="<%= note_translations[:other] %>">
+      <strong><%= l(:ai_helper_suggested_hours) %>:</strong>
+      <span id="ai-helper-suggested-hours-value"><%= estimation[:suggested_hours] %></span> h
+      <span class="ai-helper-suggested-hours-note" id="ai-helper-suggested-hours-note">(<%= l(:ai_helper_suggested_hours_note, count: estimation[:based_on_count]) %>)</span>
+      <%= link_to l(:ai_helper_apply_suggested_hours), "#", id: "ai-helper-apply-suggested-hours", class: "icon icon-checked" %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/ai_helper/issues/_similar_issues.html.erb
+++ b/app/views/ai_helper/issues/_similar_issues.html.erb
@@ -37,9 +37,10 @@
           <td class="ai-helper-status"><%= similar_issue[:status][:name] %></td>
           <td class="ai-helper-spent-hours">
             <% if estimation[:available] %>
-              <%# Default-unchecked for missing or zero spent_hours: neither contributes usable
-                  data to the weighted average, so pre-selecting them would misrepresent what
-                  the suggested hours are actually based on. %>
+              <%# Default-unchecked when spent_hours is missing or zero. Note that a zero
+                  value still contributes to the weighted average (0 is truthy in Ruby),
+                  but leaving it unchecked keeps the default selection focused on issues
+                  with recorded effort. %>
               <%= check_box_tag "ai_helper_effort_#{similar_issue[:id]}", "1", similar_issue[:spent_hours].to_f > 0,
                     class: "ai-helper-effort-checkbox",
                     data: { "spent-hours": similar_issue[:spent_hours], "similarity-score": similar_issue[:similarity_score] },

--- a/app/views/ai_helper/issues/_similar_issues.html.erb
+++ b/app/views/ai_helper/issues/_similar_issues.html.erb
@@ -37,6 +37,9 @@
           <td class="ai-helper-status"><%= similar_issue[:status][:name] %></td>
           <td class="ai-helper-spent-hours">
             <% if estimation[:available] %>
+              <%# Default-unchecked for missing or zero spent_hours: neither contributes usable
+                  data to the weighted average, so pre-selecting them would misrepresent what
+                  the suggested hours are actually based on. %>
               <%= check_box_tag "ai_helper_effort_#{similar_issue[:id]}", "1", similar_issue[:spent_hours].to_f > 0,
                     class: "ai-helper-effort-checkbox",
                     data: { "spent-hours": similar_issue[:spent_hours], "similarity-score": similar_issue[:similarity_score] },

--- a/assets/stylesheets/ai_helper.css
+++ b/assets/stylesheets/ai_helper.css
@@ -292,6 +292,12 @@ table.ai-helper-sub-issues-table td {
 
 .ai-helper-status {}
 
+.ai-helper-spent-hours .ai-helper-effort-checkbox,
+#ai-helper-effort-select-all {
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
 .ai-helper-priority {}
 
 .ai-helper-assigned {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,9 @@ en:
   ai_helper_find_similar_issues: "Find Similar Issues"
   ai_helper_similarity: "Similarity"
   ai_helper_no_similar_issues_found: "No similar issues found"
-  ai_helper_suggested_hours: "Suggested hours"
+  ai_helper_suggested_hours: "Estimated time suggestion"
+  ai_helper_apply_suggested_hours: "Apply to this issue's estimated time"
+  ai_helper_effort_select_all: "Select all effort hours"
   ai_helper_suggested_hours_note:
     one: "based on %{count} similar issue"
     other: "based on %{count} similar issues"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -11,7 +11,9 @@ it:
   ai_helper_find_similar_issues: "Trova ticket simili"
   ai_helper_similarity: "Somiglianza"
   ai_helper_no_similar_issues_found: "Nessun ticket simile trovato"
-  ai_helper_suggested_hours: "Ore suggerite"
+  ai_helper_suggested_hours: "Suggerimento tempo stimato"
+  ai_helper_apply_suggested_hours: "Applica al tempo stimato di questo ticket"
+  ai_helper_effort_select_all: "Seleziona tutto il tempo impiegato"
   ai_helper_suggested_hours_note:
     one: "basato su %{count} ticket simile"
     other: "basato su %{count} ticket simili"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,7 +11,9 @@ ja:
   ai_helper_find_similar_issues: "類似チケットを検索"
   ai_helper_similarity: "類似度"
   ai_helper_no_similar_issues_found: "類似するチケットが見つかりませんでした"
-  ai_helper_suggested_hours: "提案作業時間"
+  ai_helper_suggested_hours: "予定工数の提案"
+  ai_helper_apply_suggested_hours: "このチケットの予定工数に反映"
+  ai_helper_effort_select_all: "すべての作業時間を選択"
   ai_helper_suggested_hours_note:
     other: "%{count}件の類似チケットに基づく"
   ai_helper_scope_current_project: "このプロジェクト内"

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -601,7 +601,7 @@ class AiHelperControllerTest < ActionController::TestCase
         get :similar_issues, params: { id: @issue.id }
 
         assert_response :success
-        assert_match(/Suggested hours/, @response.body)
+        assert_match(/Estimated time suggestion/, @response.body)
         assert_match(/3\.5 h/, @response.body)
       end
 
@@ -627,14 +627,86 @@ class AiHelperControllerTest < ActionController::TestCase
         assert_match(/checked/, @response.body)
         assert_match(/data-spent-hours="3\.5"/, @response.body)
         assert_match(/data-similarity-score="85\.0"/, @response.body)
+        assert_match(/<td class="ai-helper-spent-hours">\s*<input[^>]*class="ai-helper-effort-checkbox"/, @response.body)
+        assert_no_match(/<th><\/th>/, @response.body)
+        assert_no_match(/<td class="ai-helper-effort-select">/, @response.body)
       end
 
-      should "not render a selection checkbox for similar issues without spent_hours data" do
+      should "render an unchecked checkbox for similar issues without spent_hours data" do
         similar_issues = [ {
           id: 2,
           project: { name: "Test Project" },
           subject: "Similar issue",
           status: { name: "Open" },
+          spent_hours: 3.5,
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        }, {
+          id: 3,
+          project: { name: "Test Project" },
+          subject: "Unrecorded similar issue",
+          status: { name: "Open" },
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 70.0,
+          issue_url: "/issues/3"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        checkbox_2 = @response.body[/<input[^>]*name="ai_helper_effort_2"[^>]*>/]
+        checkbox_3 = @response.body[/<input[^>]*name="ai_helper_effort_3"[^>]*>/]
+        assert_match(/class="ai-helper-effort-checkbox"/, checkbox_2)
+        assert_match(/checked="checked"/, checkbox_2)
+        assert_match(/class="ai-helper-effort-checkbox"/, checkbox_3)
+        assert_no_match(/checked="checked"/, checkbox_3)
+      end
+
+      should "render an unchecked checkbox for similar issues with zero spent_hours" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          spent_hours: 3.5,
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 85.0,
+          issue_url: "/issues/2"
+        }, {
+          id: 3,
+          project: { name: "Test Project" },
+          subject: "Zero spent hours similar issue",
+          status: { name: "Open" },
+          spent_hours: 0,
+          updated_on: Time.zone.now,
+          assigned_to: { name: "Test User" },
+          similarity_score: 70.0,
+          issue_url: "/issues/3"
+        } ]
+
+        @llm_mock.stubs(:find_similar_issues).with(issue: @issue, scope: "with_subprojects", project: @issue.project).returns(similar_issues)
+
+        get :similar_issues, params: { id: @issue.id }
+
+        assert_response :success
+        checkbox_3 = @response.body[/<input[^>]*name="ai_helper_effort_3"[^>]*>/]
+        assert_match(/class="ai-helper-effort-checkbox"/, checkbox_3)
+        assert_no_match(/checked="checked"/, checkbox_3)
+      end
+
+      should "render a select-all checkbox in the spent-time column header when estimation is available" do
+        similar_issues = [ {
+          id: 2,
+          project: { name: "Test Project" },
+          subject: "Similar issue",
+          status: { name: "Open" },
+          spent_hours: 3.5,
           updated_on: Time.zone.now,
           assigned_to: { name: "Test User" },
           similarity_score: 85.0,
@@ -646,7 +718,7 @@ class AiHelperControllerTest < ActionController::TestCase
         get :similar_issues, params: { id: @issue.id }
 
         assert_response :success
-        assert_no_match(/class="ai-helper-effort-checkbox"/, @response.body)
+        assert_match(/id="ai-helper-effort-select-all"/, @response.body)
       end
 
       should "render an apply button for the suggested hours" do
@@ -668,6 +740,8 @@ class AiHelperControllerTest < ActionController::TestCase
 
         assert_response :success
         assert_match(/id="ai-helper-apply-suggested-hours"/, @response.body)
+        assert_match(/Apply to this issue&#39;s estimated time/, @response.body)
+        assert_operator @response.body.index("</table>"), :<, @response.body.index('id="ai-helper-suggested-hours-block"')
       end
 
       should "not display suggested hours or selection controls when no similar issue has spent_hours data" do
@@ -687,8 +761,9 @@ class AiHelperControllerTest < ActionController::TestCase
         get :similar_issues, params: { id: @issue.id }
 
         assert_response :success
-        assert_no_match(/Suggested hours/, @response.body)
+        assert_no_match(/Estimated time suggestion/, @response.body)
         assert_no_match(/id="ai-helper-apply-suggested-hours"/, @response.body)
+        assert_no_match(/id="ai-helper-effort-select-all"/, @response.body)
       end
 
       should "exclude current issue from results" do

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -665,6 +665,7 @@ class AiHelperControllerTest < ActionController::TestCase
         assert_match(/checked="checked"/, checkbox_2)
         assert_match(/class="ai-helper-effort-checkbox"/, checkbox_3)
         assert_no_match(/checked="checked"/, checkbox_3)
+        assert_no_match(/data-spent-hours=/, checkbox_3)
       end
 
       should "render an unchecked checkbox for similar issues with zero spent_hours" do

--- a/test/unit/effort_estimation_test.rb
+++ b/test/unit/effort_estimation_test.rb
@@ -70,6 +70,19 @@ class RedmineAiHelper::EffortEstimationTest < ActiveSupport::TestCase
         assert_equal 4.0, result[:suggested_hours]
         assert_equal 1, result[:based_on_count]
       end
+
+      should "include issues with zero spent_hours in the average and based_on_count" do
+        similar_issues = [
+          { id: 1, similarity_score: 90.0, spent_hours: 4.0 },
+          { id: 2, similarity_score: 60.0, spent_hours: 0 }
+        ]
+        # (4.0 * 90.0 + 0 * 60.0) / (90.0 + 60.0) = 360.0 / 150.0 = 2.4
+        result = RedmineAiHelper::EffortEstimation.suggest(similar_issues)
+
+        assert_equal true, result[:available]
+        assert_equal 2.4, result[:suggested_hours]
+        assert_equal 2, result[:based_on_count]
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes

- Move each similar issue's checkbox into the spent hours column, next to the hours value, instead of the leftmost column
- Add a header checkbox in the spent hours column to bulk select/deselect all rows, reflecting a mixed (indeterminate) state when only some rows are checked
- Default-check only similar issues with recorded spent hours (> 0); leave unrecorded issues unchecked
- Move the suggested effort display below the similar issues list instead of above it
- Rename the label from "提案作業時間" (Suggested working hours) to "予定工数の提案" (Suggested estimated hours), and the apply button from "適用" (Apply) to "このチケットの予定工数に反映" (Reflect to this issue's estimated hours)
- Hide the suggested effort display when no checkboxes are selected

This is a UI/UX-only follow-up to #338 and does not change the underlying effort estimation logic.