### PR TITLE
Add external chat tool gateway with Slack adapter

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/027-settings-tabs"
+  "feature_directory": "specs/028-chat-channel-gateway"
 }

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "ruby_llm-mcp", "~> 1.0.0"
 
 gem "langfuse", "~> 0.1.1"
 gem "qdrant-ruby", "~> 0.9.9"
+gem "websocket-client-simple", "~> 0.9"
 
 group :test do
   gem "factory_bot_rails"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Project Health Report](#project-health-report)
     - [Health Report History](#health-report-history)
     - [Health Report REST API](#health-report-rest-api)
+  - [Chat Channel Gateway](#chat-channel-gateway)
   - [Multi-modal File Support](#multi-modal-file-support)
 - [📦 Installation](#-installation)
 - [⚙️ Basic Configuration](#️-basic-configuration)
@@ -199,6 +200,55 @@ To generate health reports automatically every Monday at 9:00 AM, add the follow
 ```bash
 0 9 * * 1 curl -X POST -H "X-Redmine-API-Key: your_api_key_here" -H "Content-Type: application/json" https://your-redmine-instance.com/projects/your-project/ai_helper/health_report.json
 ```
+
+## Chat Channel Gateway
+
+The Chat Channel Gateway allows users to interact with the AI Helper from external chat tools such as Slack. Each question is processed under the speaker's own Redmine permissions, and the AI responds as if the user were asking from the web UI. All existing behavior — custom commands, agent orchestration, Langfuse tracing — works identically to the web chat.
+
+The gateway runs as a separate background process that connects outward to chat services, so **no public URL is required** for your Redmine server.
+
+### Slack Integration
+
+1. Create a Slack App with **Socket Mode** enabled. Generate an App-Level Token (`xapp-`) and note the Bot User OAuth Token (`xoxb-`).
+2. Configure the following Bot Token Scopes: `app_mentions:read`, `im:history`, `chat:write`, `users:read`, `users:read.email`, `reactions:write`.
+3. Subscribe to bot events: `app_mention`, `message.im`.
+4. In **Administration → AI Helper → Chat integrations** tab, enable Slack, paste the tokens, and save.
+5. Optionally set a **Default project for direct messages**.
+6. Under **Channel bindings**, map Slack channels to Redmine projects (each channel maps to one project with the AI Helper module enabled).
+
+See [`docs/slack_gateway_setup.md`](docs/slack_gateway_setup.md) for the full setup guide.
+
+### Running the Gateway
+
+Start the gateway as a long-running process, separate from the Redmine web server:
+
+```bash
+cd /path/to/redmine
+bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway RAILS_ENV=production
+```
+
+### Running under systemd (example)
+
+```ini
+[Unit]
+Description=Redmine AI Helper chat gateway
+After=network.target
+
+[Service]
+Type=simple
+User=redmine
+WorkingDirectory=/path/to/redmine
+Environment=RAILS_ENV=production
+ExecStart=/usr/bin/bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway
+Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`Restart=on-failure` restarts on crashes (non-zero exit). Configuration errors (invalid tokens, no adapter enabled) exit with status **0** and are not restarted automatically — fix the configuration and start again.
 
 ## Multi-modal File Support
 

--- a/app/controllers/ai_helper_channel_bindings_controller.rb
+++ b/app/controllers/ai_helper_channel_bindings_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Admin-only CRUD for channel-to-project bindings of external chat tools.
+# Managed from the channels tab of the AI helper settings screen.
+class AiHelperChannelBindingsController < ApplicationController
+  layout "admin"
+
+  before_action :require_admin
+  self.main_menu = false
+
+  # Create a binding and return to the channels tab
+  def create
+    binding = AiHelperChannelBinding.new(binding_params)
+    if binding.save
+      flash[:notice] = l(:notice_successful_create)
+    else
+      flash[:error] = binding.errors.full_messages.join(", ")
+    end
+    redirect_to_channels_tab
+  end
+
+  # Delete a binding and return to the channels tab
+  def destroy
+    AiHelperChannelBinding.find(params[:id]).destroy
+    flash[:notice] = l(:notice_successful_delete)
+    redirect_to_channels_tab
+  end
+
+  private
+
+  # Permitted binding attributes from the add form
+  def binding_params
+    params.require(:ai_helper_channel_binding).permit(:channel_type, :channel_id, :channel_name, :project_id)
+  end
+
+  # All binding actions return to the channels tab of the settings screen
+  def redirect_to_channels_tab
+    redirect_to ai_helper_setting_path(tab: "channels")
+  end
+end

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -19,14 +19,21 @@ class AiHelperSettingsController < ApplicationController
   # Update the settings
   def update
     @setting.safe_attributes = params[:ai_helper_setting]
-    if @setting.save
+    @chat_adapter_settings = chat_adapter_settings_from_params
+    setting_saved = @setting.save
+    adapters_saved = @chat_adapter_settings.values.map(&:save).all?
+    if setting_saved && adapters_saved
       flash[:notice] = l(:notice_successful_update)
       redirect_to action: :index, tab: params[:tab].presence
     else
-      @selected_tab = ai_helper_settings_selected_tab(
-        @setting.errors.attribute_names,
-        params[:tab].presence
-      )
+      @selected_tab = if adapters_saved
+          ai_helper_settings_selected_tab(
+            @setting.errors.attribute_names,
+            params[:tab].presence
+          )
+      else
+          "channels"
+      end
       render action: :index
     end
   end
@@ -56,5 +63,21 @@ class AiHelperSettingsController < ApplicationController
     @setting = AiHelperSetting.find_or_create
     @model_profiles = AiHelperModelProfile.order(:name)
     @ai_helper_projects = Project.joins(:enabled_modules).where(enabled_modules: { name: "ai_helper" }).order(:name)
+    @channel_bindings = AiHelperChannelBinding.includes(:project).order(:channel_type, :channel_id)
+  end
+
+  # Builds adapter setting records from the channels tab params, keyed by
+  # channel_type. Only registered adapters are accepted.
+  # @return [Hash{String => AiHelperChatAdapterSetting}]
+  def chat_adapter_settings_from_params
+    submitted = params[:chat_adapter_settings] || {}
+    RedmineAiHelper::ChatChannel::BaseAdapter.adapters.keys.each_with_object({}) do |channel_type, hash|
+      attrs = submitted[channel_type]
+      next unless attrs
+
+      setting = AiHelperChatAdapterSetting.for_channel(channel_type)
+      setting.safe_attributes = attrs
+      hash[channel_type] = setting
+    end
   end
 end

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -11,17 +11,32 @@ class AiHelperSettingsController < ApplicationController
 
   include AiHelperSettingsHelper
 
+  # Placeholder value rendered in token fields when a token is already
+  # stored, so the raw value never reaches the HTML source (same approach
+  # as AiHelperModelProfilesController::DUMMY_ACCESS_KEY). When this value
+  # is submitted, the controller keeps the existing token unchanged.
+  DUMMY_TOKEN = "___DUMMY_TOKEN___"
+
   # Display the settings page
   def index
     @selected_tab = params[:tab].presence
   end
 
-  # Update the settings
+  # Update the settings. The global setting and every adapter setting are
+  # persisted atomically: if any of them is invalid, none is kept, so the
+  # page never re-renders with only half of the changes committed.
   def update
     @setting.safe_attributes = params[:ai_helper_setting]
     @chat_adapter_settings = chat_adapter_settings_from_params
-    setting_saved = @setting.save
-    adapters_saved = @chat_adapter_settings.values.map(&:save).all?
+
+    setting_saved = nil
+    adapters_saved = nil
+    AiHelperSetting.transaction do
+      setting_saved = @setting.save
+      adapters_saved = @chat_adapter_settings.values.map(&:save).all?
+      raise ActiveRecord::Rollback unless setting_saved && adapters_saved
+    end
+
     if setting_saved && adapters_saved
       flash[:notice] = l(:notice_successful_update)
       redirect_to action: :index, tab: params[:tab].presence
@@ -67,7 +82,9 @@ class AiHelperSettingsController < ApplicationController
   end
 
   # Builds adapter setting records from the channels tab params, keyed by
-  # channel_type. Only registered adapters are accepted.
+  # channel_type. Only registered adapters are accepted. Token fields that
+  # come back unchanged from the form (DUMMY_TOKEN) are preserved as-is so
+  # the stored secret is never round-tripped through the browser.
   # @return [Hash{String => AiHelperChatAdapterSetting}]
   def chat_adapter_settings_from_params
     submitted = params[:chat_adapter_settings] || {}
@@ -76,8 +93,19 @@ class AiHelperSettingsController < ApplicationController
       next unless attrs
 
       setting = AiHelperChatAdapterSetting.for_channel(channel_type)
+      preserve_unchanged_tokens!(setting, attrs)
       setting.safe_attributes = attrs
       hash[channel_type] = setting
+    end
+  end
+
+  # Replaces DUMMY_TOKEN submissions with the value currently stored so the
+  # operator does not have to re-enter a secret to keep it.
+  def preserve_unchanged_tokens!(setting, attrs)
+    %w[app_token bot_token].each do |field|
+      next unless attrs[field] == DUMMY_TOKEN
+
+      attrs[field] = setting.send(field)
     end
   end
 end

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -65,6 +65,16 @@ module AiHelperSettingsHelper
     t("ai_helper.chat_channel.adapters.#{channel_type}", default: channel_type.humanize)
   end
 
+  # Value rendered in a chat-adapter token password field. Stored tokens are
+  # replaced by DUMMY_TOKEN so the raw secret is never written to the HTML
+  # source; an empty value stays empty so a new token can be entered.
+  #
+  # @param token [String, nil] the stored token value
+  # @return [String] the value for the password field
+  def token_field_value(token)
+    token.blank? ? "" : AiHelperSettingsController::DUMMY_TOKEN
+  end
+
   # Maps an error attribute name to its owning tab name.
   #
   # @param attribute [Symbol] the attribute name with validation error

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -35,8 +35,34 @@ module AiHelperSettingsHelper
         partial: "ai_helper_settings/vector_tab",
         label: :"ai_helper.settings.tab_vector",
         f: f
+      },
+      {
+        name: "channels",
+        partial: "ai_helper_settings/channels_tab",
+        label: :"ai_helper.settings.tab_channels",
+        f: f
       }
     ]
+  end
+
+  # Returns the adapter setting record to render for the given channel_type,
+  # preferring the (possibly invalid) record built from submitted params so
+  # validation errors and entered values survive a re-render.
+  #
+  # @param channel_type [String] adapter identifier (e.g. "slack")
+  # @param submitted [Hash{String => AiHelperChatAdapterSetting}, nil] records built from params
+  # @return [AiHelperChatAdapterSetting]
+  def ai_helper_chat_adapter_setting(channel_type, submitted)
+    (submitted || {})[channel_type] || AiHelperChatAdapterSetting.for_channel(channel_type)
+  end
+
+  # Display label for a chat adapter, resolved from the locale file with the
+  # humanized channel_type as fallback.
+  #
+  # @param channel_type [String] adapter identifier (e.g. "slack")
+  # @return [String]
+  def ai_helper_chat_adapter_label(channel_type)
+    t("ai_helper.chat_channel.adapters.#{channel_type}", default: channel_type.humanize)
   end
 
   # Maps an error attribute name to its owning tab name.

--- a/app/models/ai_helper_channel_binding.rb
+++ b/app/models/ai_helper_channel_binding.rb
@@ -7,6 +7,7 @@ class AiHelperChannelBinding < ApplicationRecord
 
   validates :channel_type, presence: true
   validates :channel_id, presence: true, uniqueness: { scope: :channel_type }
+  validates :project, presence: true
 
   scope :for_channel, ->(channel_type, channel_id) {
           where(channel_type: channel_type, channel_id: channel_id)

--- a/app/models/ai_helper_channel_binding.rb
+++ b/app/models/ai_helper_channel_binding.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Binding between an external chat tool channel and a Redmine project.
+# One channel (channel_type + channel_id) maps to exactly one project.
+class AiHelperChannelBinding < ApplicationRecord
+  belongs_to :project
+
+  validates :channel_type, presence: true
+  validates :channel_id, presence: true, uniqueness: { scope: :channel_type }
+  validates :project, presence: true
+
+  scope :for_channel, ->(channel_type, channel_id) {
+          where(channel_type: channel_type, channel_id: channel_id)
+        }
+end

--- a/app/models/ai_helper_channel_binding.rb
+++ b/app/models/ai_helper_channel_binding.rb
@@ -7,7 +7,6 @@ class AiHelperChannelBinding < ApplicationRecord
 
   validates :channel_type, presence: true
   validates :channel_id, presence: true, uniqueness: { scope: :channel_type }
-  validates :project, presence: true
 
   scope :for_channel, ->(channel_type, channel_id) {
           where(channel_type: channel_type, channel_id: channel_id)

--- a/app/models/ai_helper_channel_conversation.rb
+++ b/app/models/ai_helper_channel_conversation.rb
@@ -7,6 +7,7 @@ class AiHelperChannelConversation < ApplicationRecord
 
   validates :channel_type, presence: true
   validates :thread_key, presence: true, uniqueness: { scope: :channel_type }
+  validates :conversation, presence: true
 
   # Returns the conversation bound to the given thread, creating both the
   # conversation and the binding when the thread is seen for the first time.

--- a/app/models/ai_helper_channel_conversation.rb
+++ b/app/models/ai_helper_channel_conversation.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Mapping between an external chat tool thread and an AI helper conversation.
+# One thread (channel_type + thread_key) maps to exactly one conversation.
+class AiHelperChannelConversation < ApplicationRecord
+  belongs_to :conversation, class_name: "AiHelperConversation"
+
+  validates :channel_type, presence: true
+  validates :thread_key, presence: true, uniqueness: { scope: :channel_type }
+  validates :conversation, presence: true
+
+  # Returns the conversation bound to the given thread, creating both the
+  # conversation and the binding when the thread is seen for the first time.
+  # The conversation owner stays the thread starter; later speakers are
+  # represented by User.current at message processing time.
+  # @param channel_type [String] Tool type (e.g. "slack")
+  # @param thread_key [String] Tool-specific thread identifier
+  # @param user [User] The user who starts the conversation
+  # @return [AiHelperConversation] The bound conversation
+  def self.find_or_create_conversation(channel_type:, thread_key:, user:)
+    channel_conversation = find_by(channel_type: channel_type, thread_key: thread_key)
+    return channel_conversation.conversation if channel_conversation
+
+    conversation = AiHelperConversation.new(user: user, title: "-")
+    transaction do
+      conversation.save!
+      create!(channel_type: channel_type, thread_key: thread_key, conversation: conversation)
+    end
+    conversation
+  end
+end

--- a/app/models/ai_helper_channel_conversation.rb
+++ b/app/models/ai_helper_channel_conversation.rb
@@ -7,7 +7,6 @@ class AiHelperChannelConversation < ApplicationRecord
 
   validates :channel_type, presence: true
   validates :thread_key, presence: true, uniqueness: { scope: :channel_type }
-  validates :conversation, presence: true
 
   # Returns the conversation bound to the given thread, creating both the
   # conversation and the binding when the thread is seen for the first time.

--- a/app/models/ai_helper_chat_adapter_setting.rb
+++ b/app/models/ai_helper_chat_adapter_setting.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Per-adapter settings for external chat tool integrations. One row per
+# adapter (channel_type, e.g. "slack"). Follows the same pattern as
+# AiHelperModelProfile: typed columns shared by all adapters, with per-adapter
+# required fields declared by the adapter class itself.
+class AiHelperChatAdapterSetting < ApplicationRecord
+  include Redmine::SafeAttributes
+
+  belongs_to :dm_default_project, class_name: "Project", optional: true
+
+  validates :channel_type, presence: true, uniqueness: true
+  validate :required_fields_present_when_enabled
+
+  safe_attributes "enabled", "app_token", "bot_token", "dm_default_project_id"
+
+  class << self
+    # Returns the setting row for the given adapter, or a new unsaved record
+    # when the adapter has no settings yet.
+    # @param channel_type [String] Adapter identifier (e.g. "slack")
+    # @return [AiHelperChatAdapterSetting]
+    def for_channel(channel_type)
+      find_by(channel_type: channel_type) || new(channel_type: channel_type)
+    end
+
+    # Returns whether the integration for the given adapter is enabled.
+    # @param channel_type [String] Adapter identifier (e.g. "slack")
+    # @return [Boolean]
+    def enabled?(channel_type)
+      for_channel(channel_type).enabled
+    end
+  end
+
+  # Masked app token for display (all but the first four characters hidden).
+  # @return [String, nil]
+  def masked_app_token
+    mask_token(app_token)
+  end
+
+  # Masked bot token for display (all but the first four characters hidden).
+  # @return [String, nil]
+  def masked_bot_token
+    mask_token(bot_token)
+  end
+
+  private
+
+  # Fields declared as required by the adapter registered for this
+  # channel_type. Empty when no adapter is registered.
+  def required_setting_fields
+    adapter = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type]
+    adapter ? adapter.required_setting_fields : []
+  end
+
+  # Validates that the adapter's required fields are present when the
+  # integration is enabled. Tokens themselves never appear in error messages.
+  def required_fields_present_when_enabled
+    return unless enabled?
+
+    required_setting_fields.each do |field|
+      errors.add(field, :blank) if send(field).blank?
+    end
+  end
+
+  # Replace all characters after the 4th with "*".
+  def mask_token(token)
+    return token if token.blank? || token.length <= 4
+
+    masked = token.dup
+    masked[4..-1] = "*" * (masked.length - 4)
+    masked
+  end
+end

--- a/app/models/ai_helper_conversation.rb
+++ b/app/models/ai_helper_conversation.rb
@@ -3,6 +3,7 @@
 # AiHelperConversation model for managing AI Helper conversations
 class AiHelperConversation < ApplicationRecord
   has_many :messages, class_name: "AiHelperMessage", foreign_key: "conversation_id", inverse_of: :conversation, dependent: :destroy
+  has_one :channel_conversation, class_name: "AiHelperChannelConversation", foreign_key: "conversation_id", inverse_of: :conversation, dependent: :destroy
   belongs_to :user
   validates :title, presence: true
 

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -1,0 +1,95 @@
+<% adapters = RedmineAiHelper::ChatChannel::BaseAdapter.adapters.keys.sort %>
+<% adapters.each do |channel_type| %>
+  <% adapter_setting = ai_helper_chat_adapter_setting(channel_type, @chat_adapter_settings) %>
+  <fieldset class="box tabular">
+    <legend><%= ai_helper_chat_adapter_label(channel_type) %></legend>
+    <% if adapter_setting.errors.any? %>
+      <div id="errorExplanation">
+        <ul>
+          <% adapter_setting.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.enabled") %></label>
+      <%= hidden_field_tag "chat_adapter_settings[#{channel_type}][enabled]", "0", id: nil %>
+      <%= check_box_tag "chat_adapter_settings[#{channel_type}][enabled]", "1", adapter_setting.enabled, id: nil %>
+    </p>
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.app_token") %></label>
+      <%= password_field_tag "chat_adapter_settings[#{channel_type}][app_token]", adapter_setting.app_token, size: 60, id: nil %>
+    </p>
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.bot_token") %></label>
+      <%= password_field_tag "chat_adapter_settings[#{channel_type}][bot_token]", adapter_setting.bot_token, size: 60, id: nil %>
+    </p>
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.dm_default_project") %></label>
+      <%= select_tag "chat_adapter_settings[#{channel_type}][dm_default_project_id]",
+                     options_from_collection_for_select(@ai_helper_projects, :id, :name, adapter_setting.dm_default_project_id),
+                     include_blank: true, id: nil %>
+    </p>
+  </fieldset>
+<% end %>
+
+<fieldset class="box">
+  <legend><%= t("ai_helper.chat_channel.settings.bindings") %></legend>
+  <% if @channel_bindings.any? %>
+    <table class="list">
+      <thead>
+        <tr>
+          <th><%= t("ai_helper.chat_channel.settings.adapter") %></th>
+          <th><%= t("ai_helper.chat_channel.settings.channel_id") %></th>
+          <th><%= t("ai_helper.chat_channel.settings.channel_name") %></th>
+          <th><%= t(:label_project) %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @channel_bindings.each do |channel_binding| %>
+          <tr>
+            <td><%= ai_helper_chat_adapter_label(channel_binding.channel_type) %></td>
+            <td><%= channel_binding.channel_id %></td>
+            <td><%= channel_binding.channel_name %></td>
+            <td><%= channel_binding.project.name %></td>
+            <td class="buttons">
+              <%= link_to(sprite_icon('del', l(:button_delete)),
+                          ai_helper_channel_binding_path(channel_binding),
+                          method: :delete,
+                          data: { confirm: l(:text_are_you_sure) },
+                          class: 'icon icon-del') %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+  <div class="tabular">
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.adapter") %></label>
+      <%= select_tag "ai_helper_channel_binding[channel_type]",
+                     options_for_select(adapters.map { |type| [ ai_helper_chat_adapter_label(type), type ] }),
+                     id: nil %>
+    </p>
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.channel_id") %></label>
+      <%= text_field_tag "ai_helper_channel_binding[channel_id]", "", size: 30, id: nil %>
+    </p>
+    <p>
+      <label><%= t("ai_helper.chat_channel.settings.channel_name") %></label>
+      <%= text_field_tag "ai_helper_channel_binding[channel_name]", "", size: 30, id: nil %>
+    </p>
+    <p>
+      <label><%= t(:label_project) %></label>
+      <%= select_tag "ai_helper_channel_binding[project_id]",
+                     options_from_collection_for_select(@ai_helper_projects, :id, :name),
+                     include_blank: true, id: nil %>
+    </p>
+    <p>
+      <%= submit_tag t("ai_helper.chat_channel.settings.add_binding"),
+                     formaction: ai_helper_channel_bindings_path, name: nil %>
+    </p>
+  </div>
+</fieldset>

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -19,11 +19,21 @@
     </p>
     <p>
       <label><%= t("ai_helper.chat_channel.settings.app_token") %></label>
-      <%= password_field_tag "chat_adapter_settings[#{channel_type}][app_token]", adapter_setting.app_token, size: 60, id: nil %>
+      <%= password_field_tag "chat_adapter_settings[#{channel_type}][app_token]",
+                             token_field_value(adapter_setting.app_token),
+                             size: 60, id: nil, autocomplete: "new-password" %>
+      <% if adapter_setting.app_token.present? %>
+        <em class="info"><%= adapter_setting.masked_app_token %></em>
+      <% end %>
     </p>
     <p>
       <label><%= t("ai_helper.chat_channel.settings.bot_token") %></label>
-      <%= password_field_tag "chat_adapter_settings[#{channel_type}][bot_token]", adapter_setting.bot_token, size: 60, id: nil %>
+      <%= password_field_tag "chat_adapter_settings[#{channel_type}][bot_token]",
+                             token_field_value(adapter_setting.bot_token),
+                             size: 60, id: nil, autocomplete: "new-password" %>
+      <% if adapter_setting.bot_token.present? %>
+        <em class="info"><%= adapter_setting.masked_bot_token %></em>
+      <% end %>
     </p>
     <p>
       <label><%= t("ai_helper.chat_channel.settings.dm_default_project") %></label>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,26 @@ en:
       tab_general: "General"
       tab_model: "Model"
       tab_vector: "Vector search"
+      tab_channels: "Chat integrations"
+    chat_channel:
+      adapters:
+        slack: "Slack"
+      settings:
+        enabled: "Enable"
+        app_token: "App Token"
+        bot_token: "Bot Token"
+        dm_default_project: "Default project for direct messages"
+        bindings: "Channel bindings"
+        adapter: "Chat tool"
+        channel_id: "Channel ID"
+        channel_name: "Channel name"
+        add_binding: "Add binding"
+      errors:
+        user_not_mapped: "No active Redmine user matches your chat account's email address, so the request could not be processed. Please ask your administrator to check your Redmine account."
+        channel_not_bound: "This channel is not associated with any Redmine project. Please ask your administrator to configure the channel mapping."
+        dm_not_configured: "No default project is configured for direct messages. Please ask your administrator to configure it."
+        module_disabled: "The AI helper module is disabled for the associated project."
+        processing_failed: "An error occurred while generating the answer. Please check the AI helper log for details."
     notice_sub_issues_added: "Sub-issues have been added"
     error_invalid_assignee: "Invalid assignee for '%{subject}' - user is not authorized for this tracker"
     chat:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -36,6 +36,26 @@ ja:
       tab_general: "全般"
       tab_model: "モデル"
       tab_vector: "ベクトル検索"
+      tab_channels: "チャット連携"
+    chat_channel:
+      adapters:
+        slack: "Slack"
+      settings:
+        enabled: "有効にする"
+        app_token: "App Token"
+        bot_token: "Bot Token"
+        dm_default_project: "ダイレクトメッセージ用の既定プロジェクト"
+        bindings: "チャンネル対応付け"
+        adapter: "チャットツール"
+        channel_id: "チャンネルID"
+        channel_name: "チャンネル名"
+        add_binding: "対応付けを追加"
+      errors:
+        user_not_mapped: "チャットアカウントのメールアドレスに一致する有効なRedmineユーザーが見つからないため、処理できませんでした。管理者にRedmineアカウントの確認を依頼してください。"
+        channel_not_bound: "このチャンネルはRedmineプロジェクトに対応付けられていません。管理者にチャンネル対応付けの設定を依頼してください。"
+        dm_not_configured: "ダイレクトメッセージ用の既定プロジェクトが設定されていません。管理者に設定を依頼してください。"
+        module_disabled: "対応付けられたプロジェクトでAIヘルパーモジュールが無効になっています。"
+        processing_failed: "回答の生成中にエラーが発生しました。詳細はAIヘルパーのログを確認してください。"
     notice_sub_issues_added: "子チケットが追加されました"
     error_invalid_assignee: "'%{subject}' の担当者が無効です。このトラッカーに対する権限がありません"
     chat:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,9 @@ RedmineApp::Application.routes.draw do
   get "ai_helper_settings/index", to: "ai_helper_settings#index", as: "ai_helper_setting"
   post "ai_helper_settings/index", to: "ai_helper_settings#update", as: "ai_helper_setting_update"
 
+  post "ai_helper_channel_bindings", to: "ai_helper_channel_bindings#create", as: "ai_helper_channel_bindings"
+  delete "ai_helper_channel_bindings/:id", to: "ai_helper_channel_bindings#destroy", as: "ai_helper_channel_binding"
+
   post "ai_helper_model_profiles/test_connection",
        to: "ai_helper_model_profiles#test_connection",
        as: "ai_helper_model_profiles_test_connection"

--- a/db/migrate/20260719000000_create_ai_helper_chat_adapter_settings.rb
+++ b/db/migrate/20260719000000_create_ai_helper_chat_adapter_settings.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Per-adapter settings for external chat tool integrations. One row per
+# adapter (channel_type, e.g. "slack"), holding the enable flag, credentials,
+# and the default project for direct message conversations. Follows the same
+# pattern as ai_helper_model_profiles: adding a new adapter never changes the
+# schema.
+class CreateAiHelperChatAdapterSettings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ai_helper_chat_adapter_settings do |t|
+      t.string :channel_type, null: false
+      t.boolean :enabled, null: false, default: false
+      t.string :app_token
+      t.string :bot_token
+      # projects.id is a signed int in Redmine core, so use :integer to keep the
+      # foreign key valid on MySQL.
+      t.integer :dm_default_project_id
+      t.timestamps
+    end
+
+    add_index :ai_helper_chat_adapter_settings, :channel_type, unique: true
+    add_foreign_key :ai_helper_chat_adapter_settings, :projects,
+                    column: :dm_default_project_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260719000001_create_ai_helper_channel_bindings.rb
+++ b/db/migrate/20260719000001_create_ai_helper_channel_bindings.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Binding between an external chat tool channel and a Redmine project.
+# One channel maps to exactly one project (unique on channel_type + channel_id).
+class CreateAiHelperChannelBindings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ai_helper_channel_bindings do |t|
+      t.string :channel_type, null: false
+      t.string :channel_id, null: false
+      t.string :channel_name
+      # projects.id is a signed int in Redmine core, so use :integer to keep the
+      # foreign key valid on MySQL.
+      t.integer :project_id, null: false
+      t.timestamps
+    end
+
+    add_index :ai_helper_channel_bindings, [ :channel_type, :channel_id ],
+              unique: true,
+              name: "index_ai_helper_channel_bindings_unique"
+    add_index :ai_helper_channel_bindings, :project_id
+    add_foreign_key :ai_helper_channel_bindings, :projects, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260719000002_create_ai_helper_channel_conversations.rb
+++ b/db/migrate/20260719000002_create_ai_helper_channel_conversations.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Mapping between an external chat tool thread and an existing AI helper
+# conversation. One thread maps to exactly one conversation (unique on
+# channel_type + thread_key).
+class CreateAiHelperChannelConversations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ai_helper_channel_conversations do |t|
+      t.string :channel_type, null: false
+      t.string :thread_key, null: false
+      t.integer :conversation_id, null: false
+      t.timestamps
+    end
+
+    add_index :ai_helper_channel_conversations, [ :channel_type, :thread_key ],
+              unique: true,
+              name: "index_ai_helper_channel_conversations_unique"
+    add_index :ai_helper_channel_conversations, :conversation_id
+    add_foreign_key :ai_helper_channel_conversations, :ai_helper_conversations,
+                    column: :conversation_id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260719000002_create_ai_helper_channel_conversations.rb
+++ b/db/migrate/20260719000002_create_ai_helper_channel_conversations.rb
@@ -8,7 +8,7 @@ class CreateAiHelperChannelConversations < ActiveRecord::Migration[7.2]
     create_table :ai_helper_channel_conversations do |t|
       t.string :channel_type, null: false
       t.string :thread_key, null: false
-      t.integer :conversation_id, null: false
+      t.bigint :conversation_id, null: false
       t.timestamps
     end
 

--- a/docs/adr/006-chat-channel-gateway-architecture.md
+++ b/docs/adr/006-chat-channel-gateway-architecture.md
@@ -1,0 +1,42 @@
+# ADR-006: External chat tool gateway with Socket Mode and a serialized worker
+
+**Date**: 2026-07-19
+**Status**: Accepted
+
+## Context
+
+Feature 028 lets users ask the AI Helper questions from external chat tools (Slack first) and receive answers in the same thread, processed under the speaker's own Redmine permissions. Three architectural questions had to be settled:
+
+1. How to receive Slack events when many Redmine installations have no public URL.
+2. How to keep the plugin open for future chat tools (Discord, Teams, ...) without touching the core processing each time.
+3. How to run LLM requests for multiple concurrent speakers without leaking one user's permission context into another's request, given that Redmine's `User.current` is a request-scoped, effectively global mechanism.
+
+## Decision
+
+1. **Gateway process with an outgoing Socket Mode connection.** A resident rake task (`redmine:plugins:ai_helper:chat_channel:gateway`) loads the Rails environment and connects *out* to Slack via Socket Mode (`apps.connections.open` → WebSocket). No public URL, reverse proxy, or webhook endpoint is required. The WebSocket client is `websocket-client-simple` (pure Ruby, one dependency); all Slack Web API calls go through `Net::HTTP` directly. Reconnection is handled in three ways: immediately on Slack's `disconnect` envelopes, with exponential backoff (1s→60s) on socket errors, and on two consecutive missed pongs from a 30-second ping cycle. Authentication failures (`ok: false`) terminate the process without retry — credential problems are never retried into silence.
+2. **Adapter abstraction with automatic registration.** `RedmineAiHelper::ChatChannel::BaseAdapter` follows the same `inherited`-hook registration pattern as `BaseAgent`. A new tool integration is one subclass in `chat_channel/adapters/` implementing `channel_type`, `start`, `stop`, `send_message`, `resolve_user_email`, and `notify_processing`, plus a `required_setting_fields` declaration. The tool-independent core (`MessageHandler`) resolves the user by email, resolves the project via `AiHelperChannelBinding` (or the adapter's DM default project), binds threads to `AiHelperConversation` rows via `AiHelperChannelConversation`, and calls the existing `RedmineAiHelper::Llm#chat` entry point so custom commands, Langfuse tracing and agent orchestration work unchanged.
+3. **Per-adapter settings in one dedicated model.** `AiHelperChatAdapterSetting` holds one row per `channel_type` (enable flag, `app_token`, `bot_token`, DM default project), following the `AiHelperModelProfile` pattern of typed shared columns with per-type required-field validation. Adding an adapter adds no columns to `ai_helper_settings` and no new tables.
+4. **Single worker thread serializes all LLM processing.** Adapters' receive threads only normalize events into `IncomingMessage` values and enqueue them (`SizedQueue`); one worker thread pops them, wraps each in `connection_pool.with_connection`, sets `User.current` to the speaker, runs the LLM, restores `User.current` in an `ensure`, and posts the reply through the adapter. Concurrent questions therefore cannot interleave permission contexts by construction.
+
+## Consequences
+
+**Positive**:
+
+- Works behind firewalls and on intranet Redmine instances (outgoing HTTPS/WSS only).
+- SC-006 holds: the test suite proves a fictional in-memory adapter works end to end with zero changes to `MessageHandler` or the Slack adapter.
+- Permission isolation (SC-003) is structural, not conventional: there is exactly one thread that ever touches `User.current`.
+- The gateway reuses `Llm#chat`, so behavior matches the web chat (custom commands, tracing, error strings posted back to the thread).
+
+**Negative**:
+
+- Throughput is bounded by the single worker: simultaneous questions queue up and are answered in order. Acceptable for the v1 scale (a handful of concurrent users); revisit only with evidence.
+- The gateway is a separate process the operator must supervise (systemd or similar); it is not managed by Puma.
+- Slack markdown differences are not translated (answers are posted as-is); a converter can be layered on later if needed.
+
+## Alternatives Considered
+
+- **Events API (webhooks)**: rejected — requires a public URL, contradicting FR-001.
+- **`slack-ruby-client` gem**: rejected — no first-class Socket Mode support; pulls in a heavy async/EventMachine-era dependency stack for its realtime layer.
+- **Thread-per-event processing**: rejected — would require proving `User.current` thread-safety under concurrent per-user assignment; a permission leak is the worst possible failure mode for this feature.
+- **ActiveJob for LLM work**: rejected — Redmine's default `:async` adapter runs inside the web process, unavailable to the gateway process.
+- **Slack columns on `ai_helper_settings`**: rejected during implementation review — each new adapter would keep widening the global settings table; a per-adapter settings model keeps the schema stable.

--- a/docs/slack_gateway_setup.md
+++ b/docs/slack_gateway_setup.md
@@ -1,0 +1,90 @@
+# Slack Gateway Setup Guide
+
+This guide explains how to connect the Redmine AI Helper to a Slack workspace so users can ask the AI Helper questions from Slack channels or direct messages and receive answers in the same thread.
+
+The integration uses Slack **Socket Mode**: the gateway process opens an outgoing WebSocket connection to Slack, so **no public URL is required** for your Redmine server.
+
+## Requirements
+
+- Redmine 6.x with the `redmine_ai_helper` plugin installed, migrated, and a working model profile (the web chat must already work).
+- Permission to create apps in your Slack workspace.
+- Slack users who should use the integration must have the **same email address** on their Slack profile and their active Redmine account.
+
+## 1. Create the Slack app
+
+1. Open <https://api.slack.com/apps> and choose **Create New App** (from scratch).
+2. Under **Socket Mode**, enable Socket Mode and generate an **App-Level Token** with the `connections:write` scope. Note the token (starts with `xapp-`).
+3. Under **OAuth & Permissions → Bot Token Scopes**, add:
+   - `app_mentions:read` — receive mentions in channels
+   - `im:history` — receive direct messages
+   - `chat:write` — post replies
+   - `users:read` and `users:read.email` — resolve the speaker's email address
+   - `reactions:write` — show the "processing" reaction
+4. Under **Event Subscriptions → Subscribe to bot events**, add:
+   - `app_mention`
+   - `message.im`
+5. Install the app into the workspace and note the **Bot User OAuth Token** (starts with `xoxb-`).
+
+## 2. Configure Redmine
+
+1. Go to **Administration → AI Helper → Chat integrations** tab.
+2. In the **Slack** section, check **Enable**, paste the App Token (`xapp-`) and Bot Token (`xoxb-`), and save.
+3. Optionally select a **Default project for direct messages**. DMs to the bot are answered in this project's context; without it, DMs receive a guidance message.
+4. Under **Channel bindings**, map each Slack channel to a Redmine project:
+   - Channel ID: open the channel in Slack, copy the ID from the URL or channel details (starts with `C`).
+   - Channel name is optional display text for this screen.
+   - One channel maps to exactly one project. The project must have the **AI Helper** module enabled.
+
+## 3. Run the gateway
+
+The gateway is a resident process, separate from the Redmine web server:
+
+```bash
+cd /path/to/redmine
+bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway RAILS_ENV=production
+```
+
+On success, `log/ai_helper.log` records the connection establishment (`hello` received). With invalid tokens the process logs the authentication error and exits without retrying — fix the tokens and start it again.
+
+The gateway reconnects automatically on Slack-initiated refreshes, network errors (exponential backoff up to 60 s), and missed ping responses. Stop it with `SIGTERM` or `Ctrl+C`; queued messages are drained before exit.
+
+### Running under systemd (example)
+
+```ini
+[Unit]
+Description=Redmine AI Helper chat gateway
+After=network.target
+
+[Service]
+Type=simple
+User=redmine
+WorkingDirectory=/path/to/redmine
+Environment=RAILS_ENV=production
+ExecStart=/usr/bin/bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`Restart=on-failure` restarts the gateway on crashes but not on clean exits caused by configuration errors (such as invalid tokens), which would otherwise loop.
+
+## 4. Use it
+
+- In a bound channel, invite the bot (`/invite @your-bot`) and mention it: `@your-bot what are the open issues?`
+- The bot reacts with ⏳ while processing and posts the answer as a thread reply.
+- Follow-up questions in the same thread keep the conversation context. Anyone can continue the thread; each question runs under the **speaker's own** Redmine permissions.
+- DMs to the bot are answered in the configured default project.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Gateway exits immediately with an authentication error | Wrong `xapp-`/`xoxb-` token, or Socket Mode not enabled on the app. |
+| "No chat channel adapter is enabled" on startup | The Slack section is not enabled or a required token is missing in the settings. |
+| Bot replies "no active Redmine user matches..." | The Slack user's profile email does not match any active Redmine user. |
+| Bot replies "this channel is not associated..." | Add a channel binding for that channel ID. |
+| Bot replies that the AI helper module is disabled | Enable the AI Helper module in the bound project's settings. |
+| No reaction / no reply at all | Check that the gateway process is running and see `log/ai_helper.log`. Verify the event subscriptions (`app_mention`, `message.im`). |
+
+All gateway activity is logged to `log/ai_helper.log`. Token values are never written to the log.

--- a/docs/slack_gateway_setup.md
+++ b/docs/slack_gateway_setup.md
@@ -44,9 +44,9 @@ cd /path/to/redmine
 bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway RAILS_ENV=production
 ```
 
-On success, `log/ai_helper.log` records the connection establishment (`hello` received). With invalid tokens the process logs the authentication error and exits without retrying — fix the tokens and start it again.
+On success, `log/ai_helper.log` records the connection establishment (`hello` received). With invalid tokens the gateway logs the authentication error and exits with status **0** so the supervisor does not keep retrying — fix the tokens and start it again.
 
-The gateway reconnects automatically on Slack-initiated refreshes, network errors (exponential backoff up to 60 s), and missed ping responses. Stop it with `SIGTERM` or `Ctrl+C`; queued messages are drained before exit.
+The gateway reconnects automatically on Slack-initiated refreshes, network errors (exponential backoff up to 60 s), missed ping responses, and clean closes that never received `hello` (suspected handshake rejection). Stop it with `SIGTERM` or `Ctrl+C`; queued messages are drained before exit.
 
 ### Running under systemd (example)
 
@@ -62,12 +62,16 @@ WorkingDirectory=/path/to/redmine
 Environment=RAILS_ENV=production
 ExecStart=/usr/bin/bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway
 Restart=on-failure
+# Bound restart frequency for genuine crashes (e.g. unhandled runtime errors).
+# Configuration/credential failures exit 0 and are NOT restarted.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-`Restart=on-failure` restarts the gateway on crashes but not on clean exits caused by configuration errors (such as invalid tokens), which would otherwise loop.
+`Restart=on-failure` restarts the gateway on crashes (non-zero exit). Configuration and credential errors — invalid tokens, or no adapter enabled — are reported in `log/ai_helper.log` and cause the process to exit with status **0**, so systemd does **not** restart them automatically. Fix the configuration and start the gateway again. Genuine crashes (unhandled exceptions) exit non-zero and are restarted, bounded by `StartLimitIntervalSec` / `StartLimitBurst` to avoid a tight restart loop.
 
 ## 4. Use it
 
@@ -80,7 +84,7 @@ WantedBy=multi-user.target
 
 | Symptom | Cause / fix |
 |---|---|
-| Gateway exits immediately with an authentication error | Wrong `xapp-`/`xoxb-` token, or Socket Mode not enabled on the app. |
+| Gateway exits immediately with an authentication error | Wrong `xapp-`/`xoxb-` token, or Socket Mode not enabled on the app. The gateway exits with status 0 so it will not be restarted automatically; update the tokens and start it again. |
 | "No chat channel adapter is enabled" on startup | The Slack section is not enabled or a required token is missing in the settings. |
 | Bot replies "no active Redmine user matches..." | The Slack user's profile email does not match any active Redmine user. |
 | Bot replies "this channel is not associated..." | Add a channel binding for that channel ID. |

--- a/init.rb
+++ b/init.rb
@@ -17,6 +17,12 @@ end
 require "redmine_ai_helper/util/config_file"
 require "redmine_ai_helper/util/permission_checker"
 require "redmine_ai_helper/user_patch"
+require "redmine_ai_helper/project_patch"
+require "redmine_ai_helper/chat_channel/base_adapter"
+require "redmine_ai_helper/chat_channel/gateway"
+Dir[File.join(File.dirname(__FILE__), "lib/redmine_ai_helper/chat_channel/adapters", "*_adapter.rb")].sort.each do |file|
+  require file
+end
 require_dependency "redmine_ai_helper/view_hook"
 Dir[File.join(File.dirname(__FILE__), "lib/redmine_ai_helper/agents", "*_agent.rb")].sort.each do |file|
   require file

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -1,0 +1,353 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "websocket-client-simple"
+require "redmine_ai_helper/chat_channel/base_adapter"
+
+module RedmineAiHelper
+  module ChatChannel
+    # Concrete chat tool adapter implementations. One file per tool.
+    module Adapters
+      # Slack adapter using Socket Mode: an outgoing WebSocket connection
+      # obtained via apps.connections.open, so no public URL is required.
+      # Web API calls (auth.test, users.info, chat.postMessage, reactions.add)
+      # go through Net::HTTP directly. Tokens are never written to the log.
+      class SlackAdapter < BaseAdapter
+        # Raised when a Slack Web API call returns ok:false. Authentication
+        # errors are not retried: the gateway terminates with this error.
+        class SlackApiError < StandardError; end
+
+        # Base URL of the Slack Web API.
+        SLACK_API_BASE = "https://slack.com/api"
+        # Open/read timeout for every Web API call (contract: 10 seconds).
+        HTTP_TIMEOUT_SECONDS = 10
+        # Interval between health-check pings on the WebSocket.
+        PING_INTERVAL_SECONDS = 30
+        # Upper bound of the exponential reconnect backoff.
+        MAX_BACKOFF_SECONDS = 60
+        # Reconnect when this many consecutive pings got no pong.
+        MAX_MISSED_PONGS = 2
+        # Replies longer than this are split before posting (research.md R-008).
+        MAX_MESSAGE_LENGTH = 3900
+
+        class << self
+          # @return [String] the adapter identifier
+          def channel_type
+            "slack"
+          end
+
+          # Socket Mode needs the app-level token, the Web API the bot token.
+          # @return [Array<Symbol>]
+          def required_setting_fields
+            [ :app_token, :bot_token ]
+          end
+        end
+
+        # The bot's own Slack user id, fetched via auth.test on start.
+        # @return [String, nil]
+        attr_reader :bot_user_id
+
+        def initialize
+          super
+          @stopped = false
+          @reconnect_requested = false
+          @connected = false
+          @backoff = 1
+          @missed_pongs = 0
+        end
+
+        # Connects to Slack and blocks while receiving events. Reconnects on
+        # disconnect envelopes (immediately, with a fresh URL), on socket
+        # errors (with exponential backoff) and on missed pongs. Auth errors
+        # (ok:false from the Web API) terminate without retry.
+        # @return [void]
+        def start
+          @stopped = false
+          @bot_user_id = fetch_bot_user_id
+          ai_helper_logger.info "slack: starting Socket Mode connection (bot user #{@bot_user_id})"
+          until stopped?
+            url = open_connection_url
+            begin
+              listen(url)
+              reset_backoff if @reconnect_requested
+            rescue SlackApiError
+              raise
+            rescue => e
+              ai_helper_logger.error "slack: socket error: #{e.full_message}"
+              sleep(next_backoff) unless stopped?
+            end
+          end
+          ai_helper_logger.info "slack: adapter stopped"
+        end
+
+        # Closes the connection and lets #start return.
+        # @return [void]
+        def stop
+          @stopped = true
+          @connection_ended&.push(true)
+          close_socket
+        end
+
+        # Whether the hello envelope has been received on the current socket.
+        # @return [Boolean]
+        def connected?
+          @connected
+        end
+
+        # Dispatches one raw Socket Mode envelope (JSON text frame).
+        # @param raw [String] the raw JSON payload
+        # @return [void]
+        def handle_envelope(raw)
+          data = JSON.parse(raw)
+          case data["type"]
+          when "hello"
+            @connected = true
+            reset_backoff
+            ai_helper_logger.info "slack: connection established (hello received)"
+          when "disconnect"
+            ai_helper_logger.info "slack: disconnect requested by Slack (reason: #{data["reason"]})"
+            request_reconnect
+          when "pong"
+            handle_pong
+          when "events_api"
+            acknowledge(data["envelope_id"])
+            process_event(data.dig("payload", "event") || {})
+          else
+            ai_helper_logger.debug "slack: ignoring envelope type #{data["type"].inspect}"
+          end
+        rescue JSON::ParserError => e
+          ai_helper_logger.error "slack: failed to parse envelope: #{e.message}"
+        end
+
+        # Resolves the email address of a Slack user via users.info.
+        # @param external_user_id [String] the Slack user id (U...)
+        # @return [String, nil] the profile email, or nil when absent
+        def resolve_user_email(external_user_id:)
+          body = api_call("users.info", token: settings.bot_token, params: { user: external_user_id })
+          body.dig("user", "profile", "email")
+        end
+
+        # Posts a reply into the given thread, splitting texts longer than
+        # the Slack message limit at paragraph boundaries.
+        # @param channel_id [String] the Slack channel id
+        # @param thread_key [String] "{channel_id}:{thread_ts}"
+        # @param text [String] the reply body (Markdown as-is)
+        # @return [void]
+        def send_message(channel_id:, thread_key:, text:)
+          thread_ts = thread_key.split(":", 2).last
+          split_text(text).each do |chunk|
+            api_call("chat.postMessage", token: settings.bot_token,
+                     params: { channel: channel_id, thread_ts: thread_ts, text: chunk })
+          end
+        end
+
+        # Marks the message as being processed with an hourglass reaction
+        # (FR-010).
+        # @param message [IncomingMessage] the message being processed
+        # @return [void]
+        def notify_processing(message:)
+          timestamp = message.thread_key.split(":", 2).last
+          api_call("reactions.add", token: settings.bot_token,
+                   params: { channel: message.channel_id, timestamp: timestamp, name: "hourglass_flowing_sand" })
+        end
+
+        private
+
+        # Whether #stop has been called.
+        def stopped?
+          @stopped
+        end
+
+        # Fetches the bot's own user id and validates the bot token.
+        # @return [String]
+        def fetch_bot_user_id
+          api_call("auth.test", token: settings.bot_token)["user_id"]
+        end
+
+        # Opens a Socket Mode connection URL with the app-level token.
+        # ok:false raises SlackApiError and terminates the adapter (no retry
+        # for credential problems).
+        # @return [String] the wss:// URL
+        def open_connection_url
+          api_call("apps.connections.open", token: settings.app_token)["url"]
+        end
+
+        # Connects the WebSocket and blocks until the connection ends, a
+        # reconnect is requested, or the adapter is stopped.
+        def listen(url)
+          @connection_ended = Queue.new
+          @reconnect_requested = false
+          @connected = false
+          @missed_pongs = 0
+          adapter = self
+          @ws = WebSocket::Client::Simple.connect(url) do |ws|
+            ws.on(:message) do |msg|
+              case msg.type
+              when :text
+                adapter.handle_envelope(msg.data)
+              when :pong
+                adapter.send(:handle_pong)
+              end
+            end
+            ws.on(:close) { |_event| adapter.send(:connection_ended!) }
+            ws.on(:error) { |error| adapter.send(:socket_errored, error) }
+          end
+          ping_loop
+        ensure
+          close_socket
+        end
+
+        # Sends pings on a fixed interval until the connection ends. Missed
+        # pongs beyond the threshold force a reconnect.
+        def ping_loop
+          until stopped? || @reconnect_requested
+            break if @connection_ended.pop(timeout: PING_INTERVAL_SECONDS)
+            if ping_tick
+              ai_helper_logger.warn "slack: #{MAX_MISSED_PONGS} pongs missed, reconnecting"
+              request_reconnect
+              break
+            end
+            @ws&.send("ping", type: :ping)
+          end
+        end
+
+        # Counts a sent ping without a pong reply yet. Returns true when the
+        # missed-pong threshold is exceeded and the connection should be
+        # dropped.
+        # @return [Boolean]
+        def ping_tick
+          @missed_pongs += 1
+          @missed_pongs > MAX_MISSED_PONGS
+        end
+
+        # A pong arrived: the connection is healthy.
+        def handle_pong
+          @missed_pongs = 0
+          ai_helper_logger.debug "slack: pong received"
+        end
+
+        # Asks the listen loop to end so #start reconnects with a fresh URL.
+        def request_reconnect
+          @reconnect_requested = true
+          @connection_ended&.push(true)
+        end
+
+        # The socket was closed by the remote side.
+        def connection_ended!
+          @connection_ended&.push(true)
+        end
+
+        # A socket error occurred; end the connection so #start can retry.
+        def socket_errored(error)
+          ai_helper_logger.error "slack: websocket error: #{error.message}"
+          @connection_ended&.push(true)
+        end
+
+        def close_socket
+          socket = @ws
+          @ws = nil
+          socket&.close
+        rescue IOError, SystemCallError => e
+          ai_helper_logger.debug "slack: error while closing socket: #{e.message}"
+        end
+
+        # Returns the current backoff delay and doubles it (capped).
+        # @return [Integer] seconds to wait
+        def next_backoff
+          current = @backoff
+          @backoff = [ @backoff * 2, MAX_BACKOFF_SECONDS ].min
+          current
+        end
+
+        # Resets the backoff after a successful connection.
+        def reset_backoff
+          @backoff = 1
+        end
+
+        # Sends the events_api ack immediately so Slack does not resend the
+        # event.
+        def acknowledge(envelope_id)
+          @ws&.send({ envelope_id: envelope_id }.to_json)
+        end
+
+        # Converts a Slack event into an IncomingMessage and dispatches it.
+        # Bot messages, the bot's own messages and subtyped events (edits,
+        # deletions) are discarded to avoid loops.
+        def process_event(event)
+          return if event["bot_id"].present?
+          return if event["subtype"].present?
+          return if event["user"].blank? || event["user"] == @bot_user_id
+
+          dm = event["type"] == "message" && event["channel_type"] == "im"
+          return unless dm || event["type"] == "app_mention"
+
+          thread_ts = event["thread_ts"].presence || event["ts"]
+          dispatch(IncomingMessage.new(
+            channel_type: channel_type,
+            channel_id: event["channel"],
+            thread_key: "#{event["channel"]}:#{thread_ts}",
+            text: strip_mention(event["text"].to_s),
+            external_user_id: event["user"],
+            dm: dm
+          ))
+        end
+
+        # Removes the bot mention markup from the question text.
+        def strip_mention(text)
+          text.gsub(/<@#{Regexp.escape(@bot_user_id.to_s)}>/, "").strip
+        end
+
+        # Splits a reply into chunks within the Slack message limit,
+        # preferring paragraph boundaries, then line boundaries, then a hard
+        # cut. No content is ever dropped.
+        # @param text [String] the full reply
+        # @return [Array<String>] the chunks to post in order
+        def split_text(text)
+          return [ text ] if text.length <= MAX_MESSAGE_LENGTH
+
+          chunks = []
+          remaining = text
+          while remaining.length > MAX_MESSAGE_LENGTH
+            slice = remaining[0, MAX_MESSAGE_LENGTH]
+            cut = slice.rindex("\n\n") || slice.rindex("\n") || MAX_MESSAGE_LENGTH
+            cut = MAX_MESSAGE_LENGTH if cut.zero?
+            chunks << remaining[0, cut]
+            remaining = remaining[cut..].to_s.sub(/\A\n+/, "")
+          end
+          chunks << remaining unless remaining.empty?
+          chunks
+        end
+
+        # Builds an HTTPS client with the contract timeouts.
+        # @param uri [URI] the request URI
+        # @return [Net::HTTP]
+        def build_http(uri)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true
+          http.open_timeout = HTTP_TIMEOUT_SECONDS
+          http.read_timeout = HTTP_TIMEOUT_SECONDS
+          http
+        end
+
+        # Calls a Slack Web API method. ok:false responses are raised as
+        # SlackApiError and never swallowed (FR-011). The token itself is
+        # never logged.
+        # @param method [String] API method name (e.g. "auth.test")
+        # @param token [String] Bearer token for the call
+        # @param params [Hash] form parameters
+        # @return [Hash] the parsed response body
+        def api_call(method, token:, params: {})
+          uri = URI("#{SLACK_API_BASE}/#{method}")
+          request = Net::HTTP::Post.new(uri.path)
+          request["Authorization"] = "Bearer #{token}"
+          request.set_form_data(params) unless params.empty?
+          response = build_http(uri).request(request)
+          body = JSON.parse(response.body)
+          raise SlackApiError, "Slack API #{method} failed: #{body["error"]}" unless body["ok"]
+          body
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -59,8 +59,11 @@ module RedmineAiHelper
 
         # Connects to Slack and blocks while receiving events. Reconnects on
         # disconnect envelopes (immediately, with a fresh URL), on socket
-        # errors (with exponential backoff) and on missed pongs. Auth errors
-        # (ok:false from the Web API) terminate without retry.
+        # errors (with exponential backoff), on missed pongs and on clean
+        # closes that never received hello (suspected handshake rejection,
+        # also backed off so a remote-side tight close loop cannot hammer
+        # apps.connections.open). Auth errors (ok:false from the Web API)
+        # terminate without retry.
         # @return [void]
         def start
           @stopped = false
@@ -70,7 +73,12 @@ module RedmineAiHelper
             url = open_connection_url
             begin
               listen(url)
-              reset_backoff if @reconnect_requested
+              if @reconnect_requested
+                reset_backoff
+              elsif !@connected
+                ai_helper_logger.warn "slack: connection ended without hello; backing off before reconnect"
+                sleep(next_backoff) unless stopped?
+              end
             rescue SlackApiError
               raise
             rescue => e
@@ -108,8 +116,6 @@ module RedmineAiHelper
           when "disconnect"
             ai_helper_logger.info "slack: disconnect requested by Slack (reason: #{data["reason"]})"
             request_reconnect
-          when "pong"
-            handle_pong
           when "events_api"
             acknowledge(data["envelope_id"])
             process_event(data.dig("payload", "event") || {})
@@ -150,6 +156,15 @@ module RedmineAiHelper
           timestamp = message.thread_key.split(":", 2).last
           api_call("reactions.add", token: settings.bot_token,
                    params: { channel: message.channel_id, timestamp: timestamp, name: "hourglass_flowing_sand" })
+        end
+
+        # Marks a SlackApiError as a fatal configuration/credential error so
+        # the gateway exits cleanly (exit 0) and is not restarted by the
+        # supervisor into the same broken configuration (ADR-006).
+        # @param error [Exception] the error raised by the adapter
+        # @return [Boolean]
+        def fatal_config_error?(error)
+          error.is_a?(SlackApiError)
         end
 
         private

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -133,6 +133,16 @@ module RedmineAiHelper
       def notify_processing(message:)
         raise NotImplementedError, "#{self.class.name} must implement #notify_processing"
       end
+
+      # Whether the given error is a fatal configuration/credential error
+      # that the supervisor (systemd) must not retry. Defaults to false;
+      # adapters override to classify their own credential errors so ADR-006
+      # ("credential problems are never retried") holds at the process level.
+      # @param _error [Exception] the error raised by the adapter
+      # @return [Boolean]
+      def fatal_config_error?(_error)
+        false
+      end
     end
   end
 end

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "redmine_ai_helper/logger"
+require "redmine_ai_helper/chat_channel/incoming_message"
+require "redmine_ai_helper/chat_channel/message_handler"
+
+module RedmineAiHelper
+  module ChatChannel
+    # Abstract base class for chat tool adapters. Subclasses are registered
+    # automatically on inheritance (same pattern as BaseAgent) and only need
+    # to implement the tool-specific interface: channel_type, start, stop,
+    # send_message, resolve_user_email and notify_processing.
+    class BaseAdapter
+      include RedmineAiHelper::Logger
+
+      class << self
+        # Adapter subclasses collected by the inherited hook. channel_type is
+        # resolved lazily in .adapters because it is not yet defined when
+        # inherited fires (the subclass body has not been evaluated).
+        # @return [Array<Class>]
+        def registered_subclasses
+          @registered_subclasses ||= []
+        end
+
+        # Registered adapter classes keyed by channel_type.
+        # @return [Hash{String => Class}]
+        def adapters
+          BaseAdapter.registered_subclasses.index_by(&:channel_type)
+        end
+
+        # Automatically registers subclasses (same pattern as BaseAgent).
+        # @param subclass [Class] The inheriting adapter class
+        # @return [void]
+        def inherited(subclass)
+          super
+          BaseAdapter.registered_subclasses << subclass
+        end
+
+        # Adapter identifier matching the channel_type column of bindings,
+        # channel conversations and adapter settings.
+        # @return [String]
+        def channel_type
+          raise NotImplementedError, "#{name} must implement .channel_type"
+        end
+
+        # Setting columns that must be present for the integration to run.
+        # @return [Array<Symbol>]
+        def required_setting_fields
+          []
+        end
+      end
+
+      # The gateway this adapter dispatches messages through. Set by the
+      # gateway when it starts the adapter; nil when the adapter runs
+      # standalone (e.g. in tests).
+      # @return [Gateway, nil]
+      attr_accessor :dispatcher
+
+      # The tool-independent message handler bound to this adapter.
+      # @return [MessageHandler]
+      def handler
+        @handler ||= MessageHandler.new(self)
+      end
+
+      # Hands a normalized message over for processing. When attached to a
+      # gateway the message is queued for the single worker thread; otherwise
+      # it is handled inline.
+      # @param message [IncomingMessage] the normalized message
+      # @return [void]
+      def dispatch(message)
+        if dispatcher
+          dispatcher.enqueue(self, message)
+        else
+          handler.handle(message)
+        end
+      end
+
+      # The settings row for this adapter.
+      # @return [AiHelperChatAdapterSetting]
+      def settings
+        AiHelperChatAdapterSetting.for_channel(channel_type)
+      end
+
+      # Whether the integration is enabled and all required setting fields
+      # are present.
+      # @return [Boolean]
+      def enabled?
+        setting = settings
+        return false unless setting.enabled
+
+        self.class.required_setting_fields.all? { |field| setting.send(field).present? }
+      end
+
+      # Instance-level logger access for adapters.
+      # @return [RedmineAiHelper::CustomLogger]
+      delegate :ai_helper_logger, to: :class
+
+      # Adapter identifier (delegates to the class-level declaration).
+      # @return [String]
+      delegate :channel_type, to: :class
+
+      # Connects to the external tool and blocks while receiving events.
+      # @return [void]
+      def start
+        raise NotImplementedError, "#{self.class.name} must implement #start"
+      end
+
+      # Closes the connection and lets #start return.
+      # @return [void]
+      def stop
+        raise NotImplementedError, "#{self.class.name} must implement #stop"
+      end
+
+      # Posts a reply into the given thread.
+      # @param channel_id [String] Channel identifier
+      # @param thread_key [String] Thread identifier
+      # @param text [String] Reply body
+      # @return [void]
+      def send_message(channel_id:, thread_key:, text:)
+        raise NotImplementedError, "#{self.class.name} must implement #send_message"
+      end
+
+      # Resolves the email address of an external user.
+      # @param external_user_id [String] Tool-specific user identifier
+      # @return [String, nil] The email address, or nil when unavailable
+      def resolve_user_email(external_user_id:)
+        raise NotImplementedError, "#{self.class.name} must implement #resolve_user_email"
+      end
+
+      # Shows a processing indicator for the given message.
+      # @param message [IncomingMessage] The message being processed
+      # @return [void]
+      def notify_processing(message:)
+        raise NotImplementedError, "#{self.class.name} must implement #notify_processing"
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/gateway.rb
+++ b/lib/redmine_ai_helper/chat_channel/gateway.rb
@@ -14,6 +14,13 @@ module RedmineAiHelper
     class Gateway
       include RedmineAiHelper::Logger
 
+      # Raised when the gateway cannot start (or an adapter terminated on a
+      # credential/configuration error). The supervisor (systemd) must not
+      # retry these — the operator has to fix the configuration first
+      # (ADR-006: "credential problems are never retried"). Rake rescues
+      # this and exits 0 so Restart=on-failure does not loop.
+      class ConfigurationError < StandardError; end
+
       # Upper bound of queued messages awaiting the worker.
       QUEUE_SIZE = 100
 
@@ -34,14 +41,15 @@ module RedmineAiHelper
       end
 
       # Starts all enabled adapters and blocks processing messages until
-      # #shutdown is called (SIGTERM/SIGINT). Raises when no adapter is
-      # enabled: the gateway never idles without a configured integration.
+      # #shutdown is called (SIGTERM/SIGINT). Raises ConfigurationError when
+      # no adapter is enabled: the gateway never idles without a configured
+      # integration, and configuration problems must not be retried.
       # @return [void]
       def run
         @adapters = build_enabled_adapters
         if @adapters.empty?
           ai_helper_logger.error "gateway: no enabled chat channel adapter found"
-          raise "No chat channel adapter is enabled. Configure one in the AI helper settings."
+          raise ConfigurationError, "No chat channel adapter is enabled. Configure one in the AI helper settings."
         end
 
         install_signal_handlers
@@ -77,29 +85,37 @@ module RedmineAiHelper
 
       # Runs one adapter's blocking receive loop in its own thread. A crashed
       # adapter takes the gateway down: errors must surface, not idle.
+      # Configuration/credential errors are wrapped in ConfigurationError so
+      # the supervisor can tell them apart from genuine crashes.
       def start_adapter_thread(adapter)
         adapter.dispatcher = self
         Thread.new do
           adapter.start
         rescue => e
           ai_helper_logger.error "gateway: adapter #{adapter.channel_type} terminated: #{e.full_message}"
-          @adapter_error = e
+          @adapter_error = adapter.fatal_config_error?(e) ? ConfigurationError.new(e.message) : e
           shutdown
         end
       end
 
       # Processes queued messages one at a time until shutdown, draining
-      # whatever was queued before the shutdown marker.
+      # whatever was queued before the shutdown marker. A single message
+      # that escapes the handler's own rescue is logged here and skipped,
+      # so the gateway never dies on a bad message.
       def worker_loop
         loop do
           item = @queue.pop
           break if item == SHUTDOWN
 
           adapter, message = item
-          ActiveRecord::Base.connection_pool.with_connection do
-            adapter.handler.handle(message)
+          begin
+            ActiveRecord::Base.connection_pool.with_connection do
+              adapter.handler.handle(message)
+            end
+            ai_helper_logger.info "gateway: processed message on #{adapter.channel_type} thread #{message.thread_key}"
+          rescue => e
+            ai_helper_logger.error "gateway: error processing message on #{adapter.channel_type}: #{e.full_message}"
           end
-          ai_helper_logger.info "gateway: processed message on #{adapter.channel_type} thread #{message.thread_key}"
         end
       end
 

--- a/lib/redmine_ai_helper/chat_channel/gateway.rb
+++ b/lib/redmine_ai_helper/chat_channel/gateway.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "redmine_ai_helper/logger"
+require "redmine_ai_helper/chat_channel/base_adapter"
+
+module RedmineAiHelper
+  # Abstraction layer connecting external chat tools (Slack etc.) to the AI
+  # helper: adapters, the shared message handler and the gateway process.
+  module ChatChannel
+    # Resident gateway process: starts every enabled adapter in its own
+    # receive thread and serializes all message processing through a single
+    # worker thread, so each question runs under its speaker's User.current
+    # without any concurrent permission context (research.md R-003).
+    class Gateway
+      include RedmineAiHelper::Logger
+
+      # Upper bound of queued messages awaiting the worker.
+      QUEUE_SIZE = 100
+
+      # Internal marker asking the worker loop to finish after draining.
+      SHUTDOWN = :shutdown
+
+      def initialize
+        @queue = SizedQueue.new(QUEUE_SIZE)
+        @shutdown_requested = false
+      end
+
+      # Queues a message received by an adapter thread for the worker.
+      # @param adapter [BaseAdapter] the adapter the message arrived on
+      # @param message [IncomingMessage] the normalized message
+      # @return [void]
+      def enqueue(adapter, message)
+        @queue << [ adapter, message ]
+      end
+
+      # Starts all enabled adapters and blocks processing messages until
+      # #shutdown is called (SIGTERM/SIGINT). Raises when no adapter is
+      # enabled: the gateway never idles without a configured integration.
+      # @return [void]
+      def run
+        @adapters = build_enabled_adapters
+        if @adapters.empty?
+          ai_helper_logger.error "gateway: no enabled chat channel adapter found"
+          raise "No chat channel adapter is enabled. Configure one in the AI helper settings."
+        end
+
+        install_signal_handlers
+        ai_helper_logger.info "gateway: starting adapters: #{@adapters.map(&:channel_type).join(", ")}"
+        threads = @adapters.map { |adapter| start_adapter_thread(adapter) }
+        worker_loop
+        threads.each { |thread| thread.join(5) }
+        ai_helper_logger.info "gateway: stopped"
+        raise @adapter_error if @adapter_error
+      end
+
+      # Stops all adapters and lets the worker drain the queue and exit.
+      # @return [void]
+      def shutdown
+        return if @shutdown_requested
+        @shutdown_requested = true
+        ai_helper_logger.info "gateway: shutdown requested"
+        (@adapters || []).each do |adapter|
+          adapter.stop
+        rescue => e
+          ai_helper_logger.error "gateway: error stopping #{adapter.channel_type}: #{e.message}"
+        end
+        @queue << SHUTDOWN
+      end
+
+      private
+
+      # Instantiates every registered adapter and keeps the enabled ones.
+      # @return [Array<BaseAdapter>]
+      def build_enabled_adapters
+        BaseAdapter.adapters.values.map(&:new).select(&:enabled?)
+      end
+
+      # Runs one adapter's blocking receive loop in its own thread. A crashed
+      # adapter takes the gateway down: errors must surface, not idle.
+      def start_adapter_thread(adapter)
+        adapter.dispatcher = self
+        Thread.new do
+          adapter.start
+        rescue => e
+          ai_helper_logger.error "gateway: adapter #{adapter.channel_type} terminated: #{e.full_message}"
+          @adapter_error = e
+          shutdown
+        end
+      end
+
+      # Processes queued messages one at a time until shutdown, draining
+      # whatever was queued before the shutdown marker.
+      def worker_loop
+        loop do
+          item = @queue.pop
+          break if item == SHUTDOWN
+
+          adapter, message = item
+          ActiveRecord::Base.connection_pool.with_connection do
+            adapter.handler.handle(message)
+          end
+          ai_helper_logger.info "gateway: processed message on #{adapter.channel_type} thread #{message.thread_key}"
+        end
+      end
+
+      # SIGTERM/SIGINT trigger a graceful shutdown. The handler body runs in
+      # a new thread because trap context forbids blocking operations.
+      def install_signal_handlers
+        %w[TERM INT].each do |signal|
+          Signal.trap(signal) { Thread.new { shutdown } }
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/incoming_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/incoming_message.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RedmineAiHelper
+  module ChatChannel
+    # Value object holding a chat tool event normalized by an adapter.
+    # Adapters guarantee that +text+ has mention markup removed and that
+    # bot-originated events are never wrapped in an IncomingMessage.
+    class IncomingMessage
+      attr_reader :channel_type, :channel_id, :thread_key, :text, :external_user_id
+
+      # @param channel_type [String] Adapter identifier (e.g. "slack")
+      # @param channel_id [String] Channel identifier (DM channel id for DMs)
+      # @param thread_key [String] Tool-specific thread identifier
+      # @param text [String] Question body with mention markup removed
+      # @param external_user_id [String] Tool-specific user identifier
+      # @param dm [Boolean] Whether the message is a direct message
+      def initialize(channel_type:, channel_id:, thread_key:, text:, external_user_id:, dm: false)
+        @channel_type = channel_type
+        @channel_id = channel_id
+        @thread_key = thread_key
+        @text = text
+        @external_user_id = external_user_id
+        @dm = dm
+      end
+
+      # Whether the message is a direct message.
+      # @return [Boolean]
+      def dm?
+        @dm
+      end
+
+      alias dm dm?
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/incoming_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/incoming_message.rb
@@ -28,8 +28,6 @@ module RedmineAiHelper
       def dm?
         @dm
       end
-
-      alias dm dm?
     end
   end
 end

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -34,7 +34,12 @@ module RedmineAiHelper
       # @param message [IncomingMessage] The message to process
       # @return [void]
       def handle(message)
-        @adapter.notify_processing(message: message)
+        user = nil
+        begin
+          @adapter.notify_processing(message: message)
+        rescue => e
+          ai_helper_logger.warn "chat channel: failed to notify processing: #{e.full_message}"
+        end
 
         user = resolve_user(message)
         return reply(message, guidance(:user_not_mapped, nil)) unless user
@@ -50,7 +55,11 @@ module RedmineAiHelper
         reply(message, answer.content)
       rescue => e
         ai_helper_logger.error "chat channel processing failed: #{e.full_message}"
-        reply(message, guidance(:processing_failed, user))
+        begin
+          reply(message, guidance(:processing_failed, user))
+        rescue => reply_error
+          ai_helper_logger.error "chat channel: failed to post error notice: #{reply_error.full_message}"
+        end
       end
 
       private
@@ -58,6 +67,8 @@ module RedmineAiHelper
       # Resolves the Redmine user for the message speaker by email address.
       # Results (including "no match") are cached in memory with a TTL so
       # repeated questions do not hit the external user API every time.
+      # Expired entries are swept on write so the cache cannot grow without
+      # bound for the lifetime of the resident gateway process.
       # @return [User, nil]
       def resolve_user(message)
         cached = @user_cache[message.external_user_id]
@@ -65,7 +76,9 @@ module RedmineAiHelper
 
         email = @adapter.resolve_user_email(external_user_id: message.external_user_id)
         user = email.blank? ? nil : User.active.having_mail(email).first
-        @user_cache[message.external_user_id] = { user: user, expires_at: Time.zone.now + USER_CACHE_TTL }
+        now = Time.zone.now
+        @user_cache.delete_if { |_id, entry| entry[:expires_at] <= now }
+        @user_cache[message.external_user_id] = { user: user, expires_at: now + USER_CACHE_TTL }
         user
       end
 

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "redmine_ai_helper/logger"
+
+module RedmineAiHelper
+  module ChatChannel
+    # Tool-independent core processing for messages received from chat tool
+    # adapters: resolves the Redmine user and project, binds the thread to a
+    # conversation and runs the LLM under the speaker's own permissions.
+    # #handle is only ever called from the gateway's single worker thread, so
+    # User.current is safe to set and restore within one call.
+    class MessageHandler
+      include RedmineAiHelper::Logger
+
+      # Streaming callback used with Llm#chat; replies are posted in one piece.
+      NOOP_PROC = proc { |_content| }
+
+      # Maximum length of a conversation title taken from the first question.
+      TITLE_MAX_LENGTH = 50
+
+      # How long a resolved external user (or the "no match" result) stays
+      # cached in memory (research.md R-005).
+      USER_CACHE_TTL = 10.minutes
+
+      # @param adapter [BaseAdapter] The adapter this handler replies through
+      def initialize(adapter)
+        @adapter = adapter
+        @user_cache = {}
+      end
+
+      # Processes one normalized incoming message end to end. Errors are
+      # reported back into the thread and logged; they are never swallowed
+      # silently (FR-011).
+      # @param message [IncomingMessage] The message to process
+      # @return [void]
+      def handle(message)
+        @adapter.notify_processing(message: message)
+
+        user = resolve_user(message)
+        return reply(message, guidance(:user_not_mapped, nil)) unless user
+
+        project = resolve_project(message)
+        unless project
+          key = message.dm? ? :dm_not_configured : :channel_not_bound
+          return reply(message, guidance(key, user))
+        end
+        return reply(message, guidance(:module_disabled, user)) unless project.module_enabled?(:ai_helper)
+
+        answer = process_question(message, user, project)
+        reply(message, answer.content)
+      rescue => e
+        ai_helper_logger.error "chat channel processing failed: #{e.full_message}"
+        reply(message, guidance(:processing_failed, user))
+      end
+
+      private
+
+      # Resolves the Redmine user for the message speaker by email address.
+      # Results (including "no match") are cached in memory with a TTL so
+      # repeated questions do not hit the external user API every time.
+      # @return [User, nil]
+      def resolve_user(message)
+        cached = @user_cache[message.external_user_id]
+        return cached[:user] if cached && cached[:expires_at] > Time.zone.now
+
+        email = @adapter.resolve_user_email(external_user_id: message.external_user_id)
+        user = email.blank? ? nil : User.active.having_mail(email).first
+        @user_cache[message.external_user_id] = { user: user, expires_at: Time.zone.now + USER_CACHE_TTL }
+        user
+      end
+
+      # Resolves the target project from the channel binding, or from the
+      # adapter's DM default project for direct messages.
+      # @return [Project, nil]
+      def resolve_project(message)
+        if message.dm?
+          AiHelperChatAdapterSetting.for_channel(message.channel_type).dm_default_project
+        else
+          AiHelperChannelBinding.for_channel(message.channel_type, message.channel_id).first&.project
+        end
+      end
+
+      # Appends the question to the thread's conversation and runs the LLM
+      # under the speaker's own permissions.
+      # @return [AiHelperMessage] The assistant's answer
+      def process_question(message, user, project)
+        conversation = AiHelperChannelConversation.find_or_create_conversation(
+          channel_type: message.channel_type, thread_key: message.thread_key, user: user
+        )
+        if conversation.messages.empty?
+          conversation.title = message.text.truncate(TITLE_MAX_LENGTH)
+        end
+        conversation.messages << AiHelperMessage.new(role: "user", content: message.text)
+        conversation.save!
+
+        begin
+          User.current = user
+          answer = RedmineAiHelper::Llm.new.chat(conversation, NOOP_PROC, { project: project })
+        ensure
+          User.current = User.anonymous
+        end
+
+        conversation.messages << answer
+        conversation.save!
+        answer
+      end
+
+      # Posts a reply into the thread the message came from.
+      def reply(message, text)
+        @adapter.send_message(channel_id: message.channel_id, thread_key: message.thread_key, text: text)
+      end
+
+      # Localized guidance text, preferring the resolved user's language.
+      def guidance(key, user)
+        locale = user&.language.presence || Setting.default_language
+        I18n.t("ai_helper.chat_channel.errors.#{key}", locale: locale)
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/project_patch.rb
+++ b/lib/redmine_ai_helper/project_patch.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RedmineAiHelper
+  # Patch for Project model to add AI Helper associations
+  module ProjectPatch
+    # Hook to extend Project model
+    # @param base [Class] The Project class
+    def self.included(base)
+      base.class_eval do
+        has_many :ai_helper_channel_bindings, class_name: "AiHelperChannelBinding", dependent: :destroy
+      end
+    end
+  end
+end
+
+unless Project.included_modules.include?(RedmineAiHelper::ProjectPatch)
+  Project.include RedmineAiHelper::ProjectPatch
+end

--- a/lib/tasks/chat_channel.rake
+++ b/lib/tasks/chat_channel.rake
@@ -7,6 +7,12 @@ namespace :redmine do
         desc "Start the chat channel gateway (resident process for Slack etc.)"
         task gateway: :environment do
           RedmineAiHelper::ChatChannel::Gateway.new.run
+        rescue RedmineAiHelper::ChatChannel::Gateway::ConfigurationError => e
+          # Configuration/credential errors must not be retried (ADR-006).
+          # The message has already been logged by the gateway; exit 0 so
+          # systemd's Restart=on-failure does not loop into the same failure.
+          warn "chat_channel gateway: #{e.message}"
+          exit 0
         end
       end
     end

--- a/lib/tasks/chat_channel.rake
+++ b/lib/tasks/chat_channel.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :redmine do
+  namespace :plugins do
+    namespace :ai_helper do
+      namespace :chat_channel do
+        desc "Start the chat channel gateway (resident process for Slack etc.)"
+        task gateway: :environment do
+          RedmineAiHelper::ChatChannel::Gateway.new.run
+        end
+      end
+    end
+  end
+end

--- a/test/functional/ai_helper_channel_bindings_controller_test.rb
+++ b/test/functional/ai_helper_channel_bindings_controller_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class AiHelperChannelBindingsControllerTest < ActionController::TestCase
+  fixtures :projects, :users
+
+  setup do
+    AiHelperChannelBinding.delete_all
+    @request.session[:user_id] = 1
+  end
+
+  context "create" do
+    should "create a binding and redirect to the channels tab" do
+      post :create, params: {
+        ai_helper_channel_binding: {
+          channel_type: "slack", channel_id: "C123", channel_name: "#dev", project_id: 1
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      binding = AiHelperChannelBinding.for_channel("slack", "C123").first
+      assert_not_nil binding
+      assert_equal "#dev", binding.channel_name
+      assert_equal 1, binding.project_id
+    end
+
+    should "reject a duplicate channel with an error message" do
+      AiHelperChannelBinding.create!(channel_type: "slack", channel_id: "C123", project_id: 1)
+
+      post :create, params: {
+        ai_helper_channel_binding: {
+          channel_type: "slack", channel_id: "C123", project_id: 2
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      assert_predicate flash[:error], :present?
+      assert_equal 1, AiHelperChannelBinding.count
+    end
+
+    should "be forbidden for non-admin users" do
+      @request.session[:user_id] = 2
+
+      post :create, params: {
+        ai_helper_channel_binding: {
+          channel_type: "slack", channel_id: "C999", project_id: 1
+        }
+      }
+
+      assert_response :forbidden
+      assert_equal 0, AiHelperChannelBinding.count
+    end
+  end
+
+  context "destroy" do
+    setup do
+      @binding = AiHelperChannelBinding.create!(channel_type: "slack", channel_id: "C123", project_id: 1)
+    end
+
+    should "delete the binding and redirect to the channels tab" do
+      delete :destroy, params: { id: @binding.id }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      assert_nil AiHelperChannelBinding.find_by(id: @binding.id)
+    end
+
+    should "be forbidden for non-admin users" do
+      @request.session[:user_id] = 2
+
+      delete :destroy, params: { id: @binding.id }
+
+      assert_response :forbidden
+      assert_not_nil AiHelperChannelBinding.find_by(id: @binding.id)
+    end
+  end
+end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -661,5 +661,65 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "#tab-content-channels", text: /C111/
       assert_select "#tab-content-channels", text: /#dev/
     end
+
+    should "not render the raw app or bot token value in the HTML source" do
+      AiHelperChatAdapterSetting.create!(
+        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-supersecret-value"
+      )
+
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_no_match(/xoxb-supersecret-value/, @response.body)
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][bot_token]'][value=?]",
+                    AiHelperSettingsController::DUMMY_TOKEN
+    end
+
+    should "render the masked token next to the field when a token is stored" do
+      AiHelperChatAdapterSetting.create!(
+        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-supersecret-value"
+      )
+
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#tab-content-channels em.info", text: /xoxb\*+/
+    end
+
+    should "preserve the stored token when the dummy value is submitted unchanged" do
+      AiHelperChatAdapterSetting.create!(
+        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-original"
+      )
+
+      post :update, params: {
+        tab: "channels",
+        ai_helper_setting: {},
+        chat_adapter_settings: {
+          "ui_chat" => { "enabled" => "1", "bot_token" => AiHelperSettingsController::DUMMY_TOKEN }
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      assert_equal "xoxb-original", AiHelperChatAdapterSetting.for_channel("ui_chat").bot_token
+    end
+
+    should "roll back adapter settings when the global setting is invalid" do
+      existing = AiHelperChatAdapterSetting.create!(
+        channel_type: "ui_chat", enabled: false, bot_token: "xoxb-old"
+      )
+
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: { attachment_send_enabled: "1", attachment_max_size_mb: "0" },
+        chat_adapter_settings: {
+          "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-new" }
+        }
+      }
+
+      assert_response :success
+      existing.reload
+      assert_not existing.enabled, "adapter must not be partially persisted when the global setting is invalid"
+      assert_equal "xoxb-old", existing.bot_token
+    end
   end
 end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -585,4 +585,81 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "input[type=hidden][name=tab][value=vector]"
     end
   end
+
+  # Test-only chat adapter registered for the channels tab tests, so the tab
+  # UI can be verified without depending on any concrete adapter.
+  class FakeUiAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    class << self
+      def channel_type
+        "ui_chat"
+      end
+
+      def required_setting_fields
+        [ :bot_token ]
+      end
+    end
+  end
+
+  context "channels tab" do
+    setup do
+      AiHelperChatAdapterSetting.delete_all
+      AiHelperChannelBinding.delete_all
+    end
+
+    should "render the channels tab link" do
+      get :index
+
+      assert_response :success
+      assert_select ".tabs a#tab-channels"
+    end
+
+    should "render a settings section for each registered adapter" do
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][enabled]']"
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][bot_token]'][type=password]"
+      assert_select "#tab-content-channels select[name='chat_adapter_settings[ui_chat][dm_default_project_id]']"
+    end
+
+    should "save adapter settings from the channels tab" do
+      post :update, params: {
+        tab: "channels",
+        ai_helper_setting: { additional_instructions: "keep" },
+        chat_adapter_settings: {
+          "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-ui", "dm_default_project_id" => "1" }
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      setting = AiHelperChatAdapterSetting.for_channel("ui_chat")
+      assert setting.enabled
+      assert_equal "xoxb-ui", setting.bot_token
+      assert_equal 1, setting.dm_default_project_id
+    end
+
+    should "re-render the channels tab when adapter settings are invalid" do
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {},
+        chat_adapter_settings: {
+          "ui_chat" => { "enabled" => "1", "bot_token" => "" }
+        }
+      }
+
+      assert_response :success
+      assert_equal "channels", assigns(:selected_tab)
+      assert_not AiHelperChatAdapterSetting.enabled?("ui_chat")
+    end
+
+    should "list existing channel bindings in the channels tab" do
+      AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
+
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#tab-content-channels", text: /C111/
+      assert_select "#tab-content-channels", text: /#dev/
+    end
+  end
 end

--- a/test/model_factory.rb
+++ b/test/model_factory.rb
@@ -13,4 +13,27 @@ FactoryBot.define do
     homepage { "http://example.com" }
     is_public { true }
   end
+
+  factory :ai_helper_chat_adapter_setting do
+    channel_type { "slack" }
+    enabled { false }
+  end
+
+  factory :ai_helper_channel_binding do
+    channel_type { "slack" }
+    sequence(:channel_id) { |n| "C#{n.to_s.rjust(7, '0')}" }
+    channel_name { "#general" }
+    project
+  end
+
+  factory :ai_helper_conversation do
+    sequence(:title) { |n| "Conversation #{n}" }
+    user { User.find(1) }
+  end
+
+  factory :ai_helper_channel_conversation do
+    channel_type { "slack" }
+    sequence(:thread_key) { |n| "C0000001:1700000000.#{n.to_s.rjust(6, '0')}" }
+    association :conversation, factory: :ai_helper_conversation
+  end
 end

--- a/test/unit/ai_helper_channel_binding_test.rb
+++ b/test/unit/ai_helper_channel_binding_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", __FILE__)
+
+class AiHelperChannelBindingTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  fixtures :projects
+
+  context "validations" do
+    should "require channel_type, channel_id and project" do
+      binding = AiHelperChannelBinding.new
+
+      assert_not binding.valid?
+      assert_predicate binding.errors[:channel_type], :present?
+      assert_predicate binding.errors[:channel_id], :present?
+      assert_predicate binding.errors[:project], :present?
+    end
+
+    should "be valid with channel_type, channel_id and project" do
+      binding = build(:ai_helper_channel_binding, project: Project.find(1))
+
+      assert_predicate binding, :valid?
+    end
+
+    should "reject a duplicate channel_id for the same channel_type" do
+      create(:ai_helper_channel_binding, channel_id: "C1234567", project: Project.find(1))
+      duplicate = build(:ai_helper_channel_binding, channel_id: "C1234567", project: Project.find(2))
+
+      assert_not duplicate.valid?
+      assert_predicate duplicate.errors[:channel_id], :present?
+    end
+
+    should "allow the same channel_id for a different channel_type" do
+      create(:ai_helper_channel_binding, channel_id: "C1234567", project: Project.find(1))
+      other = build(:ai_helper_channel_binding, channel_type: "discord", channel_id: "C1234567", project: Project.find(2))
+
+      assert_predicate other, :valid?
+    end
+  end
+
+  context "for_channel scope" do
+    should "return the binding matching channel_type and channel_id" do
+      binding = create(:ai_helper_channel_binding, channel_id: "C7654321", project: Project.find(1))
+
+      assert_equal binding, AiHelperChannelBinding.for_channel("slack", "C7654321").first
+    end
+
+    should "return no bindings for an unknown channel" do
+      create(:ai_helper_channel_binding, channel_id: "C7654321", project: Project.find(1))
+
+      assert_empty AiHelperChannelBinding.for_channel("slack", "C0000000")
+    end
+  end
+
+  context "project deletion" do
+    should "delete bindings when the project is destroyed" do
+      project = create(:project)
+      binding = create(:ai_helper_channel_binding, project: project)
+
+      project.destroy
+
+      assert_nil AiHelperChannelBinding.find_by(id: binding.id)
+    end
+  end
+end

--- a/test/unit/ai_helper_channel_conversation_test.rb
+++ b/test/unit/ai_helper_channel_conversation_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", __FILE__)
+
+class AiHelperChannelConversationTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  fixtures :users
+
+  context "validations" do
+    should "require channel_type, thread_key and conversation" do
+      channel_conversation = AiHelperChannelConversation.new
+
+      assert_not channel_conversation.valid?
+      assert_predicate channel_conversation.errors[:channel_type], :present?
+      assert_predicate channel_conversation.errors[:thread_key], :present?
+      assert_predicate channel_conversation.errors[:conversation], :present?
+    end
+
+    should "reject a duplicate thread_key for the same channel_type" do
+      create(:ai_helper_channel_conversation, thread_key: "C1:100.000001")
+      duplicate = build(:ai_helper_channel_conversation, thread_key: "C1:100.000001")
+
+      assert_not duplicate.valid?
+      assert_predicate duplicate.errors[:thread_key], :present?
+    end
+
+    should "allow the same thread_key for a different channel_type" do
+      create(:ai_helper_channel_conversation, thread_key: "C1:100.000001")
+      other = build(:ai_helper_channel_conversation, channel_type: "discord", thread_key: "C1:100.000001")
+
+      assert_predicate other, :valid?
+    end
+  end
+
+  context "find_or_create_conversation" do
+    should "create a new conversation owned by the given user" do
+      user = User.find(2)
+      conversation = AiHelperChannelConversation.find_or_create_conversation(
+        channel_type: "slack", thread_key: "C9:200.000001", user: user
+      )
+
+      assert_predicate conversation, :persisted?
+      assert_equal user, conversation.user
+      channel_conversation = AiHelperChannelConversation.find_by(channel_type: "slack", thread_key: "C9:200.000001")
+      assert_equal conversation, channel_conversation.conversation
+    end
+
+    should "return the existing conversation for a known thread" do
+      user = User.find(2)
+      first = AiHelperChannelConversation.find_or_create_conversation(
+        channel_type: "slack", thread_key: "C9:200.000002", user: user
+      )
+      second = AiHelperChannelConversation.find_or_create_conversation(
+        channel_type: "slack", thread_key: "C9:200.000002", user: User.find(3)
+      )
+
+      assert_equal first.id, second.id
+      assert_equal 1, AiHelperChannelConversation.where(thread_key: "C9:200.000002").count
+    end
+
+    should "keep the original owner when another user continues the thread" do
+      starter = User.find(2)
+      AiHelperChannelConversation.find_or_create_conversation(
+        channel_type: "slack", thread_key: "C9:200.000003", user: starter
+      )
+      conversation = AiHelperChannelConversation.find_or_create_conversation(
+        channel_type: "slack", thread_key: "C9:200.000003", user: User.find(3)
+      )
+
+      assert_equal starter, conversation.user
+    end
+  end
+
+  context "conversation deletion" do
+    should "delete the channel conversation when the conversation is destroyed" do
+      channel_conversation = create(:ai_helper_channel_conversation)
+
+      channel_conversation.conversation.destroy
+
+      assert_nil AiHelperChannelConversation.find_by(id: channel_conversation.id)
+    end
+  end
+end

--- a/test/unit/ai_helper_chat_adapter_setting_test.rb
+++ b/test/unit/ai_helper_chat_adapter_setting_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", __FILE__)
+
+class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  fixtures :projects
+
+  # Test-only adapter declaring required setting fields, used to verify the
+  # enable-time validation contract without depending on the Slack adapter.
+  class FakeSettingAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    class << self
+      def channel_type
+        "fake_setting_chat"
+      end
+
+      def required_setting_fields
+        [ :app_token, :bot_token ]
+      end
+    end
+  end
+
+  context "validations" do
+    should "require channel_type" do
+      setting = AiHelperChatAdapterSetting.new
+
+      assert_not setting.valid?
+      assert_predicate setting.errors[:channel_type], :present?
+    end
+
+    should "reject a duplicate channel_type" do
+      create(:ai_helper_chat_adapter_setting, channel_type: "slack")
+      duplicate = build(:ai_helper_chat_adapter_setting, channel_type: "slack")
+
+      assert_not duplicate.valid?
+      assert_predicate duplicate.errors[:channel_type], :present?
+    end
+
+    should "require the adapter's required fields when enabled" do
+      setting = AiHelperChatAdapterSetting.new(channel_type: "fake_setting_chat", enabled: true)
+
+      assert_not setting.valid?
+      assert_predicate setting.errors[:app_token], :present?
+      assert_predicate setting.errors[:bot_token], :present?
+    end
+
+    should "be valid when enabled with all required fields present" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat", enabled: true,
+        app_token: "xapp-test", bot_token: "xoxb-test"
+      )
+
+      assert_predicate setting, :valid?
+    end
+
+    should "not require adapter fields when disabled" do
+      setting = AiHelperChatAdapterSetting.new(channel_type: "fake_setting_chat", enabled: false)
+
+      assert_predicate setting, :valid?
+    end
+  end
+
+  context "safe_attributes" do
+    should "accept enabled, tokens and dm_default_project_id" do
+      setting = create(:ai_helper_chat_adapter_setting)
+      setting.safe_attributes = {
+        "enabled" => "1",
+        "app_token" => "xapp-abc",
+        "bot_token" => "xoxb-abc",
+        "dm_default_project_id" => "1"
+      }
+
+      assert setting.enabled
+      assert_equal "xapp-abc", setting.app_token
+      assert_equal "xoxb-abc", setting.bot_token
+      assert_equal 1, setting.dm_default_project_id
+    end
+
+    should "not allow changing channel_type" do
+      setting = create(:ai_helper_chat_adapter_setting)
+      setting.safe_attributes = { "channel_type" => "discord" }
+
+      assert_equal "slack", setting.channel_type
+    end
+  end
+
+  context "for_channel" do
+    should "return the persisted setting when it exists" do
+      setting = create(:ai_helper_chat_adapter_setting)
+
+      assert_equal setting, AiHelperChatAdapterSetting.for_channel("slack")
+    end
+
+    should "return a new record for an unknown channel_type" do
+      setting = AiHelperChatAdapterSetting.for_channel("unknown_chat")
+
+      assert_predicate setting, :new_record?
+      assert_equal "unknown_chat", setting.channel_type
+    end
+  end
+
+  context "class method enabled?" do
+    should "return true when the setting row is enabled" do
+      create(:ai_helper_chat_adapter_setting, channel_type: "fake_setting_chat", enabled: true, app_token: "xapp-a", bot_token: "xoxb-b")
+
+      assert AiHelperChatAdapterSetting.enabled?("fake_setting_chat")
+    end
+
+    should "return false when no setting row exists" do
+      assert_not AiHelperChatAdapterSetting.enabled?("missing_chat")
+    end
+  end
+
+  context "dm_default_project" do
+    should "return the associated project" do
+      setting = create(:ai_helper_chat_adapter_setting, dm_default_project_id: 1)
+
+      assert_equal Project.find(1), setting.dm_default_project
+    end
+  end
+
+  context "masked tokens" do
+    should "mask all but the first four characters" do
+      setting = AiHelperChatAdapterSetting.new(app_token: "xapp-123456", bot_token: "xoxb-abcdef")
+
+      assert_equal "xapp#{'*' * 7}", setting.masked_app_token
+      assert_equal "xoxb#{'*' * 7}", setting.masked_bot_token
+    end
+
+    should "return the token unchanged when blank or short" do
+      setting = AiHelperChatAdapterSetting.new(app_token: nil, bot_token: "abc")
+
+      assert_nil setting.masked_app_token
+      assert_equal "abc", setting.masked_bot_token
+    end
+  end
+end

--- a/test/unit/ai_helper_settings_helper_test.rb
+++ b/test/unit/ai_helper_settings_helper_test.rb
@@ -6,11 +6,11 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
   include AiHelperSettingsHelper
 
   context "ai_helper_settings_tabs" do
-    should "return 3 tab definitions in order: general, model, vector" do
+    should "return 4 tab definitions in order: general, model, vector, channels" do
       f = build_form_builder
       tabs = ai_helper_settings_tabs(f)
 
-      assert_equal 3, tabs.length
+      assert_equal 4, tabs.length
 
       assert_equal "general", tabs[0][:name]
       assert_equal "ai_helper_settings/general_tab", tabs[0][:partial]
@@ -26,6 +26,11 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
       assert_equal "ai_helper_settings/vector_tab", tabs[2][:partial]
       assert_equal :"ai_helper.settings.tab_vector", tabs[2][:label]
       assert_equal f, tabs[2][:f]
+
+      assert_equal "channels", tabs[3][:name]
+      assert_equal "ai_helper_settings/channels_tab", tabs[3][:partial]
+      assert_equal :"ai_helper.settings.tab_channels", tabs[3][:label]
+      assert_equal f, tabs[3][:f]
     end
   end
 

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -149,11 +149,12 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       @adapter.stubs(:fetch_bot_user_id).returns("B001")
       @adapter.stubs(:open_connection_url).returns("wss://example")
       slept = []
-      @adapter.stubs(:sleep) { |seconds| slept << seconds }
+      @adapter.stubs(:sleep).with { |seconds| slept << seconds; true }
       call_count = 0
-      @adapter.stubs(:listen) do
+      @adapter.stubs(:listen).with do |_url|
         call_count += 1
         @adapter.stop if call_count == 2
+        true
       end
 
       @adapter.start

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../../test_helper", __FILE__)
+
+class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  setup do
+    AiHelperChatAdapterSetting.delete_all
+    create(:ai_helper_chat_adapter_setting,
+           channel_type: "slack", enabled: true,
+           app_token: "xapp-secret", bot_token: "xoxb-secret")
+    @adapter = RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.new
+  end
+
+  def stub_api_response(body)
+    stub(body: body.to_json)
+  end
+
+  context "registration and settings" do
+    should "declare channel_type slack" do
+      assert_equal "slack", RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.channel_type
+      assert_equal RedmineAiHelper::ChatChannel::Adapters::SlackAdapter,
+                   RedmineAiHelper::ChatChannel::BaseAdapter.adapters["slack"]
+    end
+
+    should "require both tokens" do
+      assert_equal [ :app_token, :bot_token ],
+                   RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.required_setting_fields
+    end
+
+    should "be enabled with tokens present" do
+      assert_predicate @adapter, :enabled?
+    end
+  end
+
+  context "web api" do
+    should "configure open and read timeouts of 10 seconds" do
+      http = @adapter.send(:build_http, URI("https://slack.com/api/auth.test"))
+
+      assert_equal 10, http.open_timeout
+      assert_equal 10, http.read_timeout
+    end
+
+    should "raise on ok:false responses" do
+      Net::HTTP.any_instance.stubs(:request).returns(stub_api_response({ "ok" => false, "error" => "invalid_auth" }))
+
+      error = assert_raises(RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError) do
+        @adapter.send(:api_call, "auth.test", token: "xoxb-secret")
+      end
+      assert_match(/invalid_auth/, error.message)
+    end
+
+    should "return the parsed body on success" do
+      Net::HTTP.any_instance.stubs(:request).returns(stub_api_response({ "ok" => true, "url" => "wss://example" }))
+
+      body = @adapter.send(:api_call, "apps.connections.open", token: "xapp-secret")
+
+      assert_equal "wss://example", body["url"]
+    end
+  end
+
+  context "connection lifecycle" do
+    should "obtain the websocket url with the app token" do
+      @adapter.expects(:api_call).with("apps.connections.open", token: "xapp-secret").returns({ "ok" => true, "url" => "wss://example" })
+
+      assert_equal "wss://example", @adapter.send(:open_connection_url)
+    end
+
+    should "terminate without retry when apps.connections.open fails" do
+      @adapter.stubs(:fetch_bot_user_id).returns("B001")
+      @adapter.expects(:open_connection_url).once.raises(
+        RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError, "invalid_auth"
+      )
+      @adapter.expects(:listen).never
+
+      assert_raises(RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError) { @adapter.start }
+    end
+
+    should "terminate without retry when auth.test fails" do
+      @adapter.expects(:fetch_bot_user_id).raises(
+        RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError, "invalid_auth"
+      )
+      @adapter.expects(:open_connection_url).never
+
+      assert_raises(RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError) { @adapter.start }
+    end
+
+    should "fetch the bot user id via auth.test on start" do
+      @adapter.expects(:api_call).with("auth.test", token: "xoxb-secret").returns({ "ok" => true, "user_id" => "B001" })
+      @adapter.expects(:open_connection_url).with { @adapter.stop; true }.returns("wss://example")
+      @adapter.stubs(:listen)
+
+      @adapter.start
+
+      assert_equal "B001", @adapter.bot_user_id
+    end
+
+    should "reconnect with a new url after a disconnect envelope" do
+      @adapter.stubs(:fetch_bot_user_id).returns("B001")
+      urls = sequence("urls")
+      @adapter.expects(:open_connection_url).twice.in_sequence(urls).returns("wss://one", "wss://two")
+      listened = []
+      @adapter.stubs(:listen).with do |url|
+        listened << url
+        @adapter.handle_envelope({ "type" => "disconnect", "reason" => "refresh" }.to_json) if listened.size == 1
+        @adapter.stop if listened.size == 2
+        true
+      end
+
+      @adapter.start
+
+      assert_equal [ "wss://one", "wss://two" ], listened
+    end
+
+    should "back off exponentially from 1 up to 60 seconds" do
+      expected = [ 1, 2, 4, 8, 16, 32, 60, 60 ]
+
+      assert_equal(expected, (1..8).map { @adapter.send(:next_backoff) })
+    end
+
+    should "reset the backoff after a successful connection" do
+      3.times { @adapter.send(:next_backoff) }
+      @adapter.send(:reset_backoff)
+
+      assert_equal 1, @adapter.send(:next_backoff)
+    end
+
+    should "request a reconnect after two missed pongs" do
+      assert_not @adapter.send(:ping_tick)
+      assert_not @adapter.send(:ping_tick)
+      assert @adapter.send(:ping_tick)
+    end
+
+    should "reset missed pongs when a pong arrives" do
+      @adapter.send(:ping_tick)
+      @adapter.handle_envelope({ "type" => "pong" }.to_json)
+      assert_not @adapter.send(:ping_tick)
+      assert_not @adapter.send(:ping_tick)
+    end
+
+    should "log the connection establishment on hello" do
+      @adapter.handle_envelope({ "type" => "hello" }.to_json)
+
+      assert_predicate @adapter, :connected?
+    end
+  end
+
+  # Records messages dispatched by the adapter in place of the gateway.
+  class RecordingDispatcher
+    attr_reader :messages
+
+    def initialize
+      @messages = []
+    end
+
+    def enqueue(_adapter, message)
+      @messages << message
+    end
+  end
+
+  def events_envelope(event, envelope_id: "env-1")
+    {
+      "type" => "events_api",
+      "envelope_id" => envelope_id,
+      "payload" => { "event" => event }
+    }.to_json
+  end
+
+  context "events_api envelopes" do
+    setup do
+      @dispatcher = RecordingDispatcher.new
+      @adapter.dispatcher = @dispatcher
+      @ws = mock("websocket")
+      @adapter.instance_variable_set(:@ws, @ws)
+      @adapter.instance_variable_set(:@bot_user_id, "B001")
+    end
+
+    should "ack immediately with the envelope_id" do
+      @ws.expects(:send).with({ envelope_id: "env-42" }.to_json)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "app_mention", "user" => "U123", "channel" => "C123",
+          "ts" => "111.222", "text" => "<@B001> hello" },
+        envelope_id: "env-42"
+      ))
+    end
+
+    should "convert app_mention into an IncomingMessage without the mention" do
+      @ws.stubs(:send)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "app_mention", "user" => "U123", "channel" => "C123",
+          "ts" => "111.222", "text" => "<@B001> open issues?" }
+      ))
+
+      assert_equal 1, @dispatcher.messages.size
+      message = @dispatcher.messages.first
+      assert_equal "slack", message.channel_type
+      assert_equal "C123", message.channel_id
+      assert_equal "C123:111.222", message.thread_key
+      assert_equal "open issues?", message.text
+      assert_equal "U123", message.external_user_id
+      assert_not message.dm?
+    end
+
+    should "use thread_ts for the thread_key when present" do
+      @ws.stubs(:send)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "app_mention", "user" => "U123", "channel" => "C123",
+          "ts" => "333.444", "thread_ts" => "111.222", "text" => "<@B001> more" }
+      ))
+
+      assert_equal "C123:111.222", @dispatcher.messages.first.thread_key
+    end
+
+    should "convert an im message into a dm IncomingMessage" do
+      @ws.stubs(:send)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "message", "channel_type" => "im", "user" => "U123",
+          "channel" => "D123", "ts" => "111.222", "text" => "hi there" }
+      ))
+
+      message = @dispatcher.messages.first
+      assert message.dm?
+      assert_equal "D123", message.channel_id
+      assert_equal "hi there", message.text
+    end
+
+    should "discard bot messages, own messages and subtyped events" do
+      @ws.stubs(:send)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "message", "channel_type" => "im", "bot_id" => "B999",
+          "channel" => "D123", "ts" => "1.2", "text" => "from a bot" }
+      ))
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "app_mention", "user" => "B001", "channel" => "C123",
+          "ts" => "1.2", "text" => "self mention" }
+      ))
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "message", "channel_type" => "im", "user" => "U123",
+          "subtype" => "message_changed", "channel" => "D123", "ts" => "1.2", "text" => "edited" }
+      ))
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "reaction_added", "user" => "U123" }
+      ))
+
+      assert_empty @dispatcher.messages
+    end
+  end
+
+  context "web api operations" do
+    should "resolve the user email via users.info" do
+      @adapter.expects(:api_call).with("users.info", token: "xoxb-secret", params: { user: "U123" })
+              .returns({ "ok" => true, "user" => { "profile" => { "email" => "jsmith@somenet.foo" } } })
+
+      assert_equal "jsmith@somenet.foo", @adapter.resolve_user_email(external_user_id: "U123")
+    end
+
+    should "return nil when the profile has no email" do
+      @adapter.expects(:api_call).with("users.info", token: "xoxb-secret", params: { user: "U123" })
+              .returns({ "ok" => true, "user" => { "profile" => {} } })
+
+      assert_nil @adapter.resolve_user_email(external_user_id: "U123")
+    end
+
+    should "post the reply into the thread" do
+      @adapter.expects(:api_call).with(
+        "chat.postMessage",
+        token: "xoxb-secret",
+        params: { channel: "C123", thread_ts: "111.222", text: "the answer" }
+      ).returns({ "ok" => true })
+
+      @adapter.send_message(channel_id: "C123", thread_key: "C123:111.222", text: "the answer")
+    end
+
+    should "split long replies at paragraph boundaries" do
+      first = "a" * 3000
+      second = "b" * 2000
+      text = "#{first}\n\n#{second}"
+      calls = sequence("posts")
+      @adapter.expects(:api_call).with(
+        "chat.postMessage", token: "xoxb-secret",
+        params: { channel: "C123", thread_ts: "1.2", text: first }
+      ).in_sequence(calls).returns({ "ok" => true })
+      @adapter.expects(:api_call).with(
+        "chat.postMessage", token: "xoxb-secret",
+        params: { channel: "C123", thread_ts: "1.2", text: second }
+      ).in_sequence(calls).returns({ "ok" => true })
+
+      @adapter.send_message(channel_id: "C123", thread_key: "C123:1.2", text: text)
+    end
+
+    should "split on single newlines when there is no paragraph boundary" do
+      first = "a" * 3000
+      second = "b" * 2000
+      text = "#{first}\n#{second}"
+
+      chunks = @adapter.send(:split_text, text)
+
+      assert_equal [ first, second ], chunks
+    end
+
+    should "force-split when there is no newline at all" do
+      text = "a" * 8000
+
+      chunks = @adapter.send(:split_text, text)
+
+      assert_equal [ 3900, 3900, 200 ], chunks.map(&:length)
+      assert_equal text, chunks.join
+    end
+
+    should "add an hourglass reaction as the processing notice" do
+      @adapter.expects(:api_call).with(
+        "reactions.add",
+        token: "xoxb-secret",
+        params: { channel: "C123", timestamp: "111.222", name: "hourglass_flowing_sand" }
+      ).returns({ "ok" => true })
+
+      message = RedmineAiHelper::ChatChannel::IncomingMessage.new(
+        channel_type: "slack", channel_id: "C123", thread_key: "C123:111.222",
+        text: "q", external_user_id: "U123", dm: false
+      )
+      @adapter.notify_processing(message: message)
+    end
+  end
+end

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -134,7 +134,7 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
 
     should "reset missed pongs when a pong arrives" do
       @adapter.send(:ping_tick)
-      @adapter.handle_envelope({ "type" => "pong" }.to_json)
+      @adapter.send(:handle_pong)
       assert_not @adapter.send(:ping_tick)
       assert_not @adapter.send(:ping_tick)
     end
@@ -143,6 +143,35 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       @adapter.handle_envelope({ "type" => "hello" }.to_json)
 
       assert_predicate @adapter, :connected?
+    end
+
+    should "back off before reconnecting when the connection ends without hello" do
+      @adapter.stubs(:fetch_bot_user_id).returns("B001")
+      @adapter.stubs(:open_connection_url).returns("wss://example")
+      slept = []
+      @adapter.stubs(:sleep) { |seconds| slept << seconds }
+      call_count = 0
+      @adapter.stubs(:listen) do
+        call_count += 1
+        @adapter.stop if call_count == 2
+      end
+
+      @adapter.start
+
+      assert_equal 2, call_count, "adapter must retry after a hello-less clean close"
+      assert_equal [ 1 ], slept, "a backoff sleep must happen before the retry"
+    end
+  end
+
+  context "error classification" do
+    should "classify SlackApiError as a fatal config error" do
+      error = RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError.new("invalid_auth")
+
+      assert @adapter.fatal_config_error?(error)
+    end
+
+    should "not classify generic errors as a fatal config error" do
+      assert_not @adapter.fatal_config_error?(RuntimeError.new("boom"))
     end
   end
 

--- a/test/unit/chat_channel/base_adapter_test.rb
+++ b/test/unit/chat_channel/base_adapter_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../test_helper", __FILE__)
+
+class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  # In-memory adapter used to verify that subclassing BaseAdapter alone is
+  # enough to plug a new chat tool into the abstraction layer (SC-006).
+  class FakeAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    attr_reader :sent_messages, :processing_notified
+    attr_accessor :user_email
+
+    class << self
+      def channel_type
+        "fake_chat"
+      end
+
+      def required_setting_fields
+        [ :bot_token ]
+      end
+    end
+
+    def initialize
+      super
+      @sent_messages = []
+      @processing_notified = []
+    end
+
+    def start
+      # No external connection for the in-memory adapter.
+    end
+
+    def stop
+      # Nothing to close.
+    end
+
+    def send_message(channel_id:, thread_key:, text:)
+      @sent_messages << { channel_id: channel_id, thread_key: thread_key, text: text }
+    end
+
+    def resolve_user_email(external_user_id:)
+      @user_email || "fake-#{external_user_id}@example.com"
+    end
+
+    def notify_processing(message:)
+      @processing_notified << message
+    end
+  end
+
+  context "automatic registration" do
+    should "register subclasses by channel_type" do
+      assert_equal FakeAdapter, RedmineAiHelper::ChatChannel::BaseAdapter.adapters["fake_chat"]
+    end
+  end
+
+  context "settings" do
+    should "return the AiHelperChatAdapterSetting for the adapter's channel_type" do
+      setting = create(:ai_helper_chat_adapter_setting, channel_type: "fake_chat")
+
+      assert_equal setting, FakeAdapter.new.settings
+    end
+  end
+
+  context "enabled?" do
+    should "be false when no setting exists" do
+      assert_not FakeAdapter.new.enabled?
+    end
+
+    should "be false when the setting is enabled but a required field is missing" do
+      setting = create(:ai_helper_chat_adapter_setting, channel_type: "fake_chat", bot_token: nil)
+      # Bypass validation to simulate a row saved before the adapter declared
+      # the field as required.
+      setting.update_column(:enabled, true)
+
+      assert_not FakeAdapter.new.enabled?
+    end
+
+    should "be true when enabled and all required fields are present" do
+      create(:ai_helper_chat_adapter_setting, channel_type: "fake_chat", enabled: true, bot_token: "xoxb-token")
+
+      assert_predicate FakeAdapter.new, :enabled?
+    end
+  end
+
+  context "handler" do
+    should "provide a MessageHandler bound to the adapter" do
+      adapter = FakeAdapter.new
+
+      assert_kind_of RedmineAiHelper::ChatChannel::MessageHandler, adapter.handler
+    end
+  end
+
+  # SC-006: a brand-new tool integration must work end to end with nothing
+  # but a BaseAdapter subclass — no changes to MessageHandler, the models or
+  # the Slack adapter.
+  context "end-to-end with a fictional adapter" do
+    should "accept a question and return the answer through the shared core" do
+      project = Project.find(1)
+      project.enable_module!("ai_helper")
+      user = User.find(2)
+      adapter = FakeAdapter.new
+      adapter.user_email = user.mail
+      create(:ai_helper_channel_binding, channel_type: "fake_chat", channel_id: "FC1", project: project)
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        AiHelperMessage.new(role: "assistant", content: "fictional answer")
+      )
+
+      adapter.dispatch(RedmineAiHelper::ChatChannel::IncomingMessage.new(
+        channel_type: "fake_chat", channel_id: "FC1", thread_key: "FC1:1.000001",
+        text: "hello from a fictional tool", external_user_id: "U1", dm: false
+      ))
+
+      assert_equal 1, adapter.processing_notified.size
+      assert_equal [ { channel_id: "FC1", thread_key: "FC1:1.000001", text: "fictional answer" } ],
+                   adapter.sent_messages
+      conversation = AiHelperConversation.first
+      assert_equal user, conversation.user
+      assert_equal "fake_chat", conversation.channel_conversation.channel_type
+    end
+  end
+
+  context "IncomingMessage" do
+    should "hold the normalized fields" do
+      message = RedmineAiHelper::ChatChannel::IncomingMessage.new(
+        channel_type: "fake_chat",
+        channel_id: "C123",
+        thread_key: "C123:1700000000.000100",
+        text: "hello",
+        external_user_id: "U123",
+        dm: true
+      )
+
+      assert_equal "fake_chat", message.channel_type
+      assert_equal "C123", message.channel_id
+      assert_equal "C123:1700000000.000100", message.thread_key
+      assert_equal "hello", message.text
+      assert_equal "U123", message.external_user_id
+      assert message.dm
+    end
+  end
+end

--- a/test/unit/chat_channel/base_adapter_test.rb
+++ b/test/unit/chat_channel/base_adapter_test.rb
@@ -136,7 +136,7 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
       assert_equal "C123:1700000000.000100", message.thread_key
       assert_equal "hello", message.text
       assert_equal "U123", message.external_user_id
-      assert message.dm
+      assert message.dm?
     end
   end
 end

--- a/test/unit/chat_channel/gateway_test.rb
+++ b/test/unit/chat_channel/gateway_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../test_helper", __FILE__)
+
+class ChatChannelGatewayTest < ActiveSupport::TestCase
+  # Records handled messages together with the thread that handled them.
+  class RecordingHandler
+    attr_reader :handled
+
+    def initialize
+      @handled = []
+    end
+
+    def handle(message)
+      @handled << [ message, Thread.current ]
+    end
+  end
+
+  # In-memory adapter that dispatches a fixed list of messages when started.
+  class FakeGatewayAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    attr_reader :stopped
+    attr_accessor :messages_to_dispatch, :after_dispatch
+
+    class << self
+      def channel_type
+        "gateway_chat"
+      end
+    end
+
+    def initialize
+      super
+      @stopped = false
+      @messages_to_dispatch = []
+    end
+
+    def enabled?
+      true
+    end
+
+    def start
+      @messages_to_dispatch.each { |message| dispatch(message) }
+      @after_dispatch&.call
+    end
+
+    def stop
+      @stopped = true
+    end
+
+    def send_message(channel_id:, thread_key:, text:); end
+
+    def resolve_user_email(external_user_id:); end
+
+    def notify_processing(message:); end
+  end
+
+  def incoming(text)
+    RedmineAiHelper::ChatChannel::IncomingMessage.new(
+      channel_type: "gateway_chat", channel_id: "C1", thread_key: "C1:1.000001",
+      text: text, external_user_id: "U1", dm: false
+    )
+  end
+
+  setup do
+    @gateway = RedmineAiHelper::ChatChannel::Gateway.new
+  end
+
+  context "run" do
+    should "raise when no adapter is enabled" do
+      @gateway.stubs(:build_enabled_adapters).returns([])
+
+      assert_raises(RuntimeError) { @gateway.run }
+    end
+
+    should "start enabled adapters and process dispatched messages serially" do
+      adapter = FakeGatewayAdapter.new
+      handler = RecordingHandler.new
+      adapter.instance_variable_set(:@handler, handler)
+      messages = [ incoming("one"), incoming("two"), incoming("three") ]
+      adapter.messages_to_dispatch = messages
+      adapter.after_dispatch = -> { @gateway.shutdown }
+      @gateway.stubs(:build_enabled_adapters).returns([ adapter ])
+
+      @gateway.run
+
+      assert_equal messages, handler.handled.map(&:first)
+      worker_threads = handler.handled.map(&:last).uniq
+      assert_equal 1, worker_threads.size, "all messages must be handled by the single worker thread"
+    end
+
+    should "wrap each handled message in a connection pool checkout" do
+      adapter = FakeGatewayAdapter.new
+      adapter.instance_variable_set(:@handler, RecordingHandler.new)
+      adapter.messages_to_dispatch = [ incoming("one"), incoming("two") ]
+      adapter.after_dispatch = -> { @gateway.shutdown }
+      @gateway.stubs(:build_enabled_adapters).returns([ adapter ])
+      ActiveRecord::Base.connection_pool.expects(:with_connection).twice.yields
+
+      @gateway.run
+    end
+
+    should "stop all adapters and drain the queue on shutdown" do
+      adapter = FakeGatewayAdapter.new
+      handler = RecordingHandler.new
+      adapter.instance_variable_set(:@handler, handler)
+      adapter.messages_to_dispatch = [ incoming("one"), incoming("two") ]
+      adapter.after_dispatch = -> { @gateway.shutdown }
+      @gateway.stubs(:build_enabled_adapters).returns([ adapter ])
+
+      @gateway.run
+
+      assert adapter.stopped, "shutdown must call stop on every adapter"
+      assert_equal 2, handler.handled.size, "queued messages must be drained before exiting"
+    end
+  end
+
+  # Adapter that is registered but not enabled.
+  class DisabledGatewayAdapter < FakeGatewayAdapter
+    class << self
+      def channel_type
+        "disabled_gateway_chat"
+      end
+    end
+
+    def enabled?
+      false
+    end
+  end
+
+  context "build_enabled_adapters" do
+    should "instantiate only enabled adapters from the registry" do
+      RedmineAiHelper::ChatChannel::BaseAdapter.stubs(:adapters).returns(
+        { "gateway_chat" => FakeGatewayAdapter, "disabled_gateway_chat" => DisabledGatewayAdapter }
+      )
+
+      adapters = @gateway.send(:build_enabled_adapters)
+
+      assert_equal 1, adapters.size
+      assert_kind_of FakeGatewayAdapter, adapters.first
+    end
+  end
+
+  context "dispatch without a gateway" do
+    should "fall back to calling the handler directly" do
+      adapter = FakeGatewayAdapter.new
+      handler = RecordingHandler.new
+      adapter.instance_variable_set(:@handler, handler)
+      message = incoming("direct")
+
+      adapter.dispatch(message)
+
+      assert_equal [ message ], handler.handled.map(&:first)
+    end
+  end
+end

--- a/test/unit/chat_channel/gateway_test.rb
+++ b/test/unit/chat_channel/gateway_test.rb
@@ -65,10 +65,10 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
   end
 
   context "run" do
-    should "raise when no adapter is enabled" do
+    should "raise ConfigurationError when no adapter is enabled" do
       @gateway.stubs(:build_enabled_adapters).returns([])
 
-      assert_raises(RuntimeError) { @gateway.run }
+      assert_raises(RedmineAiHelper::ChatChannel::Gateway::ConfigurationError) { @gateway.run }
     end
 
     should "start enabled adapters and process dispatched messages serially" do
@@ -110,6 +110,50 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
 
       assert adapter.stopped, "shutdown must call stop on every adapter"
       assert_equal 2, handler.handled.size, "queued messages must be drained before exiting"
+    end
+
+    should "re-raise a non-config adapter crash after shutdown" do
+      adapter = FakeGatewayAdapter.new
+      adapter.after_dispatch = -> { raise RuntimeError, "adapter blew up" }
+      @gateway.stubs(:build_enabled_adapters).returns([ adapter ])
+
+      error = assert_raises(RuntimeError) { @gateway.run }
+      assert_match(/adapter blew up/, error.message)
+      assert adapter.stopped, "shutdown must still be called on the crashed adapter"
+    end
+
+    should "raise ConfigurationError when the adapter reports a config error" do
+      adapter = FakeGatewayAdapter.new
+      adapter.define_singleton_method(:fatal_config_error?) { |_e| true }
+      adapter.after_dispatch = -> { raise RuntimeError, "invalid_auth" }
+      @gateway.stubs(:build_enabled_adapters).returns([ adapter ])
+
+      error = assert_raises(RedmineAiHelper::ChatChannel::Gateway::ConfigurationError) { @gateway.run }
+      assert_match(/invalid_auth/, error.message)
+    end
+
+    should "keep the worker loop alive when a single message raises" do
+      adapter = FakeGatewayAdapter.new
+      failing_handler = Class.new do
+        def initialize
+          @calls = 0
+        end
+
+        attr_reader :calls
+
+        def handle(_message)
+          @calls += 1
+          raise "bad message" if @calls == 1
+        end
+      end.new
+      adapter.instance_variable_set(:@handler, failing_handler)
+      adapter.messages_to_dispatch = [ incoming("boom"), incoming("ok") ]
+      adapter.after_dispatch = -> { @gateway.shutdown }
+      @gateway.stubs(:build_enabled_adapters).returns([ adapter ])
+
+      assert_nothing_raised { @gateway.run }
+
+      assert_equal 2, failing_handler.calls, "worker must continue after a failed message"
     end
   end
 

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -156,6 +156,23 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       assert_equal error_text(:processing_failed), @adapter.sent_messages.first[:text]
       assert_equal User.anonymous, User.current
     end
+
+    should "continue processing when notify_processing fails" do
+      @adapter.expects(:notify_processing).raises(RuntimeError, "reaction blocked")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("answer"))
+
+      @handler.handle(incoming)
+
+      assert_equal "answer", @adapter.sent_messages.first[:text]
+    end
+
+    should "not raise when posting the error notice itself fails" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).raises(RuntimeError, "boom")
+      @adapter.expects(:send_message).raises(RuntimeError, "slack is down")
+
+      assert_nothing_raised { @handler.handle(incoming) }
+      assert_equal User.anonymous, User.current
+    end
   end
 
   context "thread continuation" do

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../test_helper", __FILE__)
+
+class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  fixtures :projects, :users, :enabled_modules
+
+  # In-memory adapter driving the handler without any external service.
+  class RecordingAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    attr_reader :sent_messages, :processing_notified, :resolve_calls
+    attr_accessor :email_by_user_id
+
+    class << self
+      def channel_type
+        "handler_chat"
+      end
+    end
+
+    def initialize
+      super
+      @sent_messages = []
+      @processing_notified = []
+      @email_by_user_id = {}
+      @resolve_calls = 0
+    end
+
+    def start; end
+
+    def stop; end
+
+    def send_message(channel_id:, thread_key:, text:)
+      @sent_messages << { channel_id: channel_id, thread_key: thread_key, text: text }
+    end
+
+    def resolve_user_email(external_user_id:)
+      @resolve_calls += 1
+      @email_by_user_id[external_user_id]
+    end
+
+    def notify_processing(message:)
+      @processing_notified << message
+    end
+  end
+
+  setup do
+    @adapter = RecordingAdapter.new
+    @handler = @adapter.handler
+    @project = Project.find(1)
+    @project.enable_module!("ai_helper")
+    @user = User.find(2)
+    @adapter.email_by_user_id["EXT_JSMITH"] = @user.mail
+    create(:ai_helper_channel_binding, channel_type: "handler_chat", channel_id: "CH1", project: @project)
+  end
+
+  def incoming(text: "What are the open issues?", channel_id: "CH1", thread_key: "CH1:1.000001", external_user_id: "EXT_JSMITH", dm: false)
+    RedmineAiHelper::ChatChannel::IncomingMessage.new(
+      channel_type: "handler_chat", channel_id: channel_id, thread_key: thread_key,
+      text: text, external_user_id: external_user_id, dm: dm
+    )
+  end
+
+  def error_text(key)
+    I18n.t("ai_helper.chat_channel.errors.#{key}", locale: @user.language.presence || Setting.default_language)
+  end
+
+  context "handle" do
+    should "notify processing before anything else" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("ok"))
+
+      message = incoming
+      @handler.handle(message)
+
+      assert_equal [ message ], @adapter.processing_notified
+    end
+
+    should "reply with guidance when the user cannot be mapped" do
+      message = incoming(external_user_id: "EXT_UNKNOWN")
+      @handler.handle(message)
+
+      assert_equal 1, @adapter.sent_messages.size
+      assert_equal error_text(:user_not_mapped), @adapter.sent_messages.first[:text]
+      assert_equal 0, AiHelperConversation.count
+    end
+
+    should "reply with guidance when the channel is not bound" do
+      message = incoming(channel_id: "UNBOUND")
+      @handler.handle(message)
+
+      assert_equal error_text(:channel_not_bound), @adapter.sent_messages.first[:text]
+    end
+
+    should "reply with guidance for a DM without a default project" do
+      message = incoming(dm: true, channel_id: "D123", thread_key: "D123:1.000001")
+      @handler.handle(message)
+
+      assert_equal error_text(:dm_not_configured), @adapter.sent_messages.first[:text]
+    end
+
+    should "use the DM default project for direct messages" do
+      create(:ai_helper_chat_adapter_setting, channel_type: "handler_chat", dm_default_project_id: @project.id)
+      RedmineAiHelper::Llm.any_instance.expects(:chat).with do |_conversation, _proc, option|
+        option[:project] == @project
+      end.returns(assistant_message("dm answer"))
+
+      @handler.handle(incoming(dm: true, channel_id: "D123", thread_key: "D123:1.000001"))
+
+      assert_equal "dm answer", @adapter.sent_messages.first[:text]
+    end
+
+    should "reply with guidance when the ai_helper module is disabled" do
+      @project.disable_module!("ai_helper")
+      message = incoming
+      @handler.handle(message)
+
+      assert_equal error_text(:module_disabled), @adapter.sent_messages.first[:text]
+    end
+
+    should "run the LLM as the resolved user and post the answer to the thread" do
+      observed_user = nil
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).with do |conversation, proc, option|
+        observed_user = User.current
+        conversation.messages.last.content == "What are the open issues?" &&
+          proc.respond_to?(:call) && option[:project] == Project.find(1)
+      end.returns(assistant_message("Here are the issues"))
+
+      message = incoming
+      @handler.handle(message)
+
+      assert_equal @user, observed_user
+      assert_equal 1, @adapter.sent_messages.size
+      sent = @adapter.sent_messages.first
+      assert_equal "CH1", sent[:channel_id]
+      assert_equal "CH1:1.000001", sent[:thread_key]
+      assert_equal "Here are the issues", sent[:text]
+
+      conversation = AiHelperConversation.first
+      assert_equal @user, conversation.user
+      assert_equal %w[user assistant], conversation.messages.order(:id).pluck(:role)
+    end
+
+    should "restore User.current to anonymous after handling" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("ok"))
+
+      @handler.handle(incoming)
+
+      assert_equal User.anonymous, User.current
+    end
+
+    should "reply with an error notice and log when processing raises" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).raises(RuntimeError, "boom")
+
+      @handler.handle(incoming)
+
+      assert_equal error_text(:processing_failed), @adapter.sent_messages.first[:text]
+      assert_equal User.anonymous, User.current
+    end
+  end
+
+  context "thread continuation" do
+    setup do
+      @other_user = User.find(3)
+      @adapter.email_by_user_id["EXT_DLOPPER"] = @other_user.mail
+    end
+
+    should "append follow-up questions to the existing conversation with full history" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message("first answer"), assistant_message("second answer")
+      )
+      @handler.handle(incoming(text: "first question", thread_key: "CH1:9.000001"))
+
+      observed_history = nil
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).with do |conversation, _proc, _option|
+        observed_history = conversation.messages.order(:id).pluck(:role, :content)
+        true
+      end.returns(assistant_message("second answer"))
+      @handler.handle(incoming(text: "second question", thread_key: "CH1:9.000001"))
+
+      assert_equal 1, AiHelperConversation.count
+      assert_equal [
+        [ "user", "first question" ],
+        [ "assistant", "first answer" ],
+        [ "user", "second question" ]
+      ], observed_history
+    end
+
+    should "process another user's follow-up under that user without changing the owner" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("answer"))
+      @handler.handle(incoming(text: "starter question", thread_key: "CH1:9.000002"))
+
+      observed_user = nil
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).with do |_conversation, _proc, _option|
+        observed_user = User.current
+        true
+      end.returns(assistant_message("follow-up answer"))
+      @handler.handle(incoming(text: "follow-up", thread_key: "CH1:9.000002", external_user_id: "EXT_DLOPPER"))
+
+      assert_equal @other_user, observed_user
+      assert_equal @user, AiHelperConversation.first.user
+    end
+
+    should "start a new conversation for a different thread" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("answer"))
+
+      @handler.handle(incoming(thread_key: "CH1:9.000003"))
+      @handler.handle(incoming(thread_key: "CH1:9.000004"))
+
+      assert_equal 2, AiHelperConversation.count
+    end
+
+    should "set the conversation title from the head of the first question" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("answer"))
+      long_question = "Q" * 80
+
+      @handler.handle(incoming(text: long_question, thread_key: "CH1:9.000005"))
+
+      title = AiHelperConversation.first.title
+      assert_equal long_question.truncate(50), title
+      assert_operator title.length, :<=, 50
+    end
+  end
+
+  context "user resolution cache" do
+    include ActiveSupport::Testing::TimeHelpers
+
+    setup do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("ok"))
+    end
+
+    should "resolve each external user only once within the TTL" do
+      @handler.handle(incoming(thread_key: "CH1:1.000001"))
+      @handler.handle(incoming(thread_key: "CH1:1.000002"))
+
+      assert_equal 1, @adapter.resolve_calls
+    end
+
+    should "cache the unmapped result as well" do
+      @handler.handle(incoming(external_user_id: "EXT_UNKNOWN", thread_key: "CH1:1.000001"))
+      @handler.handle(incoming(external_user_id: "EXT_UNKNOWN", thread_key: "CH1:1.000002"))
+
+      assert_equal 1, @adapter.resolve_calls
+      assert_equal 2, @adapter.sent_messages.size
+      assert(@adapter.sent_messages.all? { |sent| sent[:text] == error_text(:user_not_mapped) })
+    end
+
+    should "resolve again after the TTL has expired" do
+      @handler.handle(incoming(thread_key: "CH1:1.000001"))
+      travel 11.minutes do
+        @handler.handle(incoming(thread_key: "CH1:1.000002"))
+      end
+
+      assert_equal 2, @adapter.resolve_calls
+    end
+  end
+
+  private
+
+  def assistant_message(content)
+    AiHelperMessage.new(role: "assistant", content: content)
+  end
+end


### PR DESCRIPTION
## Changes

- Add a chat channel gateway abstraction with a Slack adapter for connecting Redmine AI Helper to external chat tools via outbound-only connections (no public URL required)
- Add `AiHelperChatAdapterSetting`, `AiHelperChannelBinding`, and `AiHelperChannelConversation` models plus migrations to manage adapter credentials, channel-to-project bindings, and per-thread conversation state
- Add a Channels settings tab for administrators to configure Slack credentials and channel/project bindings
- Add `MessageHandler` to route incoming channel messages to the existing AI Helper agent pipeline, reusing the caller's Redmine permissions
- Harden gateway error handling and token security; require project and conversation presence on chat channel models
- Add a `chat_channel:start` rake task, ADR for the gateway architecture, and Slack setup documentation