### PR TITLE
Reorganize AI helper settings page into tabs

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/026-read-only-mode"
+  "feature_directory": "specs/027-settings-tabs"
 }

--- a/app/controllers/ai_helper_model_profiles_controller.rb
+++ b/app/controllers/ai_helper_model_profiles_controller.rb
@@ -37,7 +37,7 @@ class AiHelperModelProfilesController < ApplicationController
     @model_profile.safe_attributes = params[:ai_helper_model_profile]
     if @model_profile.save
       flash[:notice] = l(:notice_successful_create)
-      redirect_to ai_helper_setting_path
+      redirect_to ai_helper_setting_path(tab: "model")
     else
       render action: :new
     end
@@ -51,7 +51,7 @@ class AiHelperModelProfilesController < ApplicationController
     @model_profile.access_key = original_access_key if @model_profile.access_key == DUMMY_ACCESS_KEY
     if @model_profile.save
       flash[:notice] = l(:notice_successful_update)
-      redirect_to ai_helper_setting_path
+      redirect_to ai_helper_setting_path(tab: "model")
     else
       render action: :edit
     end
@@ -113,10 +113,10 @@ class AiHelperModelProfilesController < ApplicationController
   def destroy
     if @model_profile.destroy
       flash[:notice] = l(:notice_successful_delete)
-      redirect_to ai_helper_setting_path
+      redirect_to ai_helper_setting_path(tab: "model")
     else
       flash[:error] = l(:error_failed_delete)
-      redirect_to ai_helper_setting_path
+      redirect_to ai_helper_setting_path(tab: "model")
     end
   rescue ActiveRecord::RecordNotFound
     render_404

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -9,8 +9,11 @@ class AiHelperSettingsController < ApplicationController
   before_action :require_admin, :find_setting
   self.main_menu = false
 
+  include AiHelperSettingsHelper
+
   # Display the settings page
   def index
+    @selected_tab = determine_selected_tab
   end
 
   # Update the settings
@@ -18,8 +21,12 @@ class AiHelperSettingsController < ApplicationController
     @setting.safe_attributes = params[:ai_helper_setting]
     if @setting.save
       flash[:notice] = l(:notice_successful_update)
-      redirect_to action: :index
+      redirect_to action: :index, tab: params[:tab]
     else
+      @selected_tab = ai_helper_settings_selected_tab(
+        @setting.errors.attribute_names,
+        params[:tab]
+      )
       render action: :index
     end
   end
@@ -49,5 +56,10 @@ class AiHelperSettingsController < ApplicationController
     @setting = AiHelperSetting.find_or_create
     @model_profiles = AiHelperModelProfile.order(:name)
     @ai_helper_projects = Project.joins(:enabled_modules).where(enabled_modules: { name: "ai_helper" }).order(:name)
+  end
+
+  # @return [String, nil] the selected tab name for render_tabs
+  def determine_selected_tab
+    params[:tab]
   end
 end

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -13,7 +13,7 @@ class AiHelperSettingsController < ApplicationController
 
   # Display the settings page
   def index
-    @selected_tab = params[:tab]
+    @selected_tab = params[:tab].presence
   end
 
   # Update the settings
@@ -21,11 +21,11 @@ class AiHelperSettingsController < ApplicationController
     @setting.safe_attributes = params[:ai_helper_setting]
     if @setting.save
       flash[:notice] = l(:notice_successful_update)
-      redirect_to action: :index, tab: params[:tab]
+      redirect_to action: :index, tab: params[:tab].presence
     else
       @selected_tab = ai_helper_settings_selected_tab(
         @setting.errors.attribute_names,
-        params[:tab]
+        params[:tab].presence
       )
       render action: :index
     end

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -13,7 +13,7 @@ class AiHelperSettingsController < ApplicationController
 
   # Display the settings page
   def index
-    @selected_tab = determine_selected_tab
+    @selected_tab = params[:tab]
   end
 
   # Update the settings
@@ -56,10 +56,5 @@ class AiHelperSettingsController < ApplicationController
     @setting = AiHelperSetting.find_or_create
     @model_profiles = AiHelperModelProfile.order(:name)
     @ai_helper_projects = Project.joins(:enabled_modules).where(enabled_modules: { name: "ai_helper" }).order(:name)
-  end
-
-  # @return [String, nil] the selected tab name for render_tabs
-  def determine_selected_tab
-    params[:tab]
   end
 end

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -2,6 +2,8 @@
 
 # Helper methods for AI Helper global settings views
 module AiHelperSettingsHelper
+  # Maps a setting attribute name to the tab that should be selected when the
+  # attribute has a validation error, so the user is shown the failing field.
   ERROR_ATTRIBUTE_TO_TAB = {
     attachment_max_size_mb: "general",
     think_model_profile_id: "model",

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -3,10 +3,10 @@
 # Helper methods for AI Helper global settings views
 module AiHelperSettingsHelper
   ERROR_ATTRIBUTE_TO_TAB = {
-    "attachment_max_size_mb" => "general",
-    "think_model_profile_id" => "model",
-    "vector_search_uri" => "vector",
-    "vector_model_profile_id" => "vector"
+    attachment_max_size_mb: "general",
+    think_model_profile_id: "model",
+    vector_search_uri: "vector",
+    vector_model_profile_id: "vector"
   }.freeze
 
   # Returns tab definitions for the settings page.
@@ -34,12 +34,12 @@ module AiHelperSettingsHelper
         label: :"ai_helper.settings.tab_vector",
         f: f
       }
-    ].freeze
+    ]
   end
 
   # Maps an error attribute name to its owning tab name.
   #
-  # @param attribute [String] the attribute name with validation error
+  # @param attribute [Symbol] the attribute name with validation error
   # @return [String, nil] the tab name, or nil if no mapping exists
   def ai_helper_settings_tab_for_error(attribute)
     ERROR_ATTRIBUTE_TO_TAB[attribute]
@@ -47,7 +47,7 @@ module AiHelperSettingsHelper
 
   # Determines the selected tab based on validation errors and the params[:tab] fallback.
   #
-  # @param error_attributes [Array<String>] attribute names with validation errors
+  # @param error_attributes [Array<Symbol>] attribute names with validation errors
   # @param params_tab [String, nil] the value of params[:tab]
   # @return [String, nil] the selected tab name, or nil to use render_tabs default
   def ai_helper_settings_selected_tab(error_attributes, params_tab)
@@ -56,5 +56,13 @@ module AiHelperSettingsHelper
       return found if found
     end
     params_tab
+  end
+
+  # Returns options for model profile select fields.
+  #
+  # @param profiles [ActiveRecord::Relation] collection of model profiles
+  # @return [Array<Array<String, Integer>>] array of [display_name, id] pairs
+  def ai_helper_model_profile_options(profiles)
+    profiles.map { |p| [ p.display_name, p.id ] }
   end
 end

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -1,3 +1,60 @@
+# frozen_string_literal: true
+
 # Helper methods for AI Helper global settings views
 module AiHelperSettingsHelper
+  ERROR_ATTRIBUTE_TO_TAB = {
+    "attachment_max_size_mb" => "general",
+    "think_model_profile_id" => "model",
+    "vector_search_uri" => "vector",
+    "vector_model_profile_id" => "vector"
+  }.freeze
+
+  # Returns tab definitions for the settings page.
+  # Each tab hash contains :name, :partial, :label, and :f (form builder).
+  #
+  # @param f [ActionView::Helpers::FormBuilder] the form builder for the settings form
+  # @return [Array<Hash>] array of tab definition hashes
+  def ai_helper_settings_tabs(f)
+    [
+      {
+        name: "general",
+        partial: "ai_helper_settings/general_tab",
+        label: :"ai_helper.settings.tab_general",
+        f: f
+      },
+      {
+        name: "model",
+        partial: "ai_helper_settings/model_tab",
+        label: :"ai_helper.settings.tab_model",
+        f: f
+      },
+      {
+        name: "vector",
+        partial: "ai_helper_settings/vector_tab",
+        label: :"ai_helper.settings.tab_vector",
+        f: f
+      }
+    ].freeze
+  end
+
+  # Maps an error attribute name to its owning tab name.
+  #
+  # @param attribute [String] the attribute name with validation error
+  # @return [String, nil] the tab name, or nil if no mapping exists
+  def ai_helper_settings_tab_for_error(attribute)
+    ERROR_ATTRIBUTE_TO_TAB[attribute]
+  end
+
+  # Determines the selected tab based on validation errors and the params[:tab] fallback.
+  #
+  # @param error_attributes [Array<String>] attribute names with validation errors
+  # @param params_tab [String, nil] the value of params[:tab]
+  # @return [String, nil] the selected tab name, or nil to use render_tabs default
+  def ai_helper_settings_selected_tab(error_attributes, params_tab)
+    error_attributes.each do |attr|
+      found = ai_helper_settings_tab_for_error(attr)
+      return found if found
+    end
+    params_tab
+  end
 end

--- a/app/views/ai_helper_model_profiles/_show.html.erb
+++ b/app/views/ai_helper_model_profiles/_show.html.erb
@@ -74,7 +74,7 @@
     const cancelBtn = document.getElementById('copy-profile-cancel');
     const errorEl = document.getElementById('copy-profile-error');
     const copyUrl = '<%= ai_helper_model_profiles_copy_path(id: @model_profile) %>';
-    const redirectUrl = '<%= ai_helper_setting_path %>';
+    const redirectUrl = '<%= ai_helper_setting_path(tab: "model") %>';
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
 
     copyBtn.addEventListener('click', function(e) {

--- a/app/views/ai_helper_model_profiles/edit.html.erb
+++ b/app/views/ai_helper_model_profiles/edit.html.erb
@@ -4,5 +4,5 @@
  <%= render partial: "form", locals: {f: f} %>
 
 <%= f.submit t(:button_submit) %>
-<%= link_to l(:button_cancel), ai_helper_setting_path %>
+<%= link_to l(:button_cancel), ai_helper_setting_path(tab: "model") %>
 <% end %>

--- a/app/views/ai_helper_model_profiles/new.html.erb
+++ b/app/views/ai_helper_model_profiles/new.html.erb
@@ -3,5 +3,5 @@
 <%= labelled_form_for @model_profile, html: {autocomplete: "off"} do |f| %>
   <%= render partial: "form", locals: {f: f} %>
   <%= f.submit t(:button_submit) %>
-  <%= link_to l(:button_cancel), ai_helper_setting_path %>
+  <%= link_to l(:button_cancel), ai_helper_setting_path(tab: "model") %>
 <% end %>

--- a/app/views/ai_helper_settings/_general_tab.html.erb
+++ b/app/views/ai_helper_settings/_general_tab.html.erb
@@ -1,0 +1,29 @@
+<% f = tab[:f] %>
+<div class="box tabular">
+  <p>
+    <%= f.check_box :attachment_send_enabled %>
+  </p>
+  <div id="ai-helper-attachment-settings">
+    <p>
+      <%= f.number_field :attachment_max_size_mb, min: 1, size: 10 %>
+    </p>
+  </div>
+  <hr>
+  <p>
+    <%= f.check_box :mcp_server_enabled %>
+  </p>
+  <hr>
+  <p>
+    <%= f.check_box :read_only_mode %>
+    <span class="description"><%= t("activerecord.attributes.ai_helper_setting.read_only_mode_description") %></span>
+  </p>
+  <hr>
+  <div id="ai-helper-send-user-id">
+    <p>
+      <%= f.check_box :send_user_id_enabled %>
+      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.send_user_id_enabled_description") %></span>
+    </p>
+    <hr>
+  </div>
+  <p><%= f.text_area :additional_instructions, rows: 12 %></p>
+</div>

--- a/app/views/ai_helper_settings/_model_tab.html.erb
+++ b/app/views/ai_helper_settings/_model_tab.html.erb
@@ -1,10 +1,7 @@
 <% f = tab[:f] %>
 <div class="box tabular">
   <p>
-    <%
-      options = @model_profiles.map{|p| [p.display_name, p.id]}
-    %>
-    <%= f.select :model_profile_id, options, include_blank: true, required: true %>
+    <%= f.select :model_profile_id, ai_helper_model_profile_options(@model_profiles), include_blank: true, required: true %>
     <%= link_to ai_helper_model_profiles_new_url do %>
       <%= sprite_icon('add') %>
       <%= t(:label_new) %>
@@ -19,7 +16,7 @@
   </p>
   <div id="ai-helper-think-model-settings">
     <p>
-      <%= f.select :think_model_profile_id, options, include_blank: true %>
+      <%= f.select :think_model_profile_id, ai_helper_model_profile_options(@model_profiles), include_blank: true %>
     </p>
   </div>
 </div>

--- a/app/views/ai_helper_settings/_model_tab.html.erb
+++ b/app/views/ai_helper_settings/_model_tab.html.erb
@@ -1,0 +1,25 @@
+<% f = tab[:f] %>
+<div class="box tabular">
+  <p>
+    <%
+      options = @model_profiles.map{|p| [p.display_name, p.id]}
+    %>
+    <%= f.select :model_profile_id, options, include_blank: true, required: true %>
+    <%= link_to ai_helper_model_profiles_new_url do %>
+      <%= sprite_icon('add') %>
+      <%= t(:label_new) %>
+    <% end %>
+  </p>
+  <div id="ai_helper_model_profile_description">
+  </div>
+  <hr>
+  <p>
+    <%= f.check_box :use_think_model %>
+    <span class="description"><%= t("activerecord.attributes.ai_helper_setting.think_model_description") %></span>
+  </p>
+  <div id="ai-helper-think-model-settings">
+    <p>
+      <%= f.select :think_model_profile_id, options, include_blank: true %>
+    </p>
+  </div>
+</div>

--- a/app/views/ai_helper_settings/_vector_tab.html.erb
+++ b/app/views/ai_helper_settings/_vector_tab.html.erb
@@ -1,0 +1,53 @@
+<% f = tab[:f] %>
+<div class="box tabular">
+  <p>
+    <%= f.check_box :vector_search_enabled %>
+  </p>
+  <p>
+    <%= f.check_box :use_vector_model_profile %>
+    <span class="description"><%= t("activerecord.attributes.ai_helper_setting.vector_model_profile_description") %></span>
+  </p>
+  <div id="ai-helper-vector-model-profile-settings">
+    <p>
+      <%
+        options = @model_profiles.map{|p| [p.display_name, p.id]}
+      %>
+      <%= f.select :vector_model_profile_id, options, include_blank: true %>
+    </p>
+  </div>
+  <div id="ai-helper-vector-search">
+    <p>
+      <%= f.text_field :vector_search_uri, size: 60, required: true %>
+    </p>
+    <p>
+      <%= f.text_field :vector_search_api_key, size: 60 %>
+    </p>
+    <p>
+      <%= f.text_field :embedding_model, size: 60 %>
+    </p>
+    <p id="ai_helper_dimension" style="display: none;">
+      <%= f.text_field :dimension, size: 60 %>
+    </p>
+    <p id="ai_helper_embedding_url" style="display: none;">
+      <%= f.text_field :embedding_url, size: 90 %>
+    </p>
+    <p>
+      <%= f.check_box :vector_register_all_projects %>
+      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.vector_register_all_projects_description") %></span>
+    </p>
+    <div id="ai-helper-vector-target-projects" style="<%= 'display: none;' if @setting.vector_register_all_projects %>">
+      <% if @ai_helper_projects.any? %>
+        <% selected_project_ids = @setting.vector_target_project_ids.to_a %>
+        <fieldset class="box" id="ai_helper_vector_target_project_ids">
+          <legend><%= toggle_checkboxes_link("#ai_helper_vector_target_project_ids input[type=checkbox]") %><%= t(:label_project_plural) %></legend>
+          <div class="objects-selection">
+            <%= render_project_nested_lists(@ai_helper_projects) do |p|
+              content_tag('label', check_box_tag('ai_helper_setting[vector_target_project_ids][]', p.id, selected_project_ids.include?(p.id), :id => nil) + ' ' + h(p), :class => 'block')
+            end %>
+          </div>
+          <%= hidden_field_tag('ai_helper_setting[vector_target_project_ids][]', '', :id => nil) %>
+        </fieldset>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/ai_helper_settings/_vector_tab.html.erb
+++ b/app/views/ai_helper_settings/_vector_tab.html.erb
@@ -9,10 +9,7 @@
   </p>
   <div id="ai-helper-vector-model-profile-settings">
     <p>
-      <%
-        options = @model_profiles.map{|p| [p.display_name, p.id]}
-      %>
-      <%= f.select :vector_model_profile_id, options, include_blank: true %>
+      <%= f.select :vector_model_profile_id, ai_helper_model_profile_options(@model_profiles), include_blank: true %>
     </p>
   </div>
   <div id="ai-helper-vector-search">

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :header_tags do %>
+  <%= stylesheet_link_tag('ai_helper.css', plugin: :redmine_ai_helper) %>
+<% end %>
 <h2><%= t(:label_ai_helper) %></h2>
 <%= labelled_form_for @setting, url: ai_helper_setting_update_url, method: :post do |f| %>
   <%= error_messages_for "setting" %>

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -4,7 +4,7 @@
 <h2><%= t(:label_ai_helper) %></h2>
 <%= labelled_form_for @setting, url: ai_helper_setting_update_url, method: :post do |f| %>
   <%= error_messages_for "setting" %>
-  <%= hidden_field_tag :tab, params[:tab] %>
+  <%= hidden_field_tag :tab, @selected_tab %>
   <%= render_tabs ai_helper_settings_tabs(f), @selected_tab %>
   <%= f.submit t(:button_submit) %>
 <% end %>

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -7,11 +7,11 @@
 <% end %>
 <script>
   (function() {
-    var tabHidden = document.querySelector('input[name="tab"]');
-    var tabLinks = document.querySelectorAll('.tabs a[id^="tab-"]');
+    const tabHidden = document.querySelector('input[name="tab"]');
+    const tabLinks = document.querySelectorAll('.tabs a[id^="tab-"]');
     tabLinks.forEach(function(link) {
       link.addEventListener('click', function() {
-        var name = this.id.replace('tab-', '');
+        const name = this.id.replace('tab-', '');
         if (tabHidden) { tabHidden.value = name; }
       });
     });

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -1,107 +1,22 @@
 <h2><%= t(:label_ai_helper) %></h2>
 <%= labelled_form_for @setting, url: ai_helper_setting_update_url, method: :post do |f| %>
   <%= error_messages_for "setting" %>
-  <div class="box tabular">
-    <p>
-      <%
-            options = @model_profiles.map{|p| [p.display_name, p.id]}
-        %>
-      <%= f.select :model_profile_id, options, include_blank: true, required: true %>
-      <%= link_to ai_helper_model_profiles_new_url do %>
-        <%= sprite_icon('add') %>
-        <%= t(:label_new) %>
-      <% end %>
-    </p>
-    <div id="ai_helper_model_profile_description">
-    </div>
-    <hr>
-    <p>
-      <%= f.check_box :use_think_model %>
-      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.think_model_description") %></span>
-    </p>
-    <div id="ai-helper-think-model-settings">
-      <p>
-        <%= f.select :think_model_profile_id, options, include_blank: true %>
-      </p>
-    </div>
-    <hr>
-    <p>
-      <%= f.check_box :attachment_send_enabled %>
-    </p>
-    <div id="ai-helper-attachment-settings">
-      <p>
-        <%= f.number_field :attachment_max_size_mb, min: 1, size: 10 %>
-      </p>
-    </div>
-    <hr>
-    <p>
-      <%= f.check_box :vector_search_enabled %>
-    </p>
-    <p>
-      <%= f.check_box :use_vector_model_profile %>
-      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.vector_model_profile_description") %></span>
-    </p>
-    <div id="ai-helper-vector-model-profile-settings">
-      <p>
-        <%= f.select :vector_model_profile_id, options, include_blank: true %>
-      </p>
-    </div>
-    <div id="ai-helper-vector-search">
-      <p>
-        <%= f.text_field :vector_search_uri, size: 60, required: true %>
-      </p>
-      <p>
-        <%= f.text_field :vector_search_api_key, size: 60 %>
-      </p>
-      <p>
-        <%= f.text_field :embedding_model, size: 60 %>
-      </p>
-      <p id="ai_helper_dimension" style="display: none;">
-        <%= f.text_field :dimension, size: 60 %>
-      </p>
-      <p id="ai_helper_embedding_url" style="display: none;">
-        <%= f.text_field :embedding_url, size: 90 %>
-      </p>
-      <p>
-        <%= f.check_box :vector_register_all_projects %>
-        <span class="description"><%= t("activerecord.attributes.ai_helper_setting.vector_register_all_projects_description") %></span>
-      </p>
-      <div id="ai-helper-vector-target-projects" style="<%= 'display: none;' if @setting.vector_register_all_projects %>">
-        <% if @ai_helper_projects.any? %>
-          <% selected_project_ids = @setting.vector_target_project_ids.to_a %>
-          <fieldset class="box" id="ai_helper_vector_target_project_ids">
-            <legend><%= toggle_checkboxes_link("#ai_helper_vector_target_project_ids input[type=checkbox]") %><%= t(:label_project_plural) %></legend>
-            <div class="objects-selection">
-              <%= render_project_nested_lists(@ai_helper_projects) do |p|
-                content_tag('label', check_box_tag('ai_helper_setting[vector_target_project_ids][]', p.id, selected_project_ids.include?(p.id), :id => nil) + ' ' + h(p), :class => 'block')
-              end %>
-            </div>
-            <%= hidden_field_tag('ai_helper_setting[vector_target_project_ids][]', '', :id => nil) %>
-          </fieldset>
-        <% end %>
-      </div>
-    </div>
-    <hr>
-    <p>
-      <%= f.check_box :mcp_server_enabled %>
-    </p>
-    <hr>
-    <p>
-      <%= f.check_box :read_only_mode %>
-      <span class="description"><%= t("activerecord.attributes.ai_helper_setting.read_only_mode_description") %></span>
-    </p>
-    <hr>
-    <div id="ai-helper-send-user-id">
-      <p>
-        <%= f.check_box :send_user_id_enabled %>
-        <span class="description"><%= t("activerecord.attributes.ai_helper_setting.send_user_id_enabled_description") %></span>
-      </p>
-      <hr>
-    </div>
-    <p><%= f.text_area :additional_instructions, rows: 12 %></p>
-  </div>
+  <%= hidden_field_tag :tab, params[:tab] %>
+  <%= render_tabs ai_helper_settings_tabs(f), @selected_tab %>
   <%= f.submit t(:button_submit) %>
 <% end %>
+<script>
+  (function() {
+    var tabHidden = document.querySelector('input[name="tab"]');
+    var tabLinks = document.querySelectorAll('.tabs a[id^="tab-"]');
+    tabLinks.forEach(function(link) {
+      link.addEventListener('click', function() {
+        var name = this.id.replace('tab-', '');
+        if (tabHidden) { tabHidden.value = name; }
+      });
+    });
+  })();
+</script>
 <script>
   function loadModelProfile(id) {
       $.ajax({
@@ -153,7 +68,6 @@
       const registerAll = document.getElementById('ai_helper_setting_vector_register_all_projects');
       const container = document.getElementById('ai-helper-vector-target-projects');
       if (!registerAll || !container) return;
-      // Hidden but not disabled: the selection is still submitted so it is preserved (FR-006).
       container.style.display = registerAll.checked ? 'none' : '';
   }
 

--- a/assets/stylesheets/ai_helper.css
+++ b/assets/stylesheets/ai_helper.css
@@ -1544,3 +1544,10 @@ table.list.ai-helper-report-list td.radio .radio-placeholder {
   outline: 2px solid currentColor;
   outline-offset: 2px;
 }
+
+/* Vector search settings: shrink the project selection box to its content
+   instead of Redmine's fixed 300px height */
+#ai_helper_vector_target_project_ids .objects-selection {
+  block-size: auto;
+  max-block-size: 300px;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,10 @@ en:
   label_ai_helper_report_detail_mobile: "Report Detail"
   label_ai_helper_close_detail: "Close Detail"
   ai_helper:
+    settings:
+      tab_general: "General"
+      tab_model: "Model"
+      tab_vector: "Vector search"
     notice_sub_issues_added: "Sub-issues have been added"
     error_invalid_assignee: "Invalid assignee for '%{subject}' - user is not authorized for this tracker"
     chat:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,6 +32,10 @@ ja:
   label_ai_helper_report_detail_mobile: "レポート詳細"
   label_ai_helper_close_detail: "詳細を閉じる"
   ai_helper:
+    settings:
+      tab_general: "全般"
+      tab_model: "モデル"
+      tab_vector: "ベクトル検索"
     notice_sub_issues_added: "子チケットが追加されました"
     error_invalid_assignee: "'%{subject}' の担当者が無効です。このトラッカーに対する権限がありません"
     chat:

--- a/test/functional/ai_helper_model_profiles_controller_test.rb
+++ b/test/functional/ai_helper_model_profiles_controller_test.rb
@@ -27,7 +27,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     assert_difference("AiHelperModelProfile.count", 1) do
       post :create, params: { ai_helper_model_profile: { name: "New Profile", access_key: "new_key", llm_type: "OpenAI", llm_model: "model" } }
     end
-    assert_redirected_to ai_helper_setting_path
+    assert_redirected_to ai_helper_setting_path(tab: "model")
   end
 
   should "not create model profile with invalid attributes" do
@@ -49,7 +49,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
   should "update model profile with valid attributes" do
     patch :update, params: { id: @model_profile.id, ai_helper_model_profile: { name: "Updated Profile" } }
 
-    assert_redirected_to ai_helper_setting_path
+    assert_redirected_to ai_helper_setting_path(tab: "model")
     @model_profile.reload
 
     assert_equal "Updated Profile", @model_profile.name
@@ -69,7 +69,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     assert_difference("AiHelperModelProfile.count", -1) do
       delete :destroy, params: { id: @model_profile.id }
     end
-    assert_redirected_to ai_helper_setting_path
+    assert_redirected_to ai_helper_setting_path(tab: "model")
   end
 
   should "handle destroy for non-existent model profile" do

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -342,6 +342,13 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "div#tab-content-vector[style*='display:none']"
     end
 
+    should "fallback to general tab when unknown tab name is passed" do
+      get :index, params: { tab: "bogus" }
+
+      assert_response :success
+      assert_select "a#tab-general.selected"
+    end
+
     should "render general tab fields in general tab content" do
       get :index
 
@@ -416,6 +423,32 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
       assert_response :success
       assert_select "a#tab-general.selected"
+    end
+
+    should "show model tab when error attribute maps to model tab despite submitting from general tab" do
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {
+          use_think_model: "1",
+          think_model_profile_id: ""
+        }
+      }
+
+      assert_response :success
+      assert_select "a#tab-model.selected"
+    end
+
+    should "show vector tab when error attribute maps to vector tab despite submitting from general tab" do
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {
+          vector_search_enabled: "1",
+          vector_search_uri: ""
+        }
+      }
+
+      assert_response :success
+      assert_select "a#tab-vector.selected"
     end
 
     should "render model tab fields in model tab content only" do

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -328,4 +328,193 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "input[type=checkbox][name='ai_helper_setting[read_only_mode]']"
     end
   end
+
+  context "tabbed settings layout" do
+    should "render 3 tab links with general selected by default" do
+      get :index
+
+      assert_response :success
+      assert_select "a#tab-general.selected"
+      assert_select "a#tab-model"
+      assert_select "a#tab-vector"
+      assert_select "div#tab-content-general"
+      assert_select "div#tab-content-model[style*='display:none']"
+      assert_select "div#tab-content-vector[style*='display:none']"
+    end
+
+    should "render general tab fields in general tab content" do
+      get :index
+
+      assert_response :success
+      assert_select "div#tab-content-general" do
+        assert_select "input[type=checkbox][name='ai_helper_setting[attachment_send_enabled]']"
+        assert_select "input[type=number][name='ai_helper_setting[attachment_max_size_mb]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[mcp_server_enabled]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[read_only_mode]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[send_user_id_enabled]']"
+        assert_select "textarea[name='ai_helper_setting[additional_instructions]']"
+      end
+    end
+
+    should "save all tab attributes and redirect with tab param" do
+      vector_profile = AiHelperModelProfile.create!(
+        name: "Vector Save Profile",
+        access_key: "vec_key",
+        llm_type: "OpenAI",
+        llm_model: "text-embedding-3-large"
+      )
+
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {
+          attachment_send_enabled: "1",
+          attachment_max_size_mb: "10",
+          mcp_server_enabled: "1",
+          read_only_mode: "0",
+          send_user_id_enabled: "0",
+          additional_instructions: "test instructions",
+          model_profile_id: @model_profile.id.to_s,
+          use_think_model: "0",
+          think_model_profile_id: "",
+          vector_search_enabled: "1",
+          vector_search_uri: "http://localhost:6333",
+          vector_search_api_key: "test-api-key",
+          embedding_model: "text-embedding-3-large",
+          dimension: "1536",
+          embedding_url: "",
+          use_vector_model_profile: "1",
+          vector_model_profile_id: vector_profile.id.to_s,
+          vector_register_all_projects: "1",
+          vector_target_project_ids: []
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "general"
+      @ai_helper_setting.reload
+
+      assert_equal 10, @ai_helper_setting.attachment_max_size_mb
+      assert_equal true, @ai_helper_setting.attachment_send_enabled
+      assert_equal true, @ai_helper_setting.mcp_server_enabled
+      assert_equal "test instructions", @ai_helper_setting.additional_instructions
+      assert_equal @model_profile.id, @ai_helper_setting.model_profile_id
+      assert_equal true, @ai_helper_setting.vector_search_enabled
+      assert_equal "http://localhost:6333", @ai_helper_setting.vector_search_uri
+      assert_equal true, @ai_helper_setting.use_vector_model_profile
+      assert_equal vector_profile.id, @ai_helper_setting.vector_model_profile_id
+
+      vector_profile.destroy if vector_profile.persisted?
+    end
+
+    should "show general tab on validation error for attachment_max_size_mb" do
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {
+          attachment_send_enabled: "1",
+          attachment_max_size_mb: "0"
+        }
+      }
+
+      assert_response :success
+      assert_select "a#tab-general.selected"
+    end
+
+    should "render model tab fields in model tab content only" do
+      get :index, params: { tab: "model" }
+
+      assert_response :success
+      assert_select "a#tab-model.selected"
+      assert_select "div#tab-content-model" do
+        assert_select "select[name='ai_helper_setting[model_profile_id]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[use_think_model]']"
+        assert_select "select[name='ai_helper_setting[think_model_profile_id]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[mcp_server_enabled]']", { count: 0 }
+        assert_select "input[type=checkbox][name='ai_helper_setting[vector_search_enabled]']", { count: 0 }
+      end
+    end
+
+    should "save from model tab and redirect with tab model" do
+      post :update, params: {
+        tab: "model",
+        ai_helper_setting: {
+          model_profile_id: @model_profile.id.to_s,
+          use_think_model: "0",
+          think_model_profile_id: ""
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "model"
+      @ai_helper_setting.reload
+      assert_equal @model_profile.id, @ai_helper_setting.model_profile_id
+    end
+
+    should "show model tab on validation error for think_model_profile_id" do
+      post :update, params: {
+        tab: "model",
+        ai_helper_setting: {
+          use_think_model: "1",
+          think_model_profile_id: ""
+        }
+      }
+
+      assert_response :success
+      assert_select "a#tab-model.selected"
+    end
+  end
+
+  context "vector tab layout" do
+    should "render vector tab fields in vector tab content only" do
+      get :index, params: { tab: "vector" }
+
+      assert_response :success
+      assert_select "a#tab-vector.selected"
+      assert_select "div#tab-content-vector" do
+        assert_select "input[type=checkbox][name='ai_helper_setting[vector_search_enabled]']"
+        assert_select "input[type=text][name='ai_helper_setting[vector_search_uri]']"
+        assert_select "input[type=text][name='ai_helper_setting[vector_search_api_key]']"
+        assert_select "input[type=text][name='ai_helper_setting[embedding_model]']"
+        assert_select "input[type=text][name='ai_helper_setting[dimension]']"
+        assert_select "input[type=text][name='ai_helper_setting[embedding_url]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[use_vector_model_profile]']"
+        assert_select "select[name='ai_helper_setting[vector_model_profile_id]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[vector_register_all_projects]']"
+        assert_select "input[type=checkbox][name='ai_helper_setting[attachment_send_enabled]']", { count: 0 }
+        assert_select "input[type=checkbox][name='ai_helper_setting[mcp_server_enabled]']", { count: 0 }
+        assert_select "select[name='ai_helper_setting[model_profile_id]']", { count: 0 }
+      end
+    end
+
+    should "save from vector tab and redirect with tab vector" do
+      post :update, params: {
+        tab: "vector",
+        ai_helper_setting: {
+          vector_search_enabled: "1",
+          vector_search_uri: "http://localhost:6333",
+          vector_search_api_key: "test-key",
+          embedding_model: "text-embedding-3-large",
+          dimension: "1536",
+          use_vector_model_profile: "0",
+          vector_model_profile_id: "",
+          vector_register_all_projects: "1",
+          vector_target_project_ids: []
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "vector"
+      @ai_helper_setting.reload
+      assert_equal "http://localhost:6333", @ai_helper_setting.vector_search_uri
+    end
+
+    should "show vector tab on validation error for vector_search_uri" do
+      post :update, params: {
+        tab: "vector",
+        ai_helper_setting: {
+          vector_search_enabled: "1",
+          vector_search_uri: ""
+        }
+      }
+
+      assert_response :success
+      assert_select "a#tab-vector.selected"
+    end
+  end
 end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -550,4 +550,39 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "a#tab-vector.selected"
     end
   end
+
+  context "tab param handling" do
+    should "omit tab param on redirect when tab is blank" do
+      post :update, params: { tab: "", ai_helper_setting: { model_profile_id: @model_profile.id } }
+
+      assert_response :redirect
+      assert_no_match(/[?&]tab=/, @response.redirect_url)
+    end
+
+    should "keep tab param on redirect when tab is present" do
+      post :update, params: { tab: "model", ai_helper_setting: { model_profile_id: @model_profile.id } }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "model"
+    end
+
+    should "treat blank tab param as nil on index" do
+      get :index, params: { tab: "" }
+
+      assert_response :success
+      assert_nil assigns(:selected_tab)
+    end
+
+    should "bind hidden tab field to selected tab on validation error" do
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {
+          vector_search_enabled: "1",
+          vector_search_uri: ""
+        }
+      }
+
+      assert_response :success
+      assert_select "input[type=hidden][name=tab][value=vector]"
+    end
+  end
 end

--- a/test/unit/ai_helper_settings_helper_test.rb
+++ b/test/unit/ai_helper_settings_helper_test.rb
@@ -30,31 +30,31 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
   end
 
   context "ai_helper_settings_tab_for_error" do
-    should "return general for attachment_max_size_mb" do
-      assert_equal "general", ai_helper_settings_tab_for_error("attachment_max_size_mb")
+    should "return general for attachment_max_size_mb symbol" do
+      assert_equal "general", ai_helper_settings_tab_for_error(:attachment_max_size_mb)
     end
 
-    should "return model for think_model_profile_id" do
-      assert_equal "model", ai_helper_settings_tab_for_error("think_model_profile_id")
+    should "return model for think_model_profile_id symbol" do
+      assert_equal "model", ai_helper_settings_tab_for_error(:think_model_profile_id)
     end
 
-    should "return vector for vector_search_uri" do
-      assert_equal "vector", ai_helper_settings_tab_for_error("vector_search_uri")
+    should "return vector for vector_search_uri symbol" do
+      assert_equal "vector", ai_helper_settings_tab_for_error(:vector_search_uri)
     end
 
-    should "return vector for vector_model_profile_id" do
-      assert_equal "vector", ai_helper_settings_tab_for_error("vector_model_profile_id")
+    should "return vector for vector_model_profile_id symbol" do
+      assert_equal "vector", ai_helper_settings_tab_for_error(:vector_model_profile_id)
     end
 
     should "return nil for unknown attribute" do
-      assert_nil ai_helper_settings_tab_for_error("unknown_attribute")
+      assert_nil ai_helper_settings_tab_for_error(:unknown_attribute)
     end
   end
 
   context "ai_helper_settings_selected_tab" do
     should "return error-based tab when errors present" do
       tab = ai_helper_settings_selected_tab(
-        ["attachment_max_size_mb"],
+        [ :attachment_max_size_mb ],
         "vector"
       )
       assert_equal "general", tab
@@ -62,7 +62,7 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
 
     should "fall back to params_tab when no error mapping exists" do
       tab = ai_helper_settings_selected_tab(
-        ["unknown_attribute"],
+        [ :unknown_attribute ],
         "model"
       )
       assert_equal "model", tab
@@ -76,6 +76,29 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
     should "return nil when errors array is empty and params_tab is nil" do
       tab = ai_helper_settings_selected_tab([], nil)
       assert_nil tab
+    end
+  end
+
+  context "ai_helper_model_profile_options" do
+    should "return array of [display_name, id] pairs" do
+      profile1 = AiHelperModelProfile.create!(name: "Profile 1", access_key: "key1", llm_type: "OpenAI", llm_model: "gpt-4")
+      profile2 = AiHelperModelProfile.create!(name: "Profile 2", access_key: "key2", llm_type: "Anthropic", llm_model: "claude-3-5-sonnet")
+
+      profiles = AiHelperModelProfile.where(id: [ profile1.id, profile2.id ]).order(:id)
+      options = ai_helper_model_profile_options(profiles)
+
+      assert_equal 2, options.length
+      assert_equal [ profile1.display_name, profile1.id ], options[0]
+      assert_equal [ profile2.display_name, profile2.id ], options[1]
+
+      profile1.destroy
+      profile2.destroy
+    end
+
+    should "return empty array when no profiles exist" do
+      profiles = AiHelperModelProfile.none
+      options = ai_helper_model_profile_options(profiles)
+      assert_equal [], options
     end
   end
 

--- a/test/unit/ai_helper_settings_helper_test.rb
+++ b/test/unit/ai_helper_settings_helper_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class AiHelperSettingsHelperTest < ActionView::TestCase
+  include AiHelperSettingsHelper
+
+  context "ai_helper_settings_tabs" do
+    should "return 3 tab definitions in order: general, model, vector" do
+      f = build_form_builder
+      tabs = ai_helper_settings_tabs(f)
+
+      assert_equal 3, tabs.length
+
+      assert_equal "general", tabs[0][:name]
+      assert_equal "ai_helper_settings/general_tab", tabs[0][:partial]
+      assert_equal :"ai_helper.settings.tab_general", tabs[0][:label]
+      assert_equal f, tabs[0][:f]
+
+      assert_equal "model", tabs[1][:name]
+      assert_equal "ai_helper_settings/model_tab", tabs[1][:partial]
+      assert_equal :"ai_helper.settings.tab_model", tabs[1][:label]
+      assert_equal f, tabs[1][:f]
+
+      assert_equal "vector", tabs[2][:name]
+      assert_equal "ai_helper_settings/vector_tab", tabs[2][:partial]
+      assert_equal :"ai_helper.settings.tab_vector", tabs[2][:label]
+      assert_equal f, tabs[2][:f]
+    end
+  end
+
+  context "ai_helper_settings_tab_for_error" do
+    should "return general for attachment_max_size_mb" do
+      assert_equal "general", ai_helper_settings_tab_for_error("attachment_max_size_mb")
+    end
+
+    should "return model for think_model_profile_id" do
+      assert_equal "model", ai_helper_settings_tab_for_error("think_model_profile_id")
+    end
+
+    should "return vector for vector_search_uri" do
+      assert_equal "vector", ai_helper_settings_tab_for_error("vector_search_uri")
+    end
+
+    should "return vector for vector_model_profile_id" do
+      assert_equal "vector", ai_helper_settings_tab_for_error("vector_model_profile_id")
+    end
+
+    should "return nil for unknown attribute" do
+      assert_nil ai_helper_settings_tab_for_error("unknown_attribute")
+    end
+  end
+
+  context "ai_helper_settings_selected_tab" do
+    should "return error-based tab when errors present" do
+      tab = ai_helper_settings_selected_tab(
+        ["attachment_max_size_mb"],
+        "vector"
+      )
+      assert_equal "general", tab
+    end
+
+    should "fall back to params_tab when no error mapping exists" do
+      tab = ai_helper_settings_selected_tab(
+        ["unknown_attribute"],
+        "model"
+      )
+      assert_equal "model", tab
+    end
+
+    should "return params_tab when errors array is empty" do
+      tab = ai_helper_settings_selected_tab([], "vector")
+      assert_equal "vector", tab
+    end
+
+    should "return nil when errors array is empty and params_tab is nil" do
+      tab = ai_helper_settings_selected_tab([], nil)
+      assert_nil tab
+    end
+  end
+
+  private
+
+  def build_form_builder
+    setting = AiHelperSetting.new
+    template = ActionView::Base.empty
+    template.class.include ActionView::Helpers::FormHelper
+    ActionView::Helpers::FormBuilder.new(
+      :ai_helper_setting,
+      setting,
+      template,
+      {}
+    )
+  end
+end


### PR DESCRIPTION
## Changes

- Split the AI Helper global settings page into three Redmine-style tabs: General, Model, and Vector search
- Extract per-tab partials (`_general_tab`, `_model_tab`, `_vector_tab`) from the monolithic settings view
- Add `AiHelperSettingsHelper` to drive tab rendering and preserve the active tab after saving
- Auto-select the correct tab on save and after model profile actions (redirect paths now include the model tab)
- Size the vector search project list to its content and add supporting CSS
- Add locales (EN/JA) for the new tab labels
- Add controller and helper tests covering tab selection and rendering