### PR TITLE
Expose issue custom fields in MCP read_issues tool

### DIFF
--- a/lib/redmine_ai_helper/tools/issue_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_tools.rb
@@ -9,7 +9,7 @@ module RedmineAiHelper
     # IssueTools is a specialized tool provider for handling Redmine issue-related queries.
     class IssueTools < RedmineAiHelper::BaseTools
       include RedmineAiHelper::Util::IssueJson
-      define_function :read_issues, description: "Read an issue from the database and return it as a JSON object. It returns the issue ID, subject, project, tracker, status, priority, author, assigned_to, description, start_date, due_date, done_ratio, is_private, estimated_hours, total_estimated_hours, spent_hours, total_spent_hours, created_on, updated_on, closed_on, issue_url, attachments, children, relations and custom_fields." do
+      define_function :read_issues, description: "Read issues from the database and return them as JSON objects. Each issue includes scalar fields (id, subject, project, tracker, status, priority, author, assigned_to, description, start_date, due_date, done_ratio, is_private, estimated_hours, total_estimated_hours, spent_hours, total_spent_hours, created_on, updated_on, closed_on, issue_url) plus attachments, children, parent, relations, journals, revisions, and custom_fields." do
         property :issue_ids, type: "array", description: "The issue ID array to read.", required: true do
           item type: "integer", description: "The issue ID to read."
         end

--- a/lib/redmine_ai_helper/tools/issue_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_tools.rb
@@ -9,7 +9,7 @@ module RedmineAiHelper
     # IssueTools is a specialized tool provider for handling Redmine issue-related queries.
     class IssueTools < RedmineAiHelper::BaseTools
       include RedmineAiHelper::Util::IssueJson
-      define_function :read_issues, description: "Read an issue from the database and return it as a JSON object. It returns the issue ID, subject, project, tracker, status, priority, author, assigned_to, description, start_date, due_date, done_ratio, is_private, estimated_hours, total_estimated_hours, spent_hours, total_spent_hours, created_on, updated_on, closed_on, issue_url, attachments, children and relations." do
+      define_function :read_issues, description: "Read an issue from the database and return it as a JSON object. It returns the issue ID, subject, project, tracker, status, priority, author, assigned_to, description, start_date, due_date, done_ratio, is_private, estimated_hours, total_estimated_hours, spent_hours, total_spent_hours, created_on, updated_on, closed_on, issue_url, attachments, children, relations and custom_fields." do
         property :issue_ids, type: "array", description: "The issue ID array to read.", required: true do
           item type: "integer", description: "The issue ID to read."
         end

--- a/lib/redmine_ai_helper/util/issue_json.rb
+++ b/lib/redmine_ai_helper/util/issue_json.rb
@@ -16,7 +16,8 @@ module RedmineAiHelper
           parent: format_issue_parent(issue),
           relations: issue.relations.filter { |r| r.visible? }.map { |r| format_issue_relation(issue, r) },
           journals: issue.journals.filter { |j| j.visible? }.map { |j| format_issue_journal(j) },
-          revisions: issue.changesets.map { |c| { repository_id: c.repository_id, revision: c.revision, committed_on: c.committed_on } }
+          revisions: issue.changesets.map { |c| { repository_id: c.repository_id, revision: c.revision, committed_on: c.committed_on } },
+          custom_fields: format_issue_custom_fields(issue)
         )
       end
 
@@ -92,6 +93,12 @@ module RedmineAiHelper
           other_issue_id: other_issue_id,
           other_issue_subject: Issue.find_by(id: other_issue_id)&.subject
         }
+      end
+
+      def format_issue_custom_fields(issue)
+        issue.custom_field_values.map do |cfv|
+          { id: cfv.custom_field.id, name: cfv.custom_field.name, value: cfv.value }
+        end
       end
 
       def format_issue_journal(journal)

--- a/test/unit/util/issue_json_test.rb
+++ b/test/unit/util/issue_json_test.rb
@@ -147,6 +147,22 @@ class RedmineAiHelper::Util::IssueJsonTest < ActiveSupport::TestCase
       assert_equal source_issue.id, relation_data[:other_issue_id]
       assert_equal source_issue.subject, relation_data[:other_issue_subject]
     end
+
+    should "include custom_fields with id, name, and value" do
+      custom_field = IssueCustomField.create!(name: "Severity", field_format: "string", is_for_all: true, tracker_ids: Tracker.pluck(:id))
+      @issue.custom_field_values = { custom_field.id => "Critical" }
+      @issue.save!
+
+      issue_data = @test_class.generate_issue_data(@issue)
+
+      assert issue_data.key?(:custom_fields)
+      field_data = issue_data[:custom_fields].find { |f| f[:id] == custom_field.id }
+      assert_not_nil field_data
+      assert_equal custom_field.name, field_data[:name]
+      assert_equal "Critical", field_data[:value]
+
+      custom_field.destroy
+    end
   end
 
   class TestClass < RedmineAiHelper::BaseTools


### PR DESCRIPTION
## Changes

- Add `custom_fields` (id, name, value) to the JSON returned by the MCP `read_issues` tool, via `IssueJson#generate_issue_data`
- Update `read_issues` function description to mention `custom_fields`
- Add test coverage for the new field in `issue_json_test.rb`

Issue custom field values were missing from `read_issues`, unlike `search_issues` which already exposes them. Follow-up to #342 (same gap on the project side).