### PR TITLE
Fix structured output schema conformance and add native structured output support

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/024-suggested-hours-ui"
+  "feature_directory": "specs/025-structured-output-schema"
 }

--- a/app/controllers/ai_helper_model_profiles_controller.rb
+++ b/app/controllers/ai_helper_model_profiles_controller.rb
@@ -67,7 +67,7 @@ class AiHelperModelProfilesController < ApplicationController
         original = AiHelperModelProfile.find(params[:id])
         temp_profile.access_key = original.access_key
       else
-        render json: { success: false, error: l("ai_helper.model_profiles.messages.access_key_required") }, status: :unprocessable_entity
+        render json: { success: false, error: l("ai_helper.model_profiles.messages.access_key_required") }, status: :unprocessable_content
         return
       end
     end
@@ -77,7 +77,7 @@ class AiHelperModelProfilesController < ApplicationController
     unless temp_profile.llm_type.present? && temp_profile.llm_model.present? &&
            (temp_profile.access_key.present? || !temp_profile.access_key_required?) &&
            (temp_profile.base_uri.present? || !temp_profile.base_uri_required?)
-      render json: { success: false, error: l("ai_helper.model_profiles.messages.required_fields_missing") }, status: :unprocessable_entity
+      render json: { success: false, error: l("ai_helper.model_profiles.messages.required_fields_missing") }, status: :unprocessable_content
       return
     end
 
@@ -105,7 +105,7 @@ class AiHelperModelProfilesController < ApplicationController
       render json: { success: true }
     else
       render json: { success: false, errors: new_profile.errors.full_messages },
-             status: :unprocessable_entity
+             status: :unprocessable_content
     end
   end
 

--- a/docs/adr/004-structured-output-native-and-fallback.md
+++ b/docs/adr/004-structured-output-native-and-fallback.md
@@ -1,0 +1,39 @@
+# ADR-004: Two-tier structured output — native API schema enforcement with a prompt-based fallback pipeline
+
+**Date**: 2026-07-17
+**Status**: Proposed
+
+## Context
+
+Six call sites in the plugin request structured JSON from the LLM (sub-issue draft generation, assignee suggestion, leader goal/step generation, documentation suggestions, and issue content analysis for vector search). Historically they all relied on prompt-embedded format instructions plus `JSON.parse`, which crashed when the model deviated from the requested schema — for example returning a bare JSON array instead of the declared wrapper object, or inventing undeclared keys (issue #345, `undefined method 'each' for nil` during sub-issue draft generation).
+
+ruby_llm 1.16.0 provides `RubyLLM::Chat#with_schema` for API-level structured output (OpenAI `response_format`, Gemini `responseSchema`, etc.) and `RubyLLM::Model::Info#structured_output?` to detect model capability from its registry. However, not every configured provider supports this: Azure OpenAI and OpenAI-compatible endpoints have no registry slug in our provider layer, and locally hosted models may not be registered at all.
+
+## Decision
+
+1. **Two-tier architecture.** `BaseAgent#structured_chat` checks `LlmClient::BaseProvider#supports_structured_output?`:
+   - **Native tier**: the JSON schema is passed to `create_chat(schema:)`, which applies `chat.with_schema`. Prompt-embedded format instructions are omitted (`format_instructions_for` returns `""`).
+   - **Fallback tier**: the existing prompt-instruction approach (`get_format_instructions`) is kept, and the textual response goes through JSON extraction/parsing with at most one LLM parse-fix retry.
+2. **Capability detection is conservative.** `supports_structured_output?` returns `false` when the provider has no `ruby_llm_provider_slug` (Azure OpenAI, OpenAI-compatible) or the model is not in the RubyLLM registry. Unknown means fallback, never native.
+3. **Both tiers converge into one deterministic pipeline** in `StructuredOutputHelper.parse`: conform (wrap a bare array into the single array-type property; recursively strip undeclared keys) → validate (`required` presence and `type` checks only, no coercion) → on violations, at most one schema-regeneration request → if still violating, raise `SchemaViolationError` after logging the original response and violation list. There is no silent fallback to partial data.
+4. **`strict: false` for native schemas.** `StructuredOutputHelper.native_schema_payload` always emits `{ name:, schema:, strict: false }` and passes the existing schemas through unchanged.
+
+## Consequences
+
+**Positive**:
+- Schema deviations no longer crash user-facing features; the deterministic conform/validate steps absorb the common deviations from issue #345 at zero LLM cost.
+- On native-capable models the happy path needs no extra LLM calls and no format-instruction tokens in the prompt.
+- A single pipeline behind both tiers keeps the test surface small and behavior uniform across all six call sites.
+- Unresolvable deviations fail loudly (`SchemaViolationError` with logged evidence), preserving the project's no-silent-fallback principle.
+
+**Negative**:
+- `strict: false` means the API does not hard-guarantee schema conformance even on the native tier; residual deviations rely on the conform/validate pipeline.
+- The fallback tier can add up to two extra LLM calls in the worst case (one parse fix + one schema regeneration).
+- Capability detection depends on the RubyLLM model registry; a capable but unregistered model silently uses the fallback tier (correct but less efficient).
+
+## Alternatives Considered
+
+- **`strict: true` with automatic schema transformation**: OpenAI strict mode requires `additionalProperties: false` everywhere and every property listed in `required` (optional fields become null-unions). Converting the existing schemas (which have genuinely optional fields such as `priority_id` and `due_date`) would need forward transformation plus null-stripping on responses, changing the meaning of six schema definitions. Rejected as disproportionate complexity (YAGNI); can be revisited in a future ADR.
+- **Full JSON Schema validation via a gem (json_schemer / json-schema)**: adds a dependency, and its error output would still need custom mapping into regeneration prompts. `required` + `type` checking is sufficient as a boundary guard before ActiveRecord mass assignment. Rejected.
+- **Model-name pattern matching for capability detection**: fragile, needs maintenance for every new model, and risks false positives that would break requests. Rejected in favor of the RubyLLM registry.
+- **Native tier only where available, no conformance pipeline**: would leave fallback providers (and `strict: false` residual deviations) exposed to the original crash class. Rejected.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,3 +56,4 @@ Briefly describe alternatives that were rejected and why.
 | [001](./001-qdrant-payload-index-strategy.md) | Auto-create Qdrant payload indexes for filtered fields | Proposed |
 | [002](./002-vector-scope-by-ai-helper-module.md) | Scope vector data registration to projects with ai_helper module enabled | Proposed |
 | [003](./003-vector-target-project-selection.md) | Select which projects are registered in the vector database | Proposed |
+| [004](./004-structured-output-native-and-fallback.md) | Two-tier structured output — native API schema enforcement with a prompt-based fallback pipeline | Proposed |

--- a/lib/redmine_ai_helper/agents/documentation_agent.rb
+++ b/lib/redmine_ai_helper/agents/documentation_agent.rb
@@ -59,7 +59,7 @@ module RedmineAiHelper
           description: "Array of typo correction suggestions"
         }
 
-        format_instructions = RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(json_schema)
+        format_instructions = format_instructions_for(json_schema)
 
         prompt_template = load_prompt("documentation_agent/typo_check")
 
@@ -78,14 +78,7 @@ module RedmineAiHelper
           }
         ]
 
-        response = chat(messages)
-
-        suggestions = RedmineAiHelper::Util::StructuredOutputHelper.parse(
-          response: response,
-          json_schema: json_schema,
-          chat_method: method(:chat),
-          messages: messages
-        )
+        suggestions = structured_chat(messages, json_schema: json_schema)
 
         # Validate and fix suggestions data
         validated_suggestions = validate_and_fix_suggestions(suggestions, text)

--- a/lib/redmine_ai_helper/agents/issue_agent.rb
+++ b/lib/redmine_ai_helper/agents/issue_agent.rb
@@ -144,20 +144,14 @@ module RedmineAiHelper
           parent_issue: JSON.pretty_generate(issue_json),
           instructions: instructions,
           subtask_instructions: project_setting.subtask_instructions,
-          format_instructions: RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(json_schema)
+          format_instructions: format_instructions_for(json_schema)
         )
         ai_helper_logger.debug "prompt_text: #{prompt_text}"
 
         message = { role: "user", content: prompt_text }
         messages = [ message ]
         file_paths = supported_attachment_paths(issue)
-        answer = chat(messages, {}, nil, with: file_paths.presence)
-        fixed_json = RedmineAiHelper::Util::StructuredOutputHelper.parse(
-          response: answer,
-          json_schema: json_schema,
-          chat_method: method(:chat),
-          messages: messages
-        )
+        fixed_json = structured_chat(messages, json_schema: json_schema, with: file_paths.presence)
 
         # Convert the answer to an array of Issue objects
         sub_issues = []
@@ -257,19 +251,12 @@ module RedmineAiHelper
           description: description || "",
           tracker: tracker_name || "",
           category: category_name || "",
-          format_instructions: RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(json_schema)
+          format_instructions: format_instructions_for(json_schema)
         )
 
         message = { role: "user", content: prompt_text }
         messages = [ message ]
-        answer = chat(messages)
-
-        RedmineAiHelper::Util::StructuredOutputHelper.parse(
-          response: answer,
-          json_schema: json_schema,
-          chat_method: method(:chat),
-          messages: messages
-        )
+        structured_chat(messages, json_schema: json_schema)
       end
 
       # Generate text completion for inline auto-completion

--- a/lib/redmine_ai_helper/agents/leader_agent.rb
+++ b/lib/redmine_ai_helper/agents/leader_agent.rb
@@ -81,19 +81,13 @@ module RedmineAiHelper
         }
 
         prompt_text = prompt.format(
-          format_instructions: RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(json_schema)
+          format_instructions: format_instructions_for(json_schema)
         )
 
         newmessages = messages.dup
         newmessages << { role: "user", content: prompt_text }
         langfuse.create_span(name: "goal_generation", input: prompt_text)
-        json = chat(newmessages)
-        fixed_json = RedmineAiHelper::Util::StructuredOutputHelper.parse(
-          response: json,
-          json_schema: json_schema,
-          chat_method: method(:chat),
-          messages: newmessages
-        )
+        fixed_json = structured_chat(newmessages, json_schema: json_schema)
         langfuse.finish_current_span(output: fixed_json)
         fixed_json
       end
@@ -193,7 +187,7 @@ module RedmineAiHelper
         prompt_text = prompt.format(
           goal: goal,
           agent_list: agent_list_string,
-          format_instructions: RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(json_schema),
+          format_instructions: format_instructions_for(json_schema),
           json_examples: json_examples,
           lang: I18n.locale.to_s
         )
@@ -203,13 +197,7 @@ module RedmineAiHelper
         newmessages = messages.dup
         newmessages << { role: "user", content: prompt_text }
         langfuse.create_span(name: "steps_generation", input: prompt_text)
-        json = chat(newmessages)
-        fixed_json = RedmineAiHelper::Util::StructuredOutputHelper.parse(
-          response: json,
-          json_schema: json_schema,
-          chat_method: method(:chat),
-          messages: newmessages
-        )
+        fixed_json = structured_chat(newmessages, json_schema: json_schema)
         langfuse.finish_current_span(output: fixed_json)
         fixed_json
       end

--- a/lib/redmine_ai_helper/base_agent.rb
+++ b/lib/redmine_ai_helper/base_agent.rb
@@ -250,8 +250,9 @@ module RedmineAiHelper
     #   added as history; the last is sent via ask.
     # @param callback [Proc, nil] Optional streaming callback.
     # @param with [Array<String>, nil] Image file paths to attach to the request.
-    # @return [String] The assembled answer (or the raw response content when
-    #   not streaming).
+    # @return [String, Hash, Array] The assembled answer when streaming; the raw
+    #   response content when not streaming, which is a Hash/Array instead of a
+    #   String when native structured output (with_schema) is in effect.
     def ask_with_messages(chat_instance, messages, callback, with:)
       # Add message history (all except the last message)
       messages[0..-2].each do |msg|

--- a/lib/redmine_ai_helper/base_agent.rb
+++ b/lib/redmine_ai_helper/base_agent.rb
@@ -184,7 +184,7 @@ module RedmineAiHelper
       RedmineAiHelper::Util::StructuredOutputHelper.parse(
         response: response,
         json_schema: json_schema,
-        chat_method: method(:chat),
+        chat_method: ->(retry_messages) { chat(retry_messages, {}, nil, with: with) },
         messages: messages
       )
     end
@@ -266,7 +266,7 @@ module RedmineAiHelper
 
       if callback
         chat_instance.ask(last_message[:content], **ask_options) do |chunk|
-          content = chunk.content rescue nil
+          content = chunk.content
           if content
             callback.call(content)
             answer += content
@@ -284,7 +284,8 @@ module RedmineAiHelper
     # via +with_schema+. The response content (Hash/Array or String) is fed into
     # the shared conform→validate pipeline so that any residual deviation is still
     # caught (research.md R4). Regeneration falls back to the prompt-instruction
-    # +chat+ method (no schema) to recover from provider-side misfires.
+    # +chat+ method (no schema, original attachments preserved) to recover from
+    # provider-side misfires.
     #
     # Array-rooted schemas are wrapped into an object under a single property
     # before being sent as the native schema payload, and the response is
@@ -303,7 +304,7 @@ module RedmineAiHelper
       helper.parse(
         response: response_content,
         json_schema: json_schema,
-        chat_method: method(:chat),
+        chat_method: ->(retry_messages) { chat(retry_messages, {}, nil, with: with) },
         messages: messages
       )
     end

--- a/lib/redmine_ai_helper/base_agent.rb
+++ b/lib/redmine_ai_helper/base_agent.rb
@@ -279,17 +279,28 @@ module RedmineAiHelper
 
       answer
     end
+
     # Native structured-output path: delegate schema enforcement to the provider
     # via +with_schema+. The response content (Hash/Array or String) is fed into
     # the shared conform→validate pipeline so that any residual deviation is still
     # caught (research.md R4). Regeneration falls back to the prompt-instruction
     # +chat+ method (no schema) to recover from provider-side misfires.
+    #
+    # Array-rooted schemas are wrapped into an object under a single property
+    # before being sent as the native schema payload, and the response is
+    # unwrapped back into a bare array before entering the parse pipeline,
+    # because providers such as OpenAI require an object root for native
+    # structured output (see StructuredOutputHelper#wrap_array_root_schema).
     def structured_chat_native(messages, json_schema:, with: nil)
-      schema_payload = RedmineAiHelper::Util::StructuredOutputHelper.native_schema_payload(json_schema)
+      helper = RedmineAiHelper::Util::StructuredOutputHelper
+      array_root = helper.array_root_schema?(json_schema)
+      native_schema = array_root ? helper.wrap_array_root_schema(json_schema) : json_schema
+      schema_payload = helper.native_schema_payload(native_schema)
       chat_instance = @llm_provider.create_chat(instructions: system_prompt, schema: schema_payload)
       setup_langfuse_callbacks(chat_instance, provider: @llm_provider)
       response_content = ask_with_messages(chat_instance, messages, nil, with: with)
-      RedmineAiHelper::Util::StructuredOutputHelper.parse(
+      response_content = helper.unwrap_array_root(response_content) if array_root
+      helper.parse(
         response: response_content,
         json_schema: json_schema,
         chat_method: method(:chat),
@@ -297,6 +308,7 @@ module RedmineAiHelper
       )
     end
 
+    # Build a fresh assistant using the think LLM provider (or fall back to the regular provider).
     # Replays @shared_messages so the think model has full conversation context.
     # A fresh assistant is used rather than reusing @assistant to avoid stale provider-specific
     # tool-call state that cannot be safely copied across providers.

--- a/lib/redmine_ai_helper/base_agent.rb
+++ b/lib/redmine_ai_helper/base_agent.rb
@@ -141,32 +141,7 @@ module RedmineAiHelper
     def chat(messages, _option = {}, callback = nil, with: nil)
       chat_instance = @llm_provider.create_chat(instructions: system_prompt)
       setup_langfuse_callbacks(chat_instance, provider: @llm_provider)
-
-      # Add message history (all except the last message)
-      messages[0..-2].each do |msg|
-        chat_instance.add_message(role: msg[:role].to_sym, content: msg[:content])
-      end
-
-      # Ask with the last message (with streaming support)
-      last_message = messages.last
-      ask_options = {}
-      ask_options[:with] = with if with.present?
-      answer = ""
-
-      if callback
-        chat_instance.ask(last_message[:content], **ask_options) do |chunk|
-          content = chunk.content rescue nil
-          if content
-            callback.call(content)
-            answer += content
-          end
-        end
-      else
-        response = chat_instance.ask(last_message[:content], **ask_options)
-        answer = response.content
-      end
-
-      answer
+      ask_with_messages(chat_instance, messages, callback, with: with)
     end
 
     # Chat with the Think model LLM if configured, otherwise delegates to chat().
@@ -182,30 +157,49 @@ module RedmineAiHelper
       provider = think_llm_provider || @llm_provider
       chat_instance = provider.create_chat(instructions: system_prompt)
       setup_langfuse_callbacks(chat_instance, provider: provider)
+      ask_with_messages(chat_instance, messages, callback, with: with)
+    end
 
-      messages[0..-2].each do |msg|
-        chat_instance.add_message(role: msg[:role].to_sym, content: msg[:content])
+    # Obtain a schema-conforming structured response for the given messages.
+    #
+    # Falls back to the prompt-instruction path: a regular {chat} call returns a
+    # text response that is then parsed and validated against the schema. On
+    # violations, a single regeneration is requested via the chat method.
+    # Native structured output (with_schema) is handled separately for capable
+    # providers (see User Story 2).
+    #
+    # @param messages [Array<Hash>] The messages to be sent.
+    # @param json_schema [Hash] The JSON schema the response must satisfy.
+    # @param with [Array<String>, nil] Image file paths to attach to the request.
+    # @return [Hash, Array] The schema-conforming parsed response.
+    # @raise [JSON::ParserError] If the response cannot be parsed.
+    # @raise [RedmineAiHelper::Util::StructuredOutputHelper::SchemaViolationError]
+    #   If the response cannot be conformed to the schema.
+    def structured_chat(messages, json_schema:, with: nil)
+      if @llm_provider.supports_structured_output?
+        return structured_chat_native(messages, json_schema: json_schema, with: with)
       end
 
-      last_message = messages.last
-      ask_options = {}
-      ask_options[:with] = with if with.present?
-      answer = ""
+      response = chat(messages, {}, nil, with: with)
+      RedmineAiHelper::Util::StructuredOutputHelper.parse(
+        response: response,
+        json_schema: json_schema,
+        chat_method: method(:chat),
+        messages: messages
+      )
+    end
 
-      if callback
-        chat_instance.ask(last_message[:content], **ask_options) do |chunk|
-          content = chunk.content rescue nil
-          if content
-            callback.call(content)
-            answer += content
-          end
-        end
-      else
-        response = chat_instance.ask(last_message[:content], **ask_options)
-        answer = response.content
-      end
-
-      answer
+    # Return the format-instruction text appropriate for the active provider.
+    #
+    # Native structured-output providers enforce the schema at the API level, so
+    # no format instructions are embedded in the prompt. Non-native providers
+    # use the prompt-instruction text generated from the schema.
+    # @param json_schema [Hash] The JSON schema.
+    # @return [String] Empty string for native providers; otherwise the
+    #   prompt-instruction text.
+    def format_instructions_for(json_schema)
+      return "" if @llm_provider.supports_structured_output?
+      RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(json_schema)
     end
 
     # Perform a task using the assistant.
@@ -248,7 +242,61 @@ module RedmineAiHelper
 
     private
 
-    # Build a fresh assistant using the think LLM provider (or fall back to the regular provider).
+    # Build message history and ask the last message on a chat instance.
+    # Shared by chat, think_chat and structured_chat.
+    # @param chat_instance [RubyLLM::Chat] The chat instance (already configured
+    #   with instructions, callbacks, schema, etc.).
+    # @param messages [Array<Hash>] The messages to send. All but the last are
+    #   added as history; the last is sent via ask.
+    # @param callback [Proc, nil] Optional streaming callback.
+    # @param with [Array<String>, nil] Image file paths to attach to the request.
+    # @return [String] The assembled answer (or the raw response content when
+    #   not streaming).
+    def ask_with_messages(chat_instance, messages, callback, with:)
+      # Add message history (all except the last message)
+      messages[0..-2].each do |msg|
+        chat_instance.add_message(role: msg[:role].to_sym, content: msg[:content])
+      end
+
+      # Ask with the last message (with streaming support)
+      last_message = messages.last
+      ask_options = {}
+      ask_options[:with] = with if with.present?
+      answer = ""
+
+      if callback
+        chat_instance.ask(last_message[:content], **ask_options) do |chunk|
+          content = chunk.content rescue nil
+          if content
+            callback.call(content)
+            answer += content
+          end
+        end
+      else
+        response = chat_instance.ask(last_message[:content], **ask_options)
+        answer = response.content
+      end
+
+      answer
+    end
+    # Native structured-output path: delegate schema enforcement to the provider
+    # via +with_schema+. The response content (Hash/Array or String) is fed into
+    # the shared conform→validate pipeline so that any residual deviation is still
+    # caught (research.md R4). Regeneration falls back to the prompt-instruction
+    # +chat+ method (no schema) to recover from provider-side misfires.
+    def structured_chat_native(messages, json_schema:, with: nil)
+      schema_payload = RedmineAiHelper::Util::StructuredOutputHelper.native_schema_payload(json_schema)
+      chat_instance = @llm_provider.create_chat(instructions: system_prompt, schema: schema_payload)
+      setup_langfuse_callbacks(chat_instance, provider: @llm_provider)
+      response_content = ask_with_messages(chat_instance, messages, nil, with: with)
+      RedmineAiHelper::Util::StructuredOutputHelper.parse(
+        response: response_content,
+        json_schema: json_schema,
+        chat_method: method(:chat),
+        messages: messages
+      )
+    end
+
     # Replays @shared_messages so the think model has full conversation context.
     # A fresh assistant is used rather than reusing @assistant to avoid stale provider-specific
     # tool-call state that cannot be safely copied across providers.

--- a/lib/redmine_ai_helper/llm.rb
+++ b/lib/redmine_ai_helper/llm.rb
@@ -117,7 +117,7 @@ module RedmineAiHelper
         langfuse.flush(output: sub_issues.inspect)
       rescue => e
         ai_helper_logger.error "error: #{e.full_message}"
-        throw e
+        raise
       end
       ai_helper_logger.info "sub issues: #{sub_issues.inspect}"
       sub_issues

--- a/lib/redmine_ai_helper/llm_client/azure_open_ai_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/azure_open_ai_provider.rb
@@ -11,8 +11,11 @@ module RedmineAiHelper
       # Overrides base class to use provider: :openai and assume_model_exists: true.
       # @param instructions [String, nil] system prompt
       # @param tools [Array<Class>] tool classes to attach
+      # @param schema [Hash, nil] Unused: Azure OpenAI has no provider slug, so
+      #   native structured output is never selected (the keyword is accepted
+      #   only for signature compatibility with the base class).
       # @return [RubyLLM::Chat]
-      def create_chat(instructions: nil, tools: [])
+      def create_chat(instructions: nil, tools: [], schema: nil) # rubocop:disable Lint/UnusedMethodArgument
         chat = context.chat(
           model: model_name,
           provider: :openai,

--- a/lib/redmine_ai_helper/llm_client/base_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/base_provider.rb
@@ -6,6 +6,8 @@ module RedmineAiHelper
     # BaseProvider is an abstract class that defines the interface for LLM providers.
     # Each subclass configures RubyLLM with the appropriate API keys and settings.
     class BaseProvider
+      include RedmineAiHelper::Logger
+
       # Mutex used to prevent duplicate model fetches under concurrent requests.
       FETCH_MUTEX = Mutex.new
 
@@ -76,6 +78,9 @@ module RedmineAiHelper
         return false if ruby_llm_provider_slug.nil?
         model = RubyLLM.models.by_provider(ruby_llm_provider_slug).all.find { |m| m.id == model_name }
         model&.structured_output? ? true : false
+      rescue => e
+        ai_helper_logger.warn "supports_structured_output? judgment failed, falling back to false: #{e.message}"
+        false
       end
 
       # Generate an embedding vector for the given text via the memoized context.

--- a/lib/redmine_ai_helper/llm_client/base_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/base_provider.rb
@@ -51,14 +51,31 @@ module RedmineAiHelper
       # Create a RubyLLM::Chat instance via the memoized context.
       # @param instructions [String, nil] system prompt
       # @param tools [Array<Class>] tool classes to attach
+      # @param schema [Hash, nil] native structured-output payload
+      #   (`{ name:, schema:, strict: }`). When provided, `chat.with_schema` is
+      #   applied to enforce the schema at the provider API level.
       # @return [RubyLLM::Chat]
-      def create_chat(instructions: nil, tools: [])
+      def create_chat(instructions: nil, tools: [], schema: nil)
         chat = context.chat(model: model_name)
         chat.with_instructions(instructions) if instructions
         chat.with_tools(*tools) unless tools.empty?
         chat.with_temperature(temperature) if temperature
+        chat.with_schema(schema) if schema
         apply_user_identifier(chat)
         chat
+      end
+
+      # Whether the configured model supports native structured output.
+      #
+      # Returns false when the provider slug is unknown (Azure OpenAI,
+      # OpenAI-compatible) or the model is not registered. Otherwise returns
+      # the model's `structured_output?` capability. Judgment failures fall to
+      # the safe (non-native) side.
+      # @return [Boolean]
+      def supports_structured_output?
+        return false if ruby_llm_provider_slug.nil?
+        model = RubyLLM.models.by_provider(ruby_llm_provider_slug).all.find { |m| m.id == model_name }
+        model&.structured_output? ? true : false
       end
 
       # Generate an embedding vector for the given text via the memoized context.

--- a/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
+++ b/lib/redmine_ai_helper/llm_client/open_ai_compatible_provider.rb
@@ -10,8 +10,11 @@ module RedmineAiHelper
       # Overrides base class to use provider: :openai and assume_model_exists: true.
       # @param instructions [String, nil] system prompt
       # @param tools [Array<Class>] tool classes to attach
+      # @param schema [Hash, nil] Unused: OpenAI-compatible providers have no
+      #   provider slug, so native structured output is never selected (the
+      #   keyword is accepted only for signature compatibility).
       # @return [RubyLLM::Chat]
-      def create_chat(instructions: nil, tools: [])
+      def create_chat(instructions: nil, tools: [], schema: nil) # rubocop:disable Lint/UnusedMethodArgument
         chat = context.chat(
           model: model_name,
           provider: :openai,

--- a/lib/redmine_ai_helper/util/structured_output_helper.rb
+++ b/lib/redmine_ai_helper/util/structured_output_helper.rb
@@ -373,7 +373,8 @@ module RedmineAiHelper
         # @param violations [Array<String>]
         # @return [void]
         def validate_object(data, schema, path, violations)
-          (schema["required"] || []).each do |key|
+          required_keys = schema["required"] || []
+          required_keys.each do |key|
             unless data.is_a?(Hash) && data.key?(key)
               violations << "#{join_path(path, key)}: required key missing"
             end
@@ -382,6 +383,9 @@ module RedmineAiHelper
           return unless data.is_a?(Hash)
           data.each do |key, value|
             next unless properties.key?(key)
+            # null is tolerated for optional properties (LLMs commonly emit
+            # null rather than omitting the key for "not applicable" values).
+            next if value.nil? && required_keys.exclude?(key)
             validate_value(value, properties[key], join_path(path, key), violations)
           end
         end

--- a/lib/redmine_ai_helper/util/structured_output_helper.rb
+++ b/lib/redmine_ai_helper/util/structured_output_helper.rb
@@ -1,11 +1,29 @@
 # frozen_string_literal: true
 
 require "json"
+require "redmine_ai_helper/logger"
 
 module RedmineAiHelper
   module Util
-    # Provides format instructions generation and JSON parsing with retry.
+    # Provides format instructions generation and JSON parsing with schema
+    # conformance, validation, and a single LLM regeneration retry.
     class StructuredOutputHelper
+      extend RedmineAiHelper::Logger::ClassMethods
+
+      # Error raised when an LLM response cannot be conformed to the requested
+      # JSON schema even after a single regeneration attempt.
+      class SchemaViolationError < StandardError
+        # @return [Array<String>] The list of detected schema violations.
+        attr_reader :violations
+
+        # @param message [String] Human-readable summary of the violation.
+        # @param violations [Array<String>] The detected violations.
+        def initialize(message, violations)
+          super(message)
+          @violations = violations
+        end
+      end
+
       class << self
         # Generate format instructions from a JSON schema.
         # Generates format instructions to embed in a prompt.
@@ -31,28 +49,355 @@ module RedmineAiHelper
           INSTRUCTIONS
         end
 
-        # Parse structured JSON output from an LLM response.
-        # Tries direct parsing first, then retries with the LLM if a chat_method is provided.
-        # @param response [String] The raw LLM response
-        # @param json_schema [Hash] The JSON schema (used for retry instructions)
-        # @param chat_method [Proc, nil] A method to call for retry (receives messages array, returns string)
-        # @param messages [Array<Hash>, nil] Original messages for retry context
-        # @return [Hash, Array] The parsed JSON object
-        # @raise [JSON::ParserError] If parsing fails and no retry is possible
+        # Parse structured JSON output from an LLM response and ensure it
+        # conforms to the given schema.
+        #
+        # String responses are JSON-parsed (with a single parse-fix retry when a
+        # chat_method is available). Hash/Array responses (e.g. from native
+        # structured output) are used directly. The parsed value is then
+        # conformed (wrapped/trimmed) and validated against the schema. On
+        # validation violations, a single regeneration is requested via
+        # chat_method when available; otherwise SchemaViolationError is raised.
+        #
+        # @param response [String, Hash, Array] The raw LLM response or a
+        #   pre-parsed Hash/Array.
+        # @param json_schema [Hash] The JSON schema.
+        # @param chat_method [Proc, nil] A method to call for retries (receives
+        #   the messages array, returns a String response).
+        # @param messages [Array<Hash>, nil] Original messages for retry context.
+        # @return [Hash, Array] The conformed, schema-valid value.
+        # @raise [JSON::ParserError] If parsing fails and no/limited retry helps.
+        # @raise [SchemaViolationError] If the response cannot be conformed.
         def parse(response:, json_schema:, chat_method: nil, messages: nil)
-          parse_json_from_response(response)
-        rescue JSON::ParserError => e
-          raise e unless chat_method && messages
-
-          retry_with_llm(
-            response: response,
+          data = parsed_data_from(
+            response,
+            json_schema: json_schema,
+            chat_method: chat_method,
+            messages: messages
+          )
+          conform_and_validate(
+            data,
             json_schema: json_schema,
             chat_method: chat_method,
             messages: messages
           )
         end
 
+        # Conform a parsed value to a JSON schema without mutating the input.
+        #
+        # Currently performs two deterministic transforms:
+        #   * wraps a bare Array into the single array-type property when the
+        #     schema is an object with exactly one array property;
+        #   * recursively removes keys not declared in object `properties`
+        #     (descending into `properties` and `items`).
+        #
+        # Schema keys may be symbols or strings (normalized internally).
+        # @param data [Object] The parsed value.
+        # @param json_schema [Hash] The JSON schema.
+        # @return [Object] A new, conformed value.
+        def conform_to_schema(data, json_schema)
+          schema = stringify_keys(json_schema)
+          conform_value(stringify_keys(data), schema)
+        end
+
+        # Validate a value against a JSON schema.
+        #
+        # Only `required` key presence and `type` mismatches are checked
+        # (recursively). No value coercion is performed. `format` and `enum`
+        # are intentionally not validated.
+        # @param data [Object] The value to validate.
+        # @param json_schema [Hash] The JSON schema.
+        # @return [Array<String>] Violation list (empty means conformant).
+        def validate(data, json_schema)
+          schema = stringify_keys(json_schema)
+          violations = []
+          validate_value(data, schema, "", violations)
+          violations
+        end
+
+        # Build the payload passed to RubyLLM::Chat#with_schema for native
+        # structured output.
+        #
+        # The schema is passed through unchanged. `strict` is always `false`
+        # because enabling OpenAI strict mode would require rewriting existing
+        # schemas (all properties required + null-union handling). Even with
+        # strict disabled, providers follow the schema closely and the
+        # conformance/validation pipeline catches any residual deviation.
+        # @param json_schema [Hash] The JSON schema, passed through unchanged.
+        # @param name [String] Schema identifier (only [a-zA-Z0-9_-]).
+        # @return [Hash] `{ name:, schema:, strict: false }`.
+        def native_schema_payload(json_schema, name: "response")
+          { name: name, schema: json_schema, strict: false }
+        end
+
         private
+
+        # Resolve the response into a Hash/Array, applying a single parse-fix
+        # retry for String responses when a chat_method is available.
+        # @return [Hash, Array]
+        # @raise [JSON::ParserError] if parsing ultimately fails.
+        def parsed_data_from(response, json_schema:, chat_method:, messages:)
+          return response if response.is_a?(Hash) || response.is_a?(Array)
+          parse_json_from_response(response)
+        rescue JSON::ParserError
+          raise unless chat_method && messages
+          fixed = request_llm_correction(
+            messages: messages,
+            json_schema: json_schema,
+            chat_method: chat_method,
+            problem: unparseable_response_problem(response)
+          )
+          parse_json_from_response(fixed)
+        end
+
+        # Conform and validate data against the schema, requesting a single
+        # regeneration on violations when a chat_method is available.
+        # @return [Object] The conformed, valid value.
+        # @raise [SchemaViolationError] if violations cannot be resolved.
+        def conform_and_validate(data, json_schema:, chat_method:, messages:)
+          conformed = conform_to_schema(data, json_schema)
+          violations = validate(conformed, json_schema)
+          return conformed if violations.empty?
+
+          return raise_schema_violation(conformed, violations) unless chat_method && messages
+
+          regenerated = request_llm_correction(
+            messages: messages,
+            json_schema: json_schema,
+            chat_method: chat_method,
+            problem: schema_violation_problem(conformed, violations)
+          )
+          reg_data = regenerated.is_a?(String) ? parse_json_from_response(regenerated) : regenerated
+          reg_conformed = conform_to_schema(reg_data, json_schema)
+          reg_violations = validate(reg_conformed, json_schema)
+          return reg_conformed if reg_violations.empty?
+
+          raise_schema_violation(reg_conformed, reg_violations)
+        end
+
+        # Log the unresolved response and violations, then raise.
+        # @return [void]
+        # @raise [SchemaViolationError]
+        def raise_schema_violation(data, violations)
+          ai_helper_logger.error(
+            "Schema violation could not be resolved. " \
+            "Response: #{data.inspect}. Violations: #{violations.join('; ')}"
+          )
+          raise SchemaViolationError.new(
+            "LLM response did not conform to the JSON schema after conformance and validation",
+            violations
+          )
+        end
+
+        # Request a correction from the LLM by embedding the problem description
+        # and schema into a retry prompt. Generalized for both parse failures
+        # and schema violations.
+        # @param messages [Array<Hash>] Original messages.
+        # @param json_schema [Hash] The JSON schema.
+        # @param chat_method [Proc] The chat method to call.
+        # @param problem [String] Human-readable problem description.
+        # @return [String] The raw LLM response.
+        def request_llm_correction(messages:, json_schema:, chat_method:, problem:)
+          prompt = <<~PROMPT
+            The previous response did not satisfy the expected JSON structure.
+
+            #{problem}
+
+            Expected JSON Schema:
+            ```json
+            #{JSON.pretty_generate(json_schema)}
+            ```
+
+            Please output ONLY a valid JSON value that matches the schema exactly. No additional text.
+          PROMPT
+
+          new_messages = messages.dup
+          new_messages << { role: "user", content: prompt }
+          chat_method.call(new_messages)
+        end
+
+        # Build the problem description for an unparseable response.
+        # @param response [String] The unparseable response.
+        # @return [String]
+        def unparseable_response_problem(response)
+          <<~MSG
+            The following response was supposed to be a valid JSON value but it could not be parsed.
+
+            Response:
+            #{response}
+          MSG
+        end
+
+        # Build the problem description for a schema violation.
+        # @param data [Object] The conformed value.
+        # @param violations [Array<String>] The detected violations.
+        # @return [String]
+        def schema_violation_problem(data, violations)
+          <<~MSG
+            The response was parsed as JSON but violates the schema. The following problems were detected:
+
+            #{violations.map { |v| "- #{v}" }.join("\n")}
+
+            Current response:
+            #{JSON.generate(data) rescue data.inspect}
+          MSG
+        end
+
+        # Recursively conform a value to its schema.
+        # @param data [Object]
+        # @param schema [Hash] String-keyed schema.
+        # @return [Object] A new conformed value.
+        def conform_value(data, schema)
+          type = schema["type"]
+          if data.is_a?(Array)
+            return wrap_bare_array(data, schema) if type == "object" && single_array_property?(schema)
+            return conform_array(data, schema) if type == "array"
+            return data
+          end
+          return conform_object(data, schema) if data.is_a?(Hash) && type == "object"
+          data
+        end
+
+        # Wrap a bare array into the single array-type property.
+        # @param data [Array]
+        # @param schema [Hash] Object schema with one array property.
+        # @return [Hash]
+        def wrap_bare_array(data, schema)
+          prop_name = schema["properties"].keys.first
+          { prop_name => conform_array(data, schema["properties"][prop_name]) }
+        end
+
+        # Conform each element of an array against the items schema.
+        # @param data [Array]
+        # @param schema [Hash] Array schema.
+        # @return [Array]
+        def conform_array(data, schema)
+          items_schema = schema["items"]
+          return data unless items_schema
+          data.map { |item| conform_value(item, items_schema) }
+        end
+
+        # Conform an object by removing undeclared keys and recursing.
+        # @param data [Hash]
+        # @param schema [Hash] Object schema.
+        # @return [Hash]
+        def conform_object(data, schema)
+          properties = schema["properties"] || {}
+          result = {}
+          data.each do |key, value|
+            next unless properties.key?(key)
+            result[key] = conform_value(value, properties[key])
+          end
+          result
+        end
+
+        # Whether the object schema has exactly one property of array type.
+        # @param schema [Hash]
+        # @return [Boolean]
+        def single_array_property?(schema)
+          props = schema["properties"]
+          return false unless props.is_a?(Hash) && props.size == 1
+          prop_schema = props.values.first
+          prop_schema.is_a?(Hash) && prop_schema["type"] == "array"
+        end
+
+        # Recursively validate a value against its schema, appending violations.
+        # @param data [Object]
+        # @param schema [Hash] String-keyed schema.
+        # @param path [String] Current JSON path.
+        # @param violations [Array<String>] Accumulator.
+        # @return [void]
+        def validate_value(data, schema, path, violations)
+          type = schema["type"]
+          if type && !type_matches?(data, type)
+            violations << "#{path}: expected #{type}, got #{type_label(data)}"
+            return
+          end
+          case type
+          when "object" then validate_object(data, schema, path, violations)
+          when "array" then validate_array(data, schema, path, violations)
+          end
+        end
+
+        # Validate an object: required keys and declared properties.
+        # @param data [Object]
+        # @param schema [Hash]
+        # @param path [String]
+        # @param violations [Array<String>]
+        # @return [void]
+        def validate_object(data, schema, path, violations)
+          (schema["required"] || []).each do |key|
+            unless data.is_a?(Hash) && data.key?(key)
+              violations << "#{join_path(path, key)}: required key missing"
+            end
+          end
+          properties = schema["properties"] || {}
+          return unless data.is_a?(Hash)
+          data.each do |key, value|
+            next unless properties.key?(key)
+            validate_value(value, properties[key], join_path(path, key), violations)
+          end
+        end
+
+        # Validate each array element against the items schema.
+        # @param data [Array]
+        # @param schema [Hash]
+        # @param path [String]
+        # @param violations [Array<String>]
+        # @return [void]
+        def validate_array(data, schema, path, violations)
+          items_schema = schema["items"]
+          return unless items_schema
+          data.each_with_index do |item, index|
+            validate_value(item, items_schema, "#{path}[#{index}]", violations)
+          end
+        end
+
+        # Join a base path with a key (no leading dot at the root).
+        # @param path [String]
+        # @param key [String, Symbol]
+        # @return [String]
+        def join_path(path, key)
+          path.empty? ? key.to_s : "#{path}.#{key}"
+        end
+
+        # Whether a value matches a JSON schema type.
+        # @param data [Object]
+        # @param type [String]
+        # @return [Boolean]
+        def type_matches?(data, type)
+          case type
+          when "string" then data.is_a?(String)
+          when "integer" then data.is_a?(Integer)
+          when "number" then data.is_a?(Numeric)
+          when "boolean" then [ true, false ].include?(data)
+          when "array" then data.is_a?(Array)
+          when "object" then data.is_a?(Hash)
+          else true
+          end
+        end
+
+        # Human-readable label for a value's type, used in violation messages.
+        # @param data [Object]
+        # @return [String]
+        def type_label(data)
+          return "Boolean" if [ true, false ].include?(data)
+          data.class.name
+        end
+
+        # Recursively convert all Hash keys to strings.
+        # @param obj [Object]
+        # @return [Object] A new object with string keys.
+        def stringify_keys(obj)
+          case obj
+          when Hash
+            obj.to_h { |k, v| [ k.to_s, stringify_keys(v) ] }
+          when Array
+            obj.map { |v| stringify_keys(v) }
+          else
+            obj
+          end
+        end
 
         # Extract and parse JSON from a response string.
         # Handles JSON wrapped in ```json ... ``` code blocks.
@@ -64,40 +409,10 @@ module RedmineAiHelper
 
           # Try to extract from ```json ... ``` or ``` ... ``` blocks
           json_match = response.match(/```(?:json)?\s*\n?(.*?)\n?\s*```/m)
-          if json_match
-            return JSON.parse(json_match[1].strip)
-          end
+          return JSON.parse(json_match[1].strip) if json_match
 
           # Fall back to direct parse
           JSON.parse(response.strip)
-        end
-
-        # Retry parsing by sending the failed response back to the LLM with fix instructions.
-        # @param response [String] The original failed response
-        # @param json_schema [Hash] The JSON schema
-        # @param chat_method [Proc] The chat method to use for retry
-        # @param messages [Array<Hash>] The original messages
-        # @return [Hash, Array] Parsed JSON from retry
-        # @raise [JSON::ParserError] If retry also fails
-        def retry_with_llm(response:, json_schema:, chat_method:, messages:)
-          fix_prompt = <<~PROMPT
-            The following response was supposed to be a valid JSON object matching the schema below, but it could not be parsed.
-
-            Response:
-            #{response}
-
-            Expected JSON Schema:
-            ```json
-            #{JSON.pretty_generate(json_schema)}
-            ```
-
-            Please output ONLY a valid JSON object that matches the schema. No additional text.
-          PROMPT
-
-          new_messages = messages.dup
-          new_messages << { role: "user", content: fix_prompt }
-          fixed_response = chat_method.call(new_messages)
-          parse_json_from_response(fixed_response)
         end
       end
     end

--- a/lib/redmine_ai_helper/util/structured_output_helper.rb
+++ b/lib/redmine_ai_helper/util/structured_output_helper.rb
@@ -130,6 +130,53 @@ module RedmineAiHelper
           { name: name, schema: json_schema, strict: false }
         end
 
+        # Property name used by {wrap_array_root_schema}/{unwrap_array_root} to
+        # lift an array-rooted schema into an object for native structured
+        # output providers that require an object root (e.g. OpenAI).
+        ARRAY_ROOT_PROPERTY = "value"
+
+        # Whether the given JSON schema has an array root.
+        # @param json_schema [Hash] The JSON schema.
+        # @return [Boolean]
+        def array_root_schema?(json_schema)
+          stringify_keys(json_schema)["type"] == "array"
+        end
+
+        # Lift an array-rooted schema into an object schema with a single
+        # {ARRAY_ROOT_PROPERTY} property. Native structured output on
+        # providers such as OpenAI requires an object root, so array-rooted
+        # schemas (e.g. documentation_agent's typo-suggestion list) must be
+        # wrapped before being sent as the native schema payload.
+        # @param json_schema [Hash] An array-rooted schema.
+        # @return [Hash] An object schema wrapping the array under
+        #   ARRAY_ROOT_PROPERTY.
+        def wrap_array_root_schema(json_schema)
+          schema = stringify_keys(json_schema)
+          {
+            "type" => "object",
+            "properties" => { ARRAY_ROOT_PROPERTY => schema },
+            "required" => [ ARRAY_ROOT_PROPERTY ]
+          }
+        end
+
+        # Unwrap a native response produced against a
+        # {wrap_array_root_schema} payload back into a bare array.
+        #
+        # Returns the response unchanged (String, Hash, or Array) when it is
+        # not in the expected wrapped shape, so the normal parse pipeline can
+        # still handle it (e.g. surface a JSON::ParserError or schema
+        # violation instead of silently swallowing an unexpected shape).
+        # @param response [String, Hash, Array] The raw native response.
+        # @return [String, Hash, Array] The unwrapped array, or the response
+        #   unchanged.
+        def unwrap_array_root(response)
+          data = response.is_a?(String) ? parsed_json_or_nil(response) : response
+          return response unless data.is_a?(Hash)
+
+          wrapped = stringify_keys(data)
+          wrapped.key?(ARRAY_ROOT_PROPERTY) ? wrapped[ARRAY_ROOT_PROPERTY] : response
+        end
+
         private
 
         # Resolve the response into a Hash/Array, applying a single parse-fix
@@ -413,6 +460,17 @@ module RedmineAiHelper
 
           # Fall back to direct parse
           JSON.parse(response.strip)
+        end
+
+        # Best-effort JSON parse used by {unwrap_array_root}; returns nil
+        # instead of raising so a malformed native response is passed through
+        # unchanged to the normal parse pipeline.
+        # @param response [String]
+        # @return [Hash, Array, nil]
+        def parsed_json_or_nil(response)
+          parse_json_from_response(response)
+        rescue JSON::ParserError
+          nil
         end
       end
     end

--- a/lib/redmine_ai_helper/vector/issue_content_analyzer.rb
+++ b/lib/redmine_ai_helper/vector/issue_content_analyzer.rb
@@ -45,7 +45,7 @@ module RedmineAiHelper
         file_paths = supported_attachment_paths(issue)
         schema_payload = native ? RedmineAiHelper::Util::StructuredOutputHelper.native_schema_payload(JSON_SCHEMA) : nil
         response = call_llm(messages, with: file_paths.presence, schema: schema_payload)
-        parse_response(response, messages)
+        parse_response(response, messages, with: file_paths.presence)
       rescue StandardError => e
         ai_helper_logger.warn("Failed to analyze issue content: #{e.message}")
         empty_result
@@ -95,17 +95,20 @@ module RedmineAiHelper
       end
 
       # Parse the LLM response using StructuredOutputHelper.
+      # Retries keep the original file attachments but not the native schema:
+      # the retry prompt embeds the schema textually instead.
       # @param response [String, Hash, Array] The raw response text from the LLM,
       #   or a pre-parsed Hash/Array when native structured output is used.
       # @param messages [Array<Hash>] The original messages for retry context.
+      # @param with [Array<String>, nil] File paths attached to the original request.
       # @return [Hash] A hash containing :summary (String) and :keywords (Array<String>).
-      def parse_response(response, messages)
+      def parse_response(response, messages, with: nil)
         return empty_result if response.nil? || (response.is_a?(String) && response.strip.empty?)
 
         result = RedmineAiHelper::Util::StructuredOutputHelper.parse(
           response: response,
           json_schema: JSON_SCHEMA,
-          chat_method: method(:call_llm),
+          chat_method: ->(retry_messages) { call_llm(retry_messages, with: with) },
           messages: messages
         )
 

--- a/lib/redmine_ai_helper/vector/issue_content_analyzer.rb
+++ b/lib/redmine_ai_helper/vector/issue_content_analyzer.rb
@@ -38,11 +38,13 @@ module RedmineAiHelper
       # @param issue [Issue] The issue to analyze.
       # @return [Hash] A hash containing :summary (String) and :keywords (Array<String>).
       def analyze(issue)
-        format_instructions = RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(JSON_SCHEMA)
+        native = @llm_provider.supports_structured_output?
+        format_instructions = native ? "" : RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(JSON_SCHEMA)
         prompt = build_prompt(issue, format_instructions)
         messages = [ { role: "user", content: prompt } ]
         file_paths = supported_attachment_paths(issue)
-        response = call_llm(messages, with: file_paths.presence)
+        schema_payload = native ? RedmineAiHelper::Util::StructuredOutputHelper.native_schema_payload(JSON_SCHEMA) : nil
+        response = call_llm(messages, with: file_paths.presence, schema: schema_payload)
         parse_response(response, messages)
       rescue StandardError => e
         ai_helper_logger.warn("Failed to analyze issue content: #{e.message}")
@@ -72,8 +74,12 @@ module RedmineAiHelper
       # Call the LLM with the given messages.
       # @param messages [Array<Hash>] The messages to send to the LLM.
       # @return [String] The text response from the LLM.
-      def call_llm(messages, with: nil)
-        chat_instance = @llm_provider.create_chat
+      def call_llm(messages, with: nil, schema: nil)
+        chat_instance = if schema
+          @llm_provider.create_chat(schema: schema)
+        else
+          @llm_provider.create_chat
+        end
 
         # Add message history (all except the last message)
         messages[0..-2].each do |msg|
@@ -89,11 +95,12 @@ module RedmineAiHelper
       end
 
       # Parse the LLM response using StructuredOutputHelper.
-      # @param response [String] The raw response text from the LLM.
+      # @param response [String, Hash, Array] The raw response text from the LLM,
+      #   or a pre-parsed Hash/Array when native structured output is used.
       # @param messages [Array<Hash>] The original messages for retry context.
       # @return [Hash] A hash containing :summary (String) and :keywords (Array<String>).
       def parse_response(response, messages)
-        return empty_result if response.nil? || response.strip.empty?
+        return empty_result if response.nil? || (response.is_a?(String) && response.strip.empty?)
 
         result = RedmineAiHelper::Util::StructuredOutputHelper.parse(
           response: response,

--- a/test/unit/agents/documentation_agent_test.rb
+++ b/test/unit/agents/documentation_agent_test.rb
@@ -56,6 +56,25 @@ class DocumentationAgentTest < ActiveSupport::TestCase
     assert_equal [], @agent.available_tools
   end
 
+  def test_check_typos_routes_through_structured_chat
+    mock_response = [
+      {
+        "original" => "teh",
+        "corrected" => "the",
+        "position" => 0,
+        "length" => 3,
+        "reason" => "Spelling mistake",
+        "confidence" => "high"
+      }
+    ]
+
+    @agent.expects(:structured_chat).with(anything, json_schema: anything).returns(mock_response)
+
+    result = @agent.check_typos(text: "teh quick brown fox", context_type: "test")
+
+    assert_equal mock_response, result
+  end
+
   def test_backstory_returns_prompt
     prompt_mock = mock("prompt")
     @agent.stubs(:load_prompt).with("documentation_agent/backstory").returns(prompt_mock)

--- a/test/unit/agents/documentation_agent_test.rb
+++ b/test/unit/agents/documentation_agent_test.rb
@@ -75,6 +75,36 @@ class DocumentationAgentTest < ActiveSupport::TestCase
     assert_equal mock_response, result
   end
 
+  def test_check_typos_native_structured_output_with_array_rooted_schema
+    @agent.llm_provider = mock("llm_provider")
+    @agent.llm_provider.stubs(:supports_structured_output?).returns(true)
+    mock_chat_instance = mock("RubyLLM::Chat")
+    mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+    mock_chat_instance.stubs(:add_message)
+    mock_response = mock("Response")
+    mock_response.stubs(:content).returns(
+      "value" => [
+        {
+          "original" => "teh",
+          "corrected" => "the",
+          "position" => 0,
+          "length" => 3,
+          "reason" => "Spelling mistake",
+          "confidence" => "high"
+        }
+      ]
+    )
+    mock_chat_instance.stubs(:ask).returns(mock_response)
+    @agent.llm_provider.expects(:create_chat).with do |opts|
+      opts[:schema][:schema]["type"] == "object" && opts[:schema][:schema]["properties"].key?("value")
+    end.returns(mock_chat_instance)
+
+    result = @agent.check_typos(text: "teh quick brown fox", context_type: "test")
+
+    assert_equal 1, result.length
+    assert_equal "the", result.first["corrected"]
+  end
+
   def test_backstory_returns_prompt
     prompt_mock = mock("prompt")
     @agent.stubs(:load_prompt).with("documentation_agent/backstory").returns(prompt_mock)

--- a/test/unit/agents/issue_agent_test.rb
+++ b/test/unit/agents/issue_agent_test.rb
@@ -329,6 +329,83 @@ class RedmineAiHelper::Agents::IssueAgentTest < ActiveSupport::TestCase
       end
     end
 
+    context "generate_sub_issues_draft Issue #345 reproduction (structured_chat routing)" do
+      setup do
+        User.current = User.find(1)
+        @issue = Issue.find(1)
+      end
+
+      should "US1-1: route through structured_chat and build sub-issues from a wrapped bare-array response" do
+        @agent.expects(:structured_chat).with(anything, json_schema: anything, with: anything).returns(
+          { "sub_issues" => [ { "subject" => "Sub A", "description" => "desc", "project_id" => @issue.project_id, "tracker_id" => @issue.tracker_id } ] }
+        )
+
+        result = @agent.generate_sub_issues_draft(issue: @issue, instructions: "Create sub issues.")
+
+        assert_kind_of Array, result
+        assert_equal "Sub A", result.first.subject
+      end
+
+      should "US1-2: not raise when the conformed response originally had undeclared keys" do
+        @agent.expects(:structured_chat).returns(
+          { "sub_issues" => [ { "subject" => "Sub B", "description" => "desc", "project_id" => @issue.project_id, "tracker_id" => @issue.tracker_id } ] }
+        )
+
+        result = @agent.generate_sub_issues_draft(issue: @issue, instructions: "Create sub issues.")
+
+        assert_kind_of Array, result
+        assert_equal "Sub B", result.first.subject
+      end
+
+      should "propagate attachment file paths to structured_chat via with:" do
+        file_paths = [ "/path/to/file.png" ]
+        @agent.stubs(:supported_attachment_paths).with(@issue).returns(file_paths)
+        @agent.expects(:structured_chat).with(anything, json_schema: anything, with: file_paths).returns(
+          { "sub_issues" => [ { "subject" => "Sub", "description" => "d", "project_id" => @issue.project_id, "tracker_id" => @issue.tracker_id } ] }
+        )
+
+        @agent.generate_sub_issues_draft(issue: @issue, instructions: "Create sub issues considering attachments.")
+      end
+    end
+
+    context "suggest_assignees_by_instructions (structured_chat routing)" do
+      setup do
+        User.current = User.find(1)
+        @assignable_users = [ User.find(1) ]
+      end
+
+      should "route through structured_chat and return the parsed suggestions" do
+        @agent.expects(:structured_chat).with(anything, json_schema: anything).returns(
+          { "suggestions" => [ { "user_id" => 1, "reason" => "expert" } ] }
+        )
+
+        result = @agent.suggest_assignees_by_instructions(
+          assignable_users: @assignable_users,
+          instructions: "assign to the expert",
+          subject: "title",
+          description: "desc"
+        )
+
+        assert_equal 1, result["suggestions"].length
+        assert_equal 1, result["suggestions"][0]["user_id"]
+      end
+    end
+
+    context "native structured output format_instructions (US2)" do
+      setup do
+        User.current = User.find(1)
+        @issue = Issue.find(1)
+        @agent.llm_provider.stubs(:supports_structured_output?).returns(true)
+      end
+
+      should "use format_instructions_for to omit prompt instructions when native" do
+        @agent.expects(:format_instructions_for).at_least_once
+        @agent.stubs(:structured_chat).returns({ "sub_issues" => [] })
+
+        @agent.generate_sub_issues_draft(issue: @issue, instructions: "Create sub issues.")
+      end
+    end
+
     context "US4 per-project vector gating" do
       should "exclude vector tools when vector_search_enabled_for? is false for the project" do
         AiHelperSetting.stubs(:vector_search_enabled_for?).with(@project).returns(false)

--- a/test/unit/agents/leader_agent_test.rb
+++ b/test/unit/agents/leader_agent_test.rb
@@ -17,6 +17,7 @@ class LeaderAgentTest < ActiveSupport::TestCase
     @mock_ruby_llm_chat.stubs(:on_end_message).returns(@mock_ruby_llm_chat)
     @mock_ruby_llm_chat.stubs(:add_message)
     @mock_llm_provider.stubs(:create_chat).returns(@mock_ruby_llm_chat)
+    @mock_llm_provider.stubs(:supports_structured_output?).returns(false)
 
     RedmineAiHelper::LlmProvider.stubs(:get_llm_provider).returns(@mock_llm_provider)
 
@@ -57,11 +58,33 @@ class LeaderAgentTest < ActiveSupport::TestCase
       assert_equal "test goal", goal["goal"]
     end
 
+    context "structured_chat routing (US1)" do
+      should "route generate_goal through structured_chat" do
+        @agent.expects(:structured_chat).with(anything, json_schema: anything).returns(
+          { "goal" => "routed goal", "generate_steps_required" => false }
+        )
+
+        goal = @agent.generate_goal(@messages)
+
+        assert_equal "routed goal", goal["goal"]
+      end
+
+      should "route generate_steps through structured_chat" do
+        @agent.expects(:structured_chat).with(anything, json_schema: anything).returns(
+          { "steps" => [ { "agent" => "wiki_agent", "step" => "do x", "description_for_human" => "Doing x...", "use_think_model" => true } ] }
+        )
+
+        steps = @agent.generate_steps("goal", @messages)
+
+        assert_kind_of Array, steps["steps"]
+      end
+    end
+
     should "generate steps correctly" do
       steps_json = {
         "steps" => [
-          { "agent" => "project_agent", "step" => "my_projectのIDを教えてください", "description_for_human" => "Retrieving project information..." },
-          { "agent" => "project_agent", "step" => "my_projectの情報を取得してください", "description_for_human" => "Getting project details..." }
+          { "agent" => "project_agent", "step" => "my_projectのIDを教えてください", "description_for_human" => "Retrieving project information...", "use_think_model" => false },
+          { "agent" => "project_agent", "step" => "my_projectの情報を取得してください", "description_for_human" => "Getting project details...", "use_think_model" => false }
         ]
       }.to_json
       mock_response = mock("Response")

--- a/test/unit/base_agent_test.rb
+++ b/test/unit/base_agent_test.rb
@@ -387,6 +387,54 @@ class RedmineAiHelper::BaseAgentTest < ActiveSupport::TestCase
     end
   end
 
+  context "structured_chat native branch with an array-rooted schema" do
+    setup do
+      @array_schema = {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => { "corrected" => { "type" => "string" } },
+          "required" => [ "corrected" ]
+        }
+      }
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+    end
+
+    should "wrap the array-rooted schema into an object payload for create_chat" do
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns({ "value" => [ { "corrected" => "the" } ] })
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.expects(:create_chat).with do |opts|
+        opts[:schema][:schema]["type"] == "object" &&
+          opts[:schema][:schema]["properties"].key?("value") &&
+          opts[:schema][:schema]["properties"]["value"] == @array_schema
+      end.returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @array_schema)
+
+      assert_kind_of Array, result
+      assert_equal "the", result.first["corrected"]
+    end
+
+    should "unwrap a String native response before validating against the array schema" do
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns('{"value": [{"corrected": "the"}]}')
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @array_schema)
+
+      assert_kind_of Array, result
+      assert_equal "the", result.first["corrected"]
+    end
+  end
+
   context "format_instructions_for" do
     setup do
       @json_schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } } }

--- a/test/unit/base_agent_test.rb
+++ b/test/unit/base_agent_test.rb
@@ -138,6 +138,22 @@ class RedmineAiHelper::BaseAgentTest < ActiveSupport::TestCase
       assert_equal "chunk1chunk2", answer
     end
 
+    should "propagate errors raised while reading streamed chunks" do
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      failing_chunk = mock("Chunk")
+      failing_chunk.stubs(:content).raises(RuntimeError.new("stream read failed"))
+      mock_chat_instance.expects(:ask).yields(failing_chunk)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      callback = ->(content) { }
+      error = assert_raises(RuntimeError) do
+        @agent.chat([ { role: "user", content: "Hello" } ], {}, callback)
+      end
+      assert_equal "stream read failed", error.message
+    end
+
     should "pass system_prompt as instructions to create_chat" do
       mock_chat_instance = mock("RubyLLM::Chat")
       mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
@@ -289,6 +305,23 @@ class RedmineAiHelper::BaseAgentTest < ActiveSupport::TestCase
       assert_equal "img", result["goal"]
     end
 
+    should "retain the with: parameter when regenerating after a schema violation" do
+      image_paths = [ "/path/to/img.png" ]
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      bad_response = mock("Response bad")
+      bad_response.stubs(:content).returns('{"other": "no goal"}')
+      good_response = mock("Response good")
+      good_response.stubs(:content).returns('{"goal": "regenerated"}')
+      mock_chat_instance.expects(:ask).with(anything, with: image_paths).twice.returns(bad_response, good_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema, with: image_paths)
+
+      assert_equal "regenerated", result["goal"]
+    end
+
     should "not rescue JSON::ParserError" do
       mock_chat_instance = mock("RubyLLM::Chat")
       mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
@@ -382,6 +415,23 @@ class RedmineAiHelper::BaseAgentTest < ActiveSupport::TestCase
       @agent.expects(:chat).with(anything, anything, anything, anything).returns('{"goal": "regenerated"}').at_least_once
 
       result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+
+      assert_equal "regenerated", result["goal"]
+    end
+
+    should "retain the with: parameter when regenerating via the fallback chat (native)" do
+      image_paths = [ "/path/to/img.png" ]
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns({ "other" => "no goal" })
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+      @agent.expects(:chat).with { |_msgs, _opt, _cb, **kw| kw[:with] == image_paths }.returns('{"goal": "regenerated"}')
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema, with: image_paths)
 
       assert_equal "regenerated", result["goal"]
     end

--- a/test/unit/base_agent_test.rb
+++ b/test/unit/base_agent_test.rb
@@ -250,6 +250,163 @@ class RedmineAiHelper::BaseAgentTest < ActiveSupport::TestCase
     end
   end
 
+  context "structured_chat" do
+    setup do
+      @json_schema = {
+        "type" => "object",
+        "properties" => { "goal" => { "type" => "string" } },
+        "required" => [ "goal" ]
+      }
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(false)
+    end
+
+    should "obtain a string response via chat and parse it with the schema" do
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns('{"goal": "structured"}')
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+
+      assert_equal "structured", result["goal"]
+    end
+
+    should "propagate the with: parameter to chat" do
+      image_paths = [ "/path/to/img.png" ]
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns('{"goal": "img"}')
+      mock_chat_instance.expects(:ask).with("hi", with: image_paths).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema, with: image_paths)
+
+      assert_equal "img", result["goal"]
+    end
+
+    should "not rescue JSON::ParserError" do
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns("not parseable {{{")
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      assert_raises(JSON::ParserError) do
+        @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+      end
+    end
+
+    should "not rescue SchemaViolationError" do
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns('{"other": "no goal"}')
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      assert_raises(RedmineAiHelper::Util::StructuredOutputHelper::SchemaViolationError) do
+        @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+      end
+    end
+  end
+
+  context "structured_chat native branch (US2)" do
+    setup do
+      @json_schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } }, "required" => [ "goal" ] }
+    end
+
+    should "call create_chat with a non-strict schema payload when supports_structured_output? is true" do
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns({ "goal" => "native" })
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.expects(:create_chat).with { |opts| opts.key?(:schema) && opts[:schema][:strict] == false && opts[:schema][:schema] == @json_schema }.returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+
+      assert_equal "native", result["goal"]
+    end
+
+    should "skip JSON parsing when response.content is a Hash" do
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns({ "goal" => "hash-content" })
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+
+      assert_equal "hash-content", result["goal"]
+    end
+
+    should "join the normal parse path when response.content is a String" do
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns('{"goal": "string-content"}')
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+
+      assert_equal "string-content", result["goal"]
+    end
+
+    should "pass regeneration through the fallback chat method on schema violation (native)" do
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+      mock_chat_instance = mock("RubyLLM::Chat")
+      mock_chat_instance.stubs(:on_end_message).returns(mock_chat_instance)
+      mock_chat_instance.stubs(:add_message)
+      # Native returns a non-conforming Hash first
+      mock_response = mock("Response")
+      mock_response.stubs(:content).returns({ "other" => "no goal" })
+      mock_chat_instance.stubs(:ask).returns(mock_response)
+      @mock_llm_provider.stubs(:create_chat).returns(mock_chat_instance)
+      # Regeneration via fallback chat returns compliant JSON
+      @agent.expects(:chat).with(anything, anything, anything, anything).returns('{"goal": "regenerated"}').at_least_once
+
+      result = @agent.structured_chat([ { role: "user", content: "hi" } ], json_schema: @json_schema)
+
+      assert_equal "regenerated", result["goal"]
+    end
+  end
+
+  context "format_instructions_for" do
+    setup do
+      @json_schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } } }
+    end
+
+    should "return an empty string when supports_structured_output? is true" do
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+
+      assert_equal "", @agent.format_instructions_for(@json_schema)
+    end
+
+    should "return get_format_instructions result when supports_structured_output? is false" do
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(false)
+
+      result = @agent.format_instructions_for(@json_schema)
+
+      assert_includes result, "JSON Schema"
+    end
+  end
+
   context "extract_text_content" do
     should "return text as-is for plain string content" do
       result = @agent.send(:extract_text_content, "Hello world")

--- a/test/unit/llm_client/base_provider_test.rb
+++ b/test/unit/llm_client/base_provider_test.rb
@@ -471,6 +471,12 @@ class RedmineAiHelper::LlmClient::BaseProviderTest < ActiveSupport::TestCase
 
           assert_equal false, @so_provider.supports_structured_output?
         end
+
+        should "return false when the registry lookup raises an error" do
+          RubyLLM.models.stubs(:by_provider).raises(StandardError.new("registry unavailable"))
+
+          assert_equal false, @so_provider.supports_structured_output?
+        end
       end
     end
 

--- a/test/unit/llm_client/base_provider_test.rb
+++ b/test/unit/llm_client/base_provider_test.rb
@@ -407,6 +407,102 @@ class RedmineAiHelper::LlmClient::BaseProviderTest < ActiveSupport::TestCase
       end
     end
 
+    context "supports_structured_output?" do
+      should "return false when ruby_llm_provider_slug is nil" do
+        assert_equal false, @provider.supports_structured_output?
+      end
+
+      should "return false for AzureOpenAiProvider (slug nil)" do
+        azure_profile = AiHelperModelProfile.create!(
+          name: "Azure SO", llm_type: "AzureOpenAi", llm_model: "gpt-4o",
+          access_key: "k", base_uri: "https://x.azure.com"
+        )
+        provider = RedmineAiHelper::LlmClient::AzureOpenAiProvider.new(model_profile: azure_profile)
+
+        assert_equal false, provider.supports_structured_output?
+      ensure
+        azure_profile&.destroy
+      end
+
+      should "return false for OpenAiCompatibleProvider (slug nil)" do
+        compatible_profile = AiHelperModelProfile.create!(
+          name: "Compat SO", llm_type: "OpenAICompatible", llm_model: "m",
+          access_key: "k", base_uri: "https://x.com"
+        )
+        provider = RedmineAiHelper::LlmClient::OpenAiCompatibleProvider.new(model_profile: compatible_profile)
+
+        assert_equal false, provider.supports_structured_output?
+      ensure
+        compatible_profile&.destroy
+      end
+
+      context "with a provider that has a ruby_llm_provider_slug" do
+        setup do
+          @so_model_id = "so-test-model-001"
+          @so_profile = AiHelperModelProfile.create!(
+            name: "SO Profile", llm_type: "OpenAI", llm_model: @so_model_id, access_key: "k"
+          )
+          @so_provider = FakeOpenAiProvider.new(model_profile: @so_profile)
+        end
+
+        teardown do
+          @so_profile.destroy
+          RubyLLM.models.instance_variable_get(:@models).reject! { |m| m.id == @so_model_id }
+        end
+
+        should "return false when model is not in registry" do
+          assert_equal false, @so_provider.supports_structured_output?
+        end
+
+        should "return the model structured_output? value when registered as capable" do
+          capable = RubyLLM::Model::Info.new(
+            id: @so_model_id, provider: "openai", name: "Capable", capabilities: %w[structured_output]
+          )
+          RubyLLM.models.instance_variable_get(:@models) << capable
+
+          assert_equal true, @so_provider.supports_structured_output?
+        end
+
+        should "return false when registered model lacks structured_output capability" do
+          incapable = RubyLLM::Model::Info.new(
+            id: @so_model_id, provider: "openai", name: "Incapable", capabilities: %w[streaming]
+          )
+          RubyLLM.models.instance_variable_get(:@models) << incapable
+
+          assert_equal false, @so_provider.supports_structured_output?
+        end
+      end
+    end
+
+    context "create_chat with schema" do
+      should "apply with_schema when schema is provided" do
+        mock_context = mock("RubyLLM::Context")
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.stubs(:with_temperature)
+        schema_payload = { name: "response", schema: { "type" => "object" }, strict: false }
+        mock_chat.expects(:with_schema).with(schema_payload).returns(mock_chat)
+
+        mock_context.expects(:chat).with(model: @setting.model_profile.llm_model).returns(mock_chat)
+        @provider.expects(:build_context).returns(mock_context)
+
+        chat = @provider.create_chat(schema: schema_payload)
+
+        assert_equal mock_chat, chat
+      end
+
+      should "not call with_schema when schema is nil (existing behavior)" do
+        mock_context = mock("RubyLLM::Context")
+        mock_chat = mock("RubyLLM::Chat")
+        mock_chat.stubs(:with_temperature)
+        mock_chat.expects(:with_schema).never
+
+        mock_context.expects(:chat).with(model: @setting.model_profile.llm_model).returns(mock_chat)
+        @provider.expects(:build_context).returns(mock_context)
+
+        @provider.create_chat
+      end
+    end
+
     context "apply_user_identifier" do
       setup do
         @original_send_user_id = @setting.send_user_id_enabled

--- a/test/unit/llm_test.rb
+++ b/test/unit/llm_test.rb
@@ -84,6 +84,20 @@ class RedmineAiHelper::LlmTest < ActiveSupport::TestCase
         assert_equal 2, sub_issues.length
         assert_equal "Sub issue 1", sub_issues[0].subject
       end
+
+      should "propagate the original exception when sub issue generation fails" do
+        @issue.stubs(:visible?).returns(true)
+        failing_agent = DummyIssueAgent.new
+        failing_agent.stubs(:generate_sub_issues_draft).raises(RuntimeError.new("agent failure"))
+        RedmineAiHelper::Agents::IssueAgent.stubs(:new).returns(failing_agent)
+
+        error = assert_raises(RuntimeError) do
+          @llm.generate_sub_issues(issue: @issue, instructions: "test instructions")
+        end
+
+        assert_instance_of RuntimeError, error
+        assert_equal "agent failure", error.message
+      end
     end
 
     context "wiki_summary" do

--- a/test/unit/util/structured_output_helper_test.rb
+++ b/test/unit/util/structured_output_helper_test.rb
@@ -577,4 +577,89 @@ class StructuredOutputHelperTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "array-root schema wrapping (native structured output)" do
+    setup do
+      @array_schema = {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "properties" => { "corrected" => { "type" => "string" } },
+          "required" => [ "corrected" ]
+        }
+      }
+    end
+
+    context "array_root_schema?" do
+      should "return true for an array-rooted schema" do
+        assert Util::StructuredOutputHelper.array_root_schema?(@array_schema)
+      end
+
+      should "return false for an object-rooted schema" do
+        object_schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } } }
+        assert_not Util::StructuredOutputHelper.array_root_schema?(object_schema)
+      end
+
+      should "work with symbol-keyed schemas" do
+        assert Util::StructuredOutputHelper.array_root_schema?(type: "array", items: { type: "string" })
+      end
+    end
+
+    context "wrap_array_root_schema" do
+      should "wrap the array schema under the value property, required" do
+        wrapped = Util::StructuredOutputHelper.wrap_array_root_schema(@array_schema)
+
+        assert_equal "object", wrapped["type"]
+        assert_equal @array_schema, wrapped["properties"]["value"]
+        assert_equal [ "value" ], wrapped["required"]
+      end
+    end
+
+    context "unwrap_array_root" do
+      should "unwrap a Hash response with the value key" do
+        result = Util::StructuredOutputHelper.unwrap_array_root({ "value" => [ { "corrected" => "the" } ] })
+
+        assert_equal [ { "corrected" => "the" } ], result
+      end
+
+      should "unwrap a String JSON response with the value key" do
+        result = Util::StructuredOutputHelper.unwrap_array_root('{"value": [{"corrected": "the"}]}')
+
+        assert_equal [ { "corrected" => "the" } ], result
+      end
+
+      should "return the response unchanged when the value key is absent" do
+        response = { "other" => [ 1, 2 ] }
+
+        assert_equal response, Util::StructuredOutputHelper.unwrap_array_root(response)
+      end
+
+      should "return the response unchanged when it is already a bare Array" do
+        response = [ { "corrected" => "the" } ]
+
+        assert_equal response, Util::StructuredOutputHelper.unwrap_array_root(response)
+      end
+
+      should "return the response unchanged when the String is not parseable" do
+        response = "not parseable {{{"
+
+        assert_equal response, Util::StructuredOutputHelper.unwrap_array_root(response)
+      end
+    end
+
+    context "end-to-end wrap -> unwrap -> parse" do
+      should "produce a schema-conformant array from a wrapped native response" do
+        native_schema = Util::StructuredOutputHelper.wrap_array_root_schema(@array_schema)
+        payload = Util::StructuredOutputHelper.native_schema_payload(native_schema)
+        assert_equal "object", payload[:schema]["type"]
+
+        native_response = { "value" => [ { "corrected" => "the", "extra" => "strip me" } ] }
+        unwrapped = Util::StructuredOutputHelper.unwrap_array_root(native_response)
+
+        result = Util::StructuredOutputHelper.parse(response: unwrapped, json_schema: @array_schema)
+
+        assert_equal [ { "corrected" => "the" } ], result
+      end
+    end
+  end
 end

--- a/test/unit/util/structured_output_helper_test.rb
+++ b/test/unit/util/structured_output_helper_test.rb
@@ -339,6 +339,31 @@ class StructuredOutputHelperTest < ActiveSupport::TestCase
       assert_match(/tracker_id: expected integer, got String/, violations.first)
     end
 
+    should "tolerate null for an optional property" do
+      schema = {
+        "type" => "object",
+        "properties" => { "subject" => { "type" => "string" }, "fixed_version_id" => { "type" => "integer" }, "due_date" => { "type" => "string" } },
+        "required" => [ "subject" ]
+      }
+      data = { "subject" => "x", "fixed_version_id" => nil, "due_date" => nil }
+
+      assert_equal [], Util::StructuredOutputHelper.validate(data, schema)
+    end
+
+    should "still detect type mismatch for null on a required property" do
+      schema = {
+        "type" => "object",
+        "properties" => { "tracker_id" => { "type" => "integer" } },
+        "required" => [ "tracker_id" ]
+      }
+      data = { "tracker_id" => nil }
+
+      violations = Util::StructuredOutputHelper.validate(data, schema)
+
+      assert_equal 1, violations.length
+      assert_match(/tracker_id: expected integer, got NilClass/, violations.first)
+    end
+
     should "map number to Numeric and accept floats" do
       schema = { "type" => "object", "properties" => { "n" => { "type" => "number" } }, "required" => [ "n" ] }
 

--- a/test/unit/util/structured_output_helper_test.rb
+++ b/test/unit/util/structured_output_helper_test.rb
@@ -177,4 +177,404 @@ class StructuredOutputHelperTest < ActiveSupport::TestCase
       assert_equal "Direct", result["goal"]
     end
   end
+
+  context "conform_to_schema - bare array wrapping" do
+    setup do
+      @sub_issues_schema = {
+        type: "object",
+        properties: {
+          sub_issues: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                subject: { type: "string" },
+                tracker_id: { type: "integer" }
+              },
+              required: [ "subject", "tracker_id" ]
+            }
+          }
+        }
+      }
+    end
+
+    should "wrap a bare array into the single array-type property" do
+      data = [ { "subject" => "a", "tracker_id" => 1 }, { "subject" => "b", "tracker_id" => 2 } ]
+
+      result = Util::StructuredOutputHelper.conform_to_schema(data, @sub_issues_schema)
+
+      assert_kind_of Hash, result
+      assert_kind_of Array, result["sub_issues"]
+      assert_equal 2, result["sub_issues"].length
+      assert_equal "a", result["sub_issues"][0]["subject"]
+    end
+
+    should "not wrap a bare array when schema object has multiple properties" do
+      schema = {
+        type: "object",
+        properties: {
+          a: { type: "array", items: { type: "string" } },
+          b: { type: "string" }
+        }
+      }
+      data = [ "x", "y" ]
+
+      result = Util::StructuredOutputHelper.conform_to_schema(data, schema)
+
+      # Not wrapped (single array property condition not met) — validate will flag it
+      assert_equal [ "x", "y" ], result
+    end
+
+    should "not wrap a bare array when the single property is not array type" do
+      schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" }
+        }
+      }
+      data = [ 1, 2, 3 ]
+
+      result = Util::StructuredOutputHelper.conform_to_schema(data, schema)
+
+      assert_equal [ 1, 2, 3 ], result
+    end
+  end
+
+  context "conform_to_schema - undeclared key removal" do
+    should "remove undeclared keys recursively from object properties" do
+      schema = {
+        "type" => "object",
+        "properties" => {
+          "sub_issues" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "subject" => { "type" => "string" },
+                "tracker_id" => { "type" => "integer" }
+              },
+              "required" => [ "subject" ]
+            }
+          }
+        }
+      }
+      data = {
+        "sub_issues" => [
+          { "subject" => "ok", "tracker_id" => 1, "title" => "undeclared" },
+          { "subject" => "ok2", "bogus" => 99 }
+        ]
+      }
+
+      result = Util::StructuredOutputHelper.conform_to_schema(data, schema)
+
+      assert_equal "ok", result["sub_issues"][0]["subject"]
+      assert_equal 1, result["sub_issues"][0]["tracker_id"]
+      assert_nil result["sub_issues"][0]["title"]
+      assert_nil result["sub_issues"][1]["bogus"]
+    end
+
+    should "work with symbol keys in the schema" do
+      schema = {
+        type: "object",
+        properties: {
+          goal: { type: "string" }
+        },
+        required: [ "goal" ]
+      }
+      data = { goal: "g", extra: "remove me" }
+
+      result = Util::StructuredOutputHelper.conform_to_schema(data, schema)
+
+      assert_equal "g", result["goal"]
+      assert_not result.key?("extra")
+    end
+
+    should "not mutate the input" do
+      schema = { "type" => "object", "properties" => { "a" => { "type" => "string" } } }
+      data = { "a" => "1", "b" => "2" }
+
+      Util::StructuredOutputHelper.conform_to_schema(data, schema)
+
+      assert_equal({ "a" => "1", "b" => "2" }, data)
+    end
+  end
+
+  context "validate" do
+    should "return empty violations for compliant data" do
+      schema = {
+        "type" => "object",
+        "properties" => { "goal" => { "type" => "string" }, "flag" => { "type" => "boolean" } },
+        "required" => [ "goal", "flag" ]
+      }
+      data = { "goal" => "x", "flag" => true }
+
+      assert_equal [], Util::StructuredOutputHelper.validate(data, schema)
+    end
+
+    should "detect missing required keys" do
+      schema = {
+        "type" => "object",
+        "properties" => { "goal" => { "type" => "string" } },
+        "required" => [ "goal" ]
+      }
+      data = {}
+
+      violations = Util::StructuredOutputHelper.validate(data, schema)
+
+      assert_equal 1, violations.length
+      assert_match(/goal: required key missing/, violations.first)
+    end
+
+    should "detect type mismatch for integer vs string" do
+      schema = {
+        "type" => "object",
+        "properties" => { "tracker_id" => { "type" => "integer" } },
+        "required" => [ "tracker_id" ]
+      }
+      data = { "tracker_id" => "not a number" }
+
+      violations = Util::StructuredOutputHelper.validate(data, schema)
+
+      assert_equal 1, violations.length
+      assert_match(/tracker_id: expected integer, got String/, violations.first)
+    end
+
+    should "map number to Numeric and accept floats" do
+      schema = { "type" => "object", "properties" => { "n" => { "type" => "number" } }, "required" => [ "n" ] }
+
+      assert_empty Util::StructuredOutputHelper.validate({ "n" => 1.5 }, schema)
+      assert_empty Util::StructuredOutputHelper.validate({ "n" => 3 }, schema)
+    end
+
+    should "not coerce types (string integer stays a violation)" do
+      schema = { "type" => "object", "properties" => { "n" => { "type" => "integer" } }, "required" => [ "n" ] }
+      data = { "n" => "5" }
+
+      assert_not_empty Util::StructuredOutputHelper.validate(data, schema)
+    end
+
+    should "accept true and false for boolean" do
+      schema = { "type" => "object", "properties" => { "b" => { "type" => "boolean" } }, "required" => [ "b" ] }
+
+      assert_empty Util::StructuredOutputHelper.validate({ "b" => true }, schema)
+      assert_empty Util::StructuredOutputHelper.validate({ "b" => false }, schema)
+    end
+
+    should "validate recursively in nested objects and array items" do
+      schema = {
+        "type" => "object",
+        "properties" => {
+          "sub_issues" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => { "subject" => { "type" => "string" }, "tracker_id" => { "type" => "integer" } },
+              "required" => [ "subject", "tracker_id" ]
+            }
+          }
+        }
+      }
+      data = { "sub_issues" => [ { "subject" => "ok", "tracker_id" => "bad" }, {} ] }
+
+      violations = Util::StructuredOutputHelper.validate(data, schema)
+
+      # item[0] tracker_id type mismatch + item[1] missing subject + tracker_id
+      paths = violations.join("\n")
+      assert_match(/sub_issues\[0\]\.tracker_id: expected integer, got String/, paths)
+      assert_match(/sub_issues\[1\]\.subject: required key missing/, paths)
+      assert_match(/sub_issues\[1\]\.tracker_id: required key missing/, paths)
+    end
+
+    should "not validate format or enum" do
+      schema = {
+        "type" => "object",
+        "properties" => { "due_date" => { "type" => "string", "format" => "date" },
+                          "conf" => { "type" => "string", "enum" => [ "high", "low" ] } },
+        "required" => [ "due_date", "conf" ]
+      }
+      data = { "due_date" => "not-a-date", "conf" => "medium" }
+
+      assert_empty Util::StructuredOutputHelper.validate(data, schema)
+    end
+
+    should "flag a bare array when schema expects object" do
+      schema = { "type" => "object", "properties" => { "a" => { "type" => "string" } } }
+
+      violations = Util::StructuredOutputHelper.validate([ 1, 2 ], schema)
+
+      assert_equal 1, violations.length
+      assert_match(/expected object, got Array/, violations.first)
+    end
+  end
+
+  context "native_schema_payload" do
+    should "return a payload with name, schema, and strict: false" do
+      schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } } }
+
+      payload = Util::StructuredOutputHelper.native_schema_payload(schema)
+
+      assert_equal "response", payload[:name]
+      assert_equal schema, payload[:schema]
+      assert_equal false, payload[:strict]
+    end
+
+    should "use the provided name when given" do
+      schema = { "type" => "array" }
+
+      payload = Util::StructuredOutputHelper.native_schema_payload(schema, name: "sub_issues")
+
+      assert_equal "sub_issues", payload[:name]
+      assert_equal schema, payload[:schema]
+      assert_equal false, payload[:strict]
+    end
+
+    should "pass the json_schema through unchanged" do
+      schema = { type: "object", properties: { x: { type: "integer" } }, required: [ "x" ] }
+
+      payload = Util::StructuredOutputHelper.native_schema_payload(schema)
+
+      assert_equal schema, payload[:schema]
+    end
+
+    should "always set strict to false even if input suggests otherwise" do
+      payload = Util::StructuredOutputHelper.native_schema_payload({ "type" => "object" }, name: "x")
+
+      assert_equal false, payload[:strict]
+    end
+  end
+
+  context "SchemaViolationError" do
+    should "be a StandardError with a violations attribute" do
+      error = Util::StructuredOutputHelper::SchemaViolationError.new("msg", [ "v1", "v2" ])
+
+      assert_kind_of StandardError, error
+      assert_equal "msg", error.message
+      assert_equal [ "v1", "v2" ], error.violations
+    end
+  end
+
+  context "parse with Hash/Array input (native path)" do
+    should "skip JSON parsing and apply conform + validate for Hash input" do
+      schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } }, "required" => [ "goal" ] }
+      data = { "goal" => "g", "extra" => "x" }
+
+      result = Util::StructuredOutputHelper.parse(response: data, json_schema: schema)
+
+      assert_equal "g", result["goal"]
+      assert_not result.key?("extra")
+    end
+
+    should "conform a bare array Hash response via wrap" do
+      schema = {
+        "type" => "object",
+        "properties" => { "sub_issues" => { "type" => "array", "items" => { "type" => "object", "properties" => { "subject" => { "type" => "string" } }, "required" => [ "subject" ] } } }
+      }
+      # Native path returns a bare Array
+      result = Util::StructuredOutputHelper.parse(response: [ { "subject" => "a" } ], json_schema: schema)
+
+      assert_kind_of Hash, result
+      assert_equal "a", result["sub_issues"][0]["subject"]
+    end
+
+    should "raise SchemaViolationError immediately when no chat_method and violations found" do
+      schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } }, "required" => [ "goal" ] }
+
+      assert_raises(Util::StructuredOutputHelper::SchemaViolationError) do
+        Util::StructuredOutputHelper.parse(response: { "other" => "x" }, json_schema: schema)
+      end
+    end
+  end
+
+  context "parse schema regeneration" do
+    setup do
+      @schema = {
+        "type" => "object",
+        "properties" => { "goal" => { "type" => "string" } },
+        "required" => [ "goal" ]
+      }
+    end
+
+    should "request regeneration exactly once when violations found and chat_method provided" do
+      call_count = 0
+      mock_chat_method = lambda do |_messages|
+        call_count += 1
+        # Regenerated response is compliant
+        '{"goal": "fixed"}'
+      end
+
+      result = Util::StructuredOutputHelper.parse(
+        response: '{"other": "missing goal"}',
+        json_schema: @schema,
+        chat_method: mock_chat_method,
+        messages: [ { role: "user", content: "test" } ]
+      )
+
+      assert_equal 1, call_count
+      assert_equal "fixed", result["goal"]
+    end
+
+    should "raise SchemaViolationError when regeneration still violates" do
+      call_count = 0
+      mock_chat_method = lambda do |_messages|
+        call_count += 1
+        '{"still_no_goal": "x"}'
+      end
+
+      error = assert_raises(Util::StructuredOutputHelper::SchemaViolationError) do
+        Util::StructuredOutputHelper.parse(
+          response: '{"other": "x"}',
+          json_schema: @schema,
+          chat_method: mock_chat_method,
+          messages: [ { role: "user", content: "test" } ]
+        )
+      end
+
+      assert_equal 1, call_count
+      assert_not_empty error.violations
+    end
+
+    should "count parse-fix and schema-regeneration independently (each at most once)" do
+      schema = {
+        "type" => "object",
+        "properties" => { "goal" => { "type" => "string" } },
+        "required" => [ "goal" ]
+      }
+      call_count = 0
+      mock_chat_method = lambda do |_messages|
+        call_count += 1
+        if call_count == 1
+          # Parse-fix: returns parseable but schema-nonconforming JSON
+          '{"other": "x"}'
+        else
+          # Schema-regeneration: still nonconforming
+          '{"still_no_goal": "x"}'
+        end
+      end
+
+      assert_raises(Util::StructuredOutputHelper::SchemaViolationError) do
+        Util::StructuredOutputHelper.parse(
+          response: "not parseable at all {{{",
+          json_schema: schema,
+          chat_method: mock_chat_method,
+          messages: [ { role: "user", content: "test" } ]
+        )
+      end
+
+      # parse-fix used 1 call; schema-regeneration used 1 call = 2 total
+      assert_equal 2, call_count
+    end
+  end
+
+  context "parse logging" do
+    should "log original response and violations to ai_helper_logger before raising" do
+      schema = { "type" => "object", "properties" => { "goal" => { "type" => "string" } }, "required" => [ "goal" ] }
+      logger = mock("ai_helper_logger")
+      logger.expects(:error).with { |msg| msg.to_s.include?("goal") && msg.to_s.include?("required key missing") }.at_least_once
+      Util::StructuredOutputHelper.stubs(:ai_helper_logger).returns(logger)
+
+      assert_raises(Util::StructuredOutputHelper::SchemaViolationError) do
+        Util::StructuredOutputHelper.parse(response: { "other" => "x" }, json_schema: schema)
+      end
+    end
+  end
 end

--- a/test/unit/vector/issue_content_analyzer_test.rb
+++ b/test/unit/vector/issue_content_analyzer_test.rb
@@ -409,6 +409,23 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
         analyzer.analyze(@issue)
       end
 
+      should "retain with: attachments when regenerating after a schema violation" do
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:supported_attachment_paths).with(@issue).returns([ "/path/to/document.pdf" ])
+
+        # null summary is a schema type violation, triggering one regeneration
+        deviant_response = { "summary" => nil, "keywords" => [ "kw" ] }.to_json
+        fixed_response = { "summary" => "Fixed.", "keywords" => [ "kw" ] }.to_json
+        analyzer.expects(:call_llm).with(anything, with: [ "/path/to/document.pdf" ], schema: nil).returns(deviant_response)
+        analyzer.expects(:call_llm).with(anything, with: [ "/path/to/document.pdf" ]).returns(fixed_response)
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Fixed.", result[:summary]
+        assert_equal [ "kw" ], result[:keywords]
+      end
+
       should "pass nil when no attachments exist" do
         analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
         analyzer.stubs(:ai_helper_logger).returns(@mock_logger)

--- a/test/unit/vector/issue_content_analyzer_test.rb
+++ b/test/unit/vector/issue_content_analyzer_test.rb
@@ -9,6 +9,7 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
       @mock_llm_provider = mock("llm_provider")
       @mock_llm_provider.stubs(:model_name).returns("gpt-4")
       @mock_llm_provider.stubs(:create_chat)
+      @mock_llm_provider.stubs(:supports_structured_output?).returns(false)
       @mock_logger = mock("logger")
       @mock_logger.stubs(:debug)
       @mock_logger.stubs(:info)
@@ -134,7 +135,7 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
         assert_equal [], result[:keywords]
       end
 
-      should "handle null summary in response" do
+      should "fall back to empty_result when summary is null (type violation)" do
         response_data = {
           "summary" => nil,
           "keywords" => [ "keyword1" ]
@@ -146,8 +147,28 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
 
         result = analyzer.analyze(@issue)
 
+        # null summary is a schema type violation; regeneration fails, so the
+        # existing StandardError rescue returns empty_result (research R7).
         assert_equal "", result[:summary]
-        assert_equal [ "keyword1" ], result[:keywords]
+        assert_equal [], result[:keywords]
+      end
+
+      should "conform a schema-deviant response (undeclared keys stripped)" do
+        # Response contains an undeclared key plus the required fields
+        deviant_response = {
+          "summary" => "Conformed summary.",
+          "keywords" => [ "kw1", "kw2" ],
+          "undeclared_extra" => "should be removed"
+        }.to_json
+
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:call_llm).returns(deviant_response)
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Conformed summary.", result[:summary]
+        assert_equal [ "kw1", "kw2" ], result[:keywords]
       end
     end
 
@@ -381,7 +402,8 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
         # Verify that call_llm is called with with: containing the attachment path
         analyzer.expects(:call_llm).with(
           anything,
-          with: [ "/path/to/document.pdf" ]
+          with: [ "/path/to/document.pdf" ],
+          schema: nil
         ).returns(valid_response)
 
         analyzer.analyze(@issue)
@@ -397,7 +419,8 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
         # Verify that call_llm is called with with: nil (presence of empty array is nil)
         analyzer.expects(:call_llm).with(
           anything,
-          with: nil
+          with: nil,
+          schema: nil
         ).returns(valid_response)
 
         analyzer.analyze(@issue)
@@ -413,10 +436,95 @@ class RedmineAiHelper::Vector::IssueContentAnalyzerTest < ActiveSupport::TestCas
         # Verify that call_llm is called with with: nil when attachment_send is disabled
         analyzer.expects(:call_llm).with(
           anything,
-          with: nil
+          with: nil,
+          schema: nil
         ).returns(valid_response)
 
         analyzer.analyze(@issue)
+      end
+    end
+
+    context "native structured output (US2)" do
+      setup do
+        @mock_chat = mock("chat_instance")
+        @mock_chat.stubs(:add_message)
+        @mock_response = mock("response")
+        @mock_response.stubs(:content).returns({ "summary" => "Native summary.", "keywords" => [ "native" ] })
+        @mock_chat.stubs(:ask).returns(@mock_response)
+      end
+
+      should "pass schema to create_chat when supports_structured_output? is true" do
+        @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+        @mock_llm_provider.expects(:create_chat).with(schema: anything).returns(@mock_chat)
+
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:supported_attachment_paths).returns([])
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Native summary.", result[:summary]
+      end
+
+      should "not pass schema to create_chat when supports_structured_output? is false" do
+        @mock_llm_provider.stubs(:supports_structured_output?).returns(false)
+        @mock_llm_provider.expects(:create_chat).with { |opts = {}| !opts.key?(:schema) }.returns(@mock_chat)
+
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:supported_attachment_paths).returns([])
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Native summary.", result[:summary]
+      end
+
+      should "omit format instructions from the prompt in native mode" do
+        @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+        @mock_llm_provider.stubs(:create_chat).returns(@mock_chat)
+        RedmineAiHelper::Util::StructuredOutputHelper.expects(:get_format_instructions).never
+
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:supported_attachment_paths).returns([])
+        analyzer.expects(:build_prompt).with(@issue, "").returns("prompt")
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Native summary.", result[:summary]
+      end
+
+      should "include format instructions in the prompt in fallback mode" do
+        @mock_llm_provider.stubs(:supports_structured_output?).returns(false)
+        @mock_llm_provider.stubs(:create_chat).returns(@mock_chat)
+
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:supported_attachment_paths).returns([])
+        instructions = RedmineAiHelper::Util::StructuredOutputHelper.get_format_instructions(
+          RedmineAiHelper::Vector::IssueContentAnalyzer::JSON_SCHEMA
+        )
+        analyzer.expects(:build_prompt).with(@issue, instructions).returns("prompt")
+        @mock_response.stubs(:content).returns({ "summary" => "Fallback summary.", "keywords" => [ "fb" ] }.to_json)
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Fallback summary.", result[:summary]
+      end
+
+      should "maintain with: parameter in native mode" do
+        @mock_llm_provider.stubs(:supports_structured_output?).returns(true)
+        @mock_llm_provider.stubs(:create_chat).returns(@mock_chat)
+        @mock_chat.unstub(:ask)
+        @mock_chat.expects(:ask).with(anything, with: [ "/path/to/img.png" ]).returns(@mock_response)
+
+        analyzer = RedmineAiHelper::Vector::IssueContentAnalyzer.new(llm_provider: @mock_llm_provider)
+        analyzer.stubs(:ai_helper_logger).returns(@mock_logger)
+        analyzer.stubs(:supported_attachment_paths).returns([ "/path/to/img.png" ])
+
+        result = analyzer.analyze(@issue)
+
+        assert_equal "Native summary.", result[:summary]
       end
     end
 


### PR DESCRIPTION
## Changes

- Fix crash when LLM structured output deviates from the requested JSON schema (e.g. bare arrays instead of a wrapper object, undeclared keys) by conforming/repairing the response instead of raising, with one regeneration attempt before failing explicitly (fixes #345)
- Add native structured-output support for providers/models that support API-level schema enforcement (OpenAI, Anthropic, Gemini), falling back to prompt-instruction based structured output for non-supporting providers (Azure OpenAI, OpenAI-compatible)
- Handle array-rooted schemas in the native structured output path by wrapping/unwrapping them around a single object property, since some providers require an object root
- Propagate the original exception (class, message, backtrace) on structured output failure instead of losing it via `throw`/`raise` misuse
- Add corresponding unit tests for `StructuredOutputHelper`, `BaseAgent`, `LeaderAgent`, `IssueAgent`, `DocumentationAgent`, and provider classes

## Related

Fixes haru/redmine_ai_helper#345