### PR TITLE
Improve chat gateway settings UI

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/028-chat-channel-gateway"
+  "feature_directory": "specs/029-chat-gateway-settings-improve"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,5 +179,5 @@ replies outside SDD steps are not affected.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-specs/022-vector-project-selection/plan.md
+specs/029-chat-gateway-settings-improve/plan.md
 <!-- SPECKIT END -->

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -80,6 +80,7 @@ class AiHelperSettingsController < ApplicationController
     @ai_helper_projects = Project.joins(:enabled_modules).where(enabled_modules: { name: "ai_helper" }).order(:name)
     @channel_bindings = AiHelperChannelBinding.includes(:project).order(:channel_type, :channel_id)
     @ai_helper_users = User.active.sorted
+    @channel_bindings_by_type = @channel_bindings.group_by(&:channel_type)
   end
 
   # Builds adapter setting records from the channels tab params, keyed by

--- a/app/controllers/ai_helper_settings_controller.rb
+++ b/app/controllers/ai_helper_settings_controller.rb
@@ -73,14 +73,16 @@ class AiHelperSettingsController < ApplicationController
     render_error status: 422, message: l(:error_invalid_authenticity_token)
   end
 
-  # Find or create the AI Helper setting and load model profiles
+  # Find or create the AI Helper setting and load all settings data
+  # (model profiles, projects, channel bindings, and active users).
   def find_setting
     @setting = AiHelperSetting.find_or_create
     @model_profiles = AiHelperModelProfile.order(:name)
     @ai_helper_projects = Project.joins(:enabled_modules).where(enabled_modules: { name: "ai_helper" }).order(:name)
-    @channel_bindings = AiHelperChannelBinding.includes(:project).order(:channel_type, :channel_id)
+    @channel_bindings_by_type = AiHelperChannelBinding.includes(:project)
+                                                      .order(:channel_type, :channel_id)
+                                                      .group_by(&:channel_type)
     @ai_helper_users = User.active.sorted
-    @channel_bindings_by_type = @channel_bindings.group_by(&:channel_type)
   end
 
   # Builds adapter setting records from the channels tab params, keyed by

--- a/app/models/ai_helper_chat_adapter_setting.rb
+++ b/app/models/ai_helper_chat_adapter_setting.rb
@@ -10,10 +10,13 @@ class AiHelperChatAdapterSetting < ApplicationRecord
   belongs_to :dm_default_project, class_name: "Project", optional: true
   belongs_to :redmine_user, class_name: "User", optional: true
 
+  attr_accessor :redmine_user_name
+
   validates :channel_type, presence: true, uniqueness: true
   validate :required_fields_present_when_enabled
+  validate :redmine_user_name_matches_existing_user
 
-  safe_attributes "enabled", "app_token", "bot_token", "dm_default_project_id", "redmine_user_id"
+  safe_attributes "enabled", "app_token", "bot_token", "dm_default_project_id", "redmine_user_id", "redmine_user_name"
 
   class << self
     # Returns the setting row for the given adapter, or a new unsaved record
@@ -60,6 +63,16 @@ class AiHelperChatAdapterSetting < ApplicationRecord
   def required_setting_fields
     adapter = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type]
     adapter ? adapter.required_setting_fields : []
+  end
+
+  # Validates that the submitted redmine_user_name corresponds to an actual
+  # user record. When the form sends a non-matching name, the hidden
+  # redmine_user_id will be blank — this catches the mismatch server-side.
+  def redmine_user_name_matches_existing_user
+    return if redmine_user_name.blank?
+    return if redmine_user_id.present?
+
+    errors.add(:redmine_user_name, :invalid)
   end
 
   # Validates that the adapter's required fields are present when the

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -15,98 +15,103 @@
     <p>
       <label><%= t("ai_helper.chat_channel.settings.enabled") %></label>
       <%= hidden_field_tag "chat_adapter_settings[#{channel_type}][enabled]", "0", id: nil %>
-      <%= check_box_tag "chat_adapter_settings[#{channel_type}][enabled]", "1", adapter_setting.enabled, id: nil %>
+      <%= check_box_tag "chat_adapter_settings[#{channel_type}][enabled]", "1", adapter_setting.enabled,
+                        data: { adapter_type: channel_type }, class: "adapter-enabled-checkbox" %>
     </p>
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.app_token") %></label>
-      <%= password_field_tag "chat_adapter_settings[#{channel_type}][app_token]",
-                             token_field_value(adapter_setting.app_token),
-                             size: 60, id: nil, autocomplete: "new-password" %>
-      <% if adapter_setting.app_token.present? %>
-        <em class="info"><%= adapter_setting.masked_app_token %></em>
+    <div id="adapter-settings-<%= channel_type %>">
+      <p>
+        <label><%= t("ai_helper.chat_channel.settings.app_token") %></label>
+        <%= password_field_tag "chat_adapter_settings[#{channel_type}][app_token]",
+                               token_field_value(adapter_setting.app_token),
+                               size: 60, id: nil, autocomplete: "new-password" %>
+        <% if adapter_setting.app_token.present? %>
+          <em class="info"><%= adapter_setting.masked_app_token %></em>
+        <% end %>
+      </p>
+      <p>
+        <label><%= t("ai_helper.chat_channel.settings.bot_token") %></label>
+        <%= password_field_tag "chat_adapter_settings[#{channel_type}][bot_token]",
+                               token_field_value(adapter_setting.bot_token),
+                               size: 60, id: nil, autocomplete: "new-password" %>
+        <% if adapter_setting.bot_token.present? %>
+          <em class="info"><%= adapter_setting.masked_bot_token %></em>
+        <% end %>
+      </p>
+      <p>
+        <label><%= t("ai_helper.chat_channel.settings.redmine_user") %></label>
+        <% selected_user = @ai_helper_users.find { |u| u.id == adapter_setting.redmine_user_id } %>
+        <%= text_field_tag "chat_adapter_settings[#{channel_type}][redmine_user_name]",
+                           selected_user&.name.to_s,
+                           list: "ai-helper-users-datalist-#{channel_type}",
+                           size: 40, id: nil %>
+        <%= hidden_field_tag "chat_adapter_settings[#{channel_type}][redmine_user_id]",
+                             adapter_setting.redmine_user_id.to_s, id: nil %>
+        <datalist id="ai-helper-users-datalist-<%= channel_type %>">
+          <% @ai_helper_users.each do |user| %>
+            <option value="<%= user.id %>"><%= user.name %></option>
+          <% end %>
+        </datalist>
+        <em class="info"><%= t("ai_helper.chat_channel.settings.redmine_user_info") %></em>
+      </p>
+      <p>
+        <label><%= t("ai_helper.chat_channel.settings.dm_default_project") %></label>
+        <%= select_tag "chat_adapter_settings[#{channel_type}][dm_default_project_id]",
+                       options_from_collection_for_select(@ai_helper_projects, :id, :name, adapter_setting.dm_default_project_id),
+                       include_blank: true, id: nil %>
+      </p>
+    </div>
+    <fieldset class="box">
+      <legend><%= t("ai_helper.chat_channel.settings.bindings") %></legend>
+      <% adapter_bindings = @channel_bindings_by_type[channel_type] || [] %>
+      <% if adapter_bindings.any? %>
+        <table class="list">
+          <thead>
+            <tr>
+              <th><%= t("ai_helper.chat_channel.settings.channel_id") %></th>
+              <th><%= t("ai_helper.chat_channel.settings.channel_name") %></th>
+              <th><%= t(:label_project) %></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% adapter_bindings.each do |channel_binding| %>
+              <tr>
+                <td><%= channel_binding.channel_id %></td>
+                <td><%= channel_binding.channel_name %></td>
+                <td><%= channel_binding.project.name %></td>
+                <td class="buttons">
+                  <%= link_to(sprite_icon('del', l(:button_delete)),
+                              ai_helper_channel_binding_path(channel_binding),
+                              method: :delete,
+                              data: { confirm: l(:text_are_you_sure) },
+                              class: 'icon icon-del') %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
       <% end %>
-    </p>
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.bot_token") %></label>
-      <%= password_field_tag "chat_adapter_settings[#{channel_type}][bot_token]",
-                             token_field_value(adapter_setting.bot_token),
-                             size: 60, id: nil, autocomplete: "new-password" %>
-      <% if adapter_setting.bot_token.present? %>
-        <em class="info"><%= adapter_setting.masked_bot_token %></em>
-      <% end %>
-    </p>
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.redmine_user") %></label>
-      <%= select_tag "chat_adapter_settings[#{channel_type}][redmine_user_id]",
-                     options_from_collection_for_select(@ai_helper_users, :id, :name, adapter_setting.redmine_user_id),
-                     include_blank: true, id: nil %>
-      <em class="info"><%= t("ai_helper.chat_channel.settings.redmine_user_info") %></em>
-    </p>
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.dm_default_project") %></label>
-      <%= select_tag "chat_adapter_settings[#{channel_type}][dm_default_project_id]",
-                     options_from_collection_for_select(@ai_helper_projects, :id, :name, adapter_setting.dm_default_project_id),
-                     include_blank: true, id: nil %>
-    </p>
+      <div class="tabular">
+        <%= hidden_field_tag "ai_helper_channel_binding[channel_type]", channel_type, id: nil %>
+        <p>
+          <label><%= t("ai_helper.chat_channel.settings.channel_id") %></label>
+          <%= text_field_tag "ai_helper_channel_binding[channel_id]", "", size: 30, id: nil %>
+        </p>
+        <p>
+          <label><%= t("ai_helper.chat_channel.settings.channel_name") %></label>
+          <%= text_field_tag "ai_helper_channel_binding[channel_name]", "", size: 30, id: nil %>
+        </p>
+        <p>
+          <label><%= t(:label_project) %></label>
+          <%= select_tag "ai_helper_channel_binding[project_id]",
+                         options_from_collection_for_select(@ai_helper_projects, :id, :name),
+                         include_blank: true, id: nil %>
+        </p>
+        <p>
+          <%= submit_tag t("ai_helper.chat_channel.settings.add_binding"),
+                         formaction: ai_helper_channel_bindings_path, name: nil %>
+        </p>
+      </div>
+    </fieldset>
   </fieldset>
 <% end %>
-
-<fieldset class="box">
-  <legend><%= t("ai_helper.chat_channel.settings.bindings") %></legend>
-  <% if @channel_bindings.any? %>
-    <table class="list">
-      <thead>
-        <tr>
-          <th><%= t("ai_helper.chat_channel.settings.adapter") %></th>
-          <th><%= t("ai_helper.chat_channel.settings.channel_id") %></th>
-          <th><%= t("ai_helper.chat_channel.settings.channel_name") %></th>
-          <th><%= t(:label_project) %></th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @channel_bindings.each do |channel_binding| %>
-          <tr>
-            <td><%= ai_helper_chat_adapter_label(channel_binding.channel_type) %></td>
-            <td><%= channel_binding.channel_id %></td>
-            <td><%= channel_binding.channel_name %></td>
-            <td><%= channel_binding.project.name %></td>
-            <td class="buttons">
-              <%= link_to(sprite_icon('del', l(:button_delete)),
-                          ai_helper_channel_binding_path(channel_binding),
-                          method: :delete,
-                          data: { confirm: l(:text_are_you_sure) },
-                          class: 'icon icon-del') %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  <% end %>
-  <div class="tabular">
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.adapter") %></label>
-      <%= select_tag "ai_helper_channel_binding[channel_type]",
-                     options_for_select(adapters.map { |type| [ ai_helper_chat_adapter_label(type), type ] }),
-                     id: nil %>
-    </p>
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.channel_id") %></label>
-      <%= text_field_tag "ai_helper_channel_binding[channel_id]", "", size: 30, id: nil %>
-    </p>
-    <p>
-      <label><%= t("ai_helper.chat_channel.settings.channel_name") %></label>
-      <%= text_field_tag "ai_helper_channel_binding[channel_name]", "", size: 30, id: nil %>
-    </p>
-    <p>
-      <label><%= t(:label_project) %></label>
-      <%= select_tag "ai_helper_channel_binding[project_id]",
-                     options_from_collection_for_select(@ai_helper_projects, :id, :name),
-                     include_blank: true, id: nil %>
-    </p>
-    <p>
-      <%= submit_tag t("ai_helper.chat_channel.settings.add_binding"),
-                     formaction: ai_helper_channel_bindings_path, name: nil %>
-    </p>
-  </div>
-</fieldset>

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -60,7 +60,7 @@
                        include_blank: true, id: nil %>
       </p>
     </div>
-    <fieldset class="box">
+    <fieldset class="box" id="adapter-bindings-<%= channel_type %>">
       <legend><%= t("ai_helper.chat_channel.settings.bindings") %></legend>
       <% adapter_bindings = @channel_bindings_by_type[channel_type] || [] %>
       <% if adapter_bindings.any? %>

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -48,7 +48,7 @@
                              adapter_setting.redmine_user_id.to_s, id: nil %>
         <datalist id="ai-helper-users-datalist-<%= channel_type %>">
           <% @ai_helper_users.each do |user| %>
-            <option value="<%= user.id %>"><%= user.name %></option>
+            <option value="<%= user.name %>" data-user-id="<%= user.id %>"></option>
           <% end %>
         </datalist>
         <em class="info"><%= t("ai_helper.chat_channel.settings.redmine_user_info") %></em>

--- a/app/views/ai_helper_settings/index.html.erb
+++ b/app/views/ai_helper_settings/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :header_tags do %>
   <%= stylesheet_link_tag('ai_helper.css', plugin: :redmine_ai_helper) %>
+  <%= javascript_include_tag('ai_helper_chat_settings.js', plugin: :redmine_ai_helper) %>
 <% end %>
 <h2><%= t(:label_ai_helper) %></h2>
 <%= labelled_form_for @setting, url: ai_helper_setting_update_url, method: :post do |f| %>

--- a/assets/javascripts/ai_helper_chat_settings.js
+++ b/assets/javascripts/ai_helper_chat_settings.js
@@ -2,9 +2,9 @@
 
 function setAdapterSettingsVisible(channelType) {
   const checkbox = document.querySelector(
-    'input[type=checkbox][data-adapter-type="' + channelType + '"]'
+    `input[type=checkbox][data-adapter-type="${channelType}"]`
   );
-  const settingsDiv = document.getElementById("adapter-settings-" + channelType);
+  const settingsDiv = document.getElementById(`adapter-settings-${channelType}`);
   if (!checkbox || !settingsDiv) return;
   settingsDiv.style.display = checkbox.checked ? "" : "none";
 }
@@ -25,41 +25,30 @@ function setupAdapterCheckboxListeners() {
 }
 
 function setupDatalistHandlers() {
-  const hiddenInputs = document.querySelectorAll(
-    'input[type=hidden][name*="[redmine_user_id]"]'
+  const textInputs = document.querySelectorAll(
+    'input[list^="ai-helper-users-datalist-"]'
   );
-  hiddenInputs.forEach(function (hiddenInput) {
-    const name = hiddenInput.getAttribute("name");
-    const match = name.match(
-      /^chat_adapter_settings\[([^\]]+)\]\[redmine_user_id\]$/
+  textInputs.forEach(function (textInput) {
+    const listAttr = textInput.getAttribute("list");
+    const channelType = listAttr.replace("ai-helper-users-datalist-", "");
+    const hiddenInput = document.querySelector(
+      `input[type=hidden][name="chat_adapter_settings\\[${channelType}\\]\\[redmine_user_id\\]"]`
     );
-    if (!match) return;
+    if (!hiddenInput) return;
 
-    const channelType = match[1];
-    const textInput = document.querySelector(
-      'input[list="ai-helper-users-datalist-' + channelType + '"]'
-    );
-    if (!textInput) return;
-
-    textInput.addEventListener("input", function () {
+    function syncHiddenInput() {
       const enteredText = textInput.value.trim();
-      const datalistId = textInput.getAttribute("list");
-      const datalist = document.getElementById(datalistId);
+      const datalist = document.getElementById(listAttr);
       if (!datalist) return;
 
-      let matched = false;
-      const options = datalist.querySelectorAll("option");
-      for (let i = 0; i < options.length; i++) {
-        if (options[i].textContent === enteredText) {
-          hiddenInput.value = options[i].getAttribute("value");
-          matched = true;
-          break;
-        }
-      }
-      if (!matched) {
-        hiddenInput.value = "";
-      }
-    });
+      const matched = Array.from(datalist.querySelectorAll("option")).find(
+        function (option) { return option.textContent === enteredText; }
+      );
+      hiddenInput.value = matched ? matched.getAttribute("value") : "";
+    }
+
+    textInput.addEventListener("input", syncHiddenInput);
+    textInput.addEventListener("blur", syncHiddenInput);
   });
 }
 

--- a/assets/javascripts/ai_helper_chat_settings.js
+++ b/assets/javascripts/ai_helper_chat_settings.js
@@ -5,8 +5,11 @@ function setAdapterSettingsVisible(channelType) {
     `input[type=checkbox][data-adapter-type="${channelType}"]`
   );
   const settingsDiv = document.getElementById(`adapter-settings-${channelType}`);
-  if (!checkbox || !settingsDiv) return;
-  settingsDiv.style.display = checkbox.checked ? "" : "none";
+  const bindingsFieldset = document.getElementById(`adapter-bindings-${channelType}`);
+  if (!checkbox || !settingsDiv || !bindingsFieldset) return;
+  const display = checkbox.checked ? "" : "none";
+  settingsDiv.style.display = display;
+  bindingsFieldset.style.display = display;
 }
 
 function setupAdapterCheckboxListeners() {

--- a/assets/javascripts/ai_helper_chat_settings.js
+++ b/assets/javascripts/ai_helper_chat_settings.js
@@ -1,0 +1,72 @@
+"use strict";
+
+function setAdapterSettingsVisible(channelType) {
+  const checkbox = document.querySelector(
+    'input[type=checkbox][data-adapter-type="' + channelType + '"]'
+  );
+  const settingsDiv = document.getElementById("adapter-settings-" + channelType);
+  if (!checkbox || !settingsDiv) return;
+  settingsDiv.style.display = checkbox.checked ? "" : "none";
+}
+
+function setupAdapterCheckboxListeners() {
+  const checkboxes = document.querySelectorAll(".adapter-enabled-checkbox");
+  const adapterTypes = [];
+  checkboxes.forEach(function (checkbox) {
+    const channelType = checkbox.getAttribute("data-adapter-type");
+    if (channelType) {
+      adapterTypes.push(channelType);
+      checkbox.addEventListener("change", function () {
+        setAdapterSettingsVisible(channelType);
+      });
+    }
+  });
+  return adapterTypes;
+}
+
+function setupDatalistHandlers() {
+  const hiddenInputs = document.querySelectorAll(
+    'input[type=hidden][name*="[redmine_user_id]"]'
+  );
+  hiddenInputs.forEach(function (hiddenInput) {
+    const name = hiddenInput.getAttribute("name");
+    const match = name.match(
+      /^chat_adapter_settings\[([^\]]+)\]\[redmine_user_id\]$/
+    );
+    if (!match) return;
+
+    const channelType = match[1];
+    const textInput = document.querySelector(
+      'input[list="ai-helper-users-datalist-' + channelType + '"]'
+    );
+    if (!textInput) return;
+
+    textInput.addEventListener("input", function () {
+      const enteredText = textInput.value.trim();
+      const datalistId = textInput.getAttribute("list");
+      const datalist = document.getElementById(datalistId);
+      if (!datalist) return;
+
+      let matched = false;
+      const options = datalist.querySelectorAll("option");
+      for (let i = 0; i < options.length; i++) {
+        if (options[i].textContent === enteredText) {
+          hiddenInput.value = options[i].getAttribute("value");
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        hiddenInput.value = "";
+      }
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  const adapterTypes = setupAdapterCheckboxListeners();
+  adapterTypes.forEach(function (channelType) {
+    setAdapterSettingsVisible(channelType);
+  });
+  setupDatalistHandlers();
+});

--- a/assets/javascripts/ai_helper_chat_settings.js
+++ b/assets/javascripts/ai_helper_chat_settings.js
@@ -45,13 +45,46 @@ function setupDatalistHandlers() {
       if (!datalist) return;
 
       const matched = Array.from(datalist.querySelectorAll("option")).find(
-        function (option) { return option.textContent === enteredText; }
+        function (option) { return option.getAttribute("value") === enteredText; }
       );
-      hiddenInput.value = matched ? matched.getAttribute("value") : "";
+      hiddenInput.value = matched ? matched.getAttribute("data-user-id") : "";
     }
 
     textInput.addEventListener("input", syncHiddenInput);
     textInput.addEventListener("blur", syncHiddenInput);
+  });
+}
+
+// Each adapter's "add binding" fields share the same `name` attributes
+// (they all live inside the single settings <form>), so submitting one
+// adapter's fields would otherwise carry along every other adapter's
+// same-named fields. Disable every other adapter's fields right before
+// submission so only the clicked adapter's binding is submitted.
+function setupBindingFormIsolation() {
+  const bindingFieldsets = document.querySelectorAll(
+    'fieldset[id^="adapter-bindings-"]'
+  );
+
+  function bindingFields(fieldset) {
+    return fieldset.querySelectorAll(
+      'input[name^="ai_helper_channel_binding"], select[name^="ai_helper_channel_binding"]'
+    );
+  }
+
+  bindingFieldsets.forEach(function (fieldset) {
+    const submitButtons = fieldset.querySelectorAll(
+      "input[type=submit][formaction], button[type=submit][formaction]"
+    );
+    submitButtons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        bindingFieldsets.forEach(function (otherFieldset) {
+          const disable = otherFieldset !== fieldset;
+          bindingFields(otherFieldset).forEach(function (field) {
+            field.disabled = disable;
+          });
+        });
+      });
+    });
   });
 }
 
@@ -61,4 +94,5 @@ document.addEventListener("DOMContentLoaded", function () {
     setAdapterSettingsVisible(channelType);
   });
   setupDatalistHandlers();
+  setupBindingFormIsolation();
 });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
         channel_id: "Channel ID"
         channel_name: "Channel name"
         add_binding: "Add binding"
+        no_match_message: "No matching users found"
       errors:
         service_account_not_configured: "No active execution account is configured for this chat integration, so the request could not be processed. Please ask your administrator to configure the execution account."
         channel_not_bound: "This channel is not associated with any Redmine project. Please ask your administrator to configure the channel mapping."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,6 @@ en:
         channel_id: "Channel ID"
         channel_name: "Channel name"
         add_binding: "Add binding"
-        no_match_message: "No matching users found"
       errors:
         service_account_not_configured: "No active execution account is configured for this chat integration, so the request could not be processed. Please ask your administrator to configure the execution account."
         channel_not_bound: "This channel is not associated with any Redmine project. Please ask your administrator to configure the channel mapping."
@@ -243,6 +242,12 @@ en:
         name_duplicate: "Command name is already in use"
         project_required: "Project commands require a project"
   activerecord:
+    errors:
+      models:
+        ai_helper_chat_adapter_setting:
+          attributes:
+            redmine_user_name:
+              invalid: "does not match any user"
     models:
       ai_helper_model_profile: "Model Profile"
       ai_helper_setting: "AI Helper Setting"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,6 +52,7 @@ ja:
         channel_id: "チャンネルID"
         channel_name: "チャンネル名"
         add_binding: "対応付けを追加"
+        no_match_message: "一致するユーザーが見つかりません"
       errors:
         service_account_not_configured: "このチャット連携に有効な実行アカウントが設定されていないため、処理できませんでした。管理者に実行アカウントの設定を依頼してください。"
         channel_not_bound: "このチャンネルはRedmineプロジェクトに対応付けられていません。管理者にチャンネル対応付けの設定を依頼してください。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,7 +52,6 @@ ja:
         channel_id: "チャンネルID"
         channel_name: "チャンネル名"
         add_binding: "対応付けを追加"
-        no_match_message: "一致するユーザーが見つかりません"
       errors:
         service_account_not_configured: "このチャット連携に有効な実行アカウントが設定されていないため、処理できませんでした。管理者に実行アカウントの設定を依頼してください。"
         channel_not_bound: "このチャンネルはRedmineプロジェクトに対応付けられていません。管理者にチャンネル対応付けの設定を依頼してください。"
@@ -243,6 +242,12 @@ ja:
         name_duplicate: "コマンド名が既に使用されています"
         project_required: "プロジェクトコマンドにはプロジェクトが必要です"
   activerecord:
+    errors:
+      models:
+        ai_helper_chat_adapter_setting:
+          attributes:
+            redmine_user_name:
+              invalid: "一致するユーザーが見つかりません"
     models:
       ai_helper_model_profile: "モデルプロファイル"
       ai_helper_setting: "AIヘルパー設定"

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -757,6 +757,15 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
         assert_select "#adapter-settings-ui_chat"
       end
 
+      should "render adapter-bindings fieldset with an id so JS can toggle it alongside adapter-settings" do
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test")
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#adapter-bindings-ui_chat"
+      end
+
       should "save adapter settings correctly when adapter is disabled" do
         AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-keep")
 

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -600,6 +600,18 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     end
   end
 
+  class FakeOtherAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    class << self
+      def channel_type
+        "fake_other"
+      end
+
+      def required_setting_fields
+        [ :bot_token ]
+      end
+    end
+  end
+
   context "channels tab" do
     setup do
       AiHelperChatAdapterSetting.delete_all
@@ -733,6 +745,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
         assert_response :success
         assert_select "#adapter-settings-ui_chat"
+        assert_select ".adapter-enabled-checkbox[data-adapter-type=ui_chat]"
       end
 
       should "render adapter-settings div even when adapter is disabled" do
@@ -843,15 +856,48 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       end
 
       should "filter bindings by channel_type" do
-        other_project = Project.create!(name: "Other Proj", identifier: "other-proj")
-        other_project.enable_module!(:ai_helper)
+        slack_project = Project.create!(name: "Slack Proj", identifier: "slack-proj")
+        slack_project.enable_module!(:ai_helper)
         AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
+        AiHelperChannelBinding.create!(channel_type: "fake_other", channel_id: "S222", channel_name: "#general", project: slack_project)
 
         get :index, params: { tab: "channels" }
 
         assert_response :success
         assert_select "#tab-content-channels", text: /C111/
-        other_project.destroy if other_project.persisted?
+        assert_select "#tab-content-channels", text: /S222/
+        slack_project.destroy
+      end
+
+      should "clear redmine_user_id when both name and id are blank" do
+        user = User.active.sorted.first
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id)
+
+        post :update, params: {
+          tab: "channels",
+          ai_helper_setting: {},
+          chat_adapter_settings: {
+            "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-test", "redmine_user_id" => "", "redmine_user_name" => "" }
+          }
+        }
+
+        assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+        setting = AiHelperChatAdapterSetting.for_channel("ui_chat")
+        assert_nil setting.redmine_user_id
+      end
+
+      should "reject non-matching redmine_user_name with validation error" do
+        post :update, params: {
+          tab: "channels",
+          ai_helper_setting: {},
+          chat_adapter_settings: {
+            "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-test", "redmine_user_id" => "", "redmine_user_name" => "nonexistent user" }
+          }
+        }
+
+        assert_response :success
+        assert_equal "channels", assigns(:selected_tab)
+        assert_select ".errorExplanation", text: /does not match any user/
       end
     end
   end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -620,7 +620,8 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][enabled]']"
       assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][bot_token]'][type=password]"
       assert_select "#tab-content-channels select[name='chat_adapter_settings[ui_chat][dm_default_project_id]']"
-      assert_select "#tab-content-channels select[name='chat_adapter_settings[ui_chat][redmine_user_id]']"
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][redmine_user_id]'][type=hidden]"
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][redmine_user_name]'][type=text]"
     end
 
     should "save adapter settings from the channels tab" do
@@ -722,6 +723,136 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       existing.reload
       assert_not existing.enabled, "adapter must not be partially persisted when the global setting is invalid"
       assert_equal "xoxb-old", existing.bot_token
+    end
+
+    context "US1: adapter enabled checkbox toggle visibility" do
+      should "render adapter-settings div wrapping settings fields when enabled" do
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test")
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#adapter-settings-ui_chat"
+      end
+
+      should "render adapter-settings div even when adapter is disabled" do
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false)
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#adapter-settings-ui_chat"
+      end
+
+      should "save adapter settings correctly when adapter is disabled" do
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-keep")
+
+        post :update, params: {
+          tab: "channels",
+          ai_helper_setting: {},
+          chat_adapter_settings: {
+            "ui_chat" => { "enabled" => "0", "bot_token" => AiHelperSettingsController::DUMMY_TOKEN }
+          }
+        }
+
+        assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+        setting = AiHelperChatAdapterSetting.for_channel("ui_chat")
+        assert_not setting.enabled
+        assert_equal "xoxb-keep", setting.bot_token
+      end
+    end
+
+    context "US2: incremental search account selection" do
+      should "render text input with datalist for redmine_user instead of select" do
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#tab-content-channels input[type=text][name='chat_adapter_settings[ui_chat][redmine_user_name]']"
+        assert_select "#tab-content-channels select[name='chat_adapter_settings[ui_chat][redmine_user_id]']", { count: 0 }
+      end
+
+      should "render hidden input for redmine_user_id and datalist with options" do
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#tab-content-channels input[type=hidden][name='chat_adapter_settings[ui_chat][redmine_user_id]']"
+        assert_select "#tab-content-channels datalist#ai-helper-users-datalist-ui_chat option", { minimum: 1 }
+      end
+
+      should "display selected user name in text input on page reload when redmine_user_id is set" do
+        user = User.active.sorted.first
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id)
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "input[type=text][name='chat_adapter_settings[ui_chat][redmine_user_name]'][value=?]", user.name
+        assert_select "input[type=hidden][name='chat_adapter_settings[ui_chat][redmine_user_id]'][value=?]", user.id.to_s
+      end
+
+      should "save datalist-selected user_id correctly" do
+        user = User.active.sorted.first
+
+        post :update, params: {
+          tab: "channels",
+          ai_helper_setting: {},
+          chat_adapter_settings: {
+            "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-new", "redmine_user_id" => user.id.to_s, "redmine_user_name" => user.name }
+          }
+        }
+
+        assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+        setting = AiHelperChatAdapterSetting.for_channel("ui_chat")
+        assert_equal user.id, setting.redmine_user_id
+      end
+    end
+
+    context "US3: channel bindings inside adapter" do
+      should "render channel bindings table inside each adapter fieldset" do
+        AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#tab-content-channels fieldset.box.tabular" do
+          assert_select "fieldset.box table.list td", text: "C111"
+        end
+      end
+
+      should "not render chat tool selector dropdown in channels tab" do
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "select[name='ai_helper_channel_binding[channel_type]']", { count: 0 }
+      end
+
+      should "not render channel type column in bindings table" do
+        AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#tab-content-channels fieldset.box.tabular table.list thead th", { count: 4 }
+      end
+
+      should "render hidden field with channel_type in the add binding form" do
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "input[type=hidden][name='ai_helper_channel_binding[channel_type]'][value='ui_chat']"
+      end
+
+      should "filter bindings by channel_type" do
+        other_project = Project.create!(name: "Other Proj", identifier: "other-proj")
+        other_project.enable_module!(:ai_helper)
+        AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#tab-content-channels", text: /C111/
+        other_project.destroy if other_project.persisted?
+      end
     end
   end
 end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -801,6 +801,16 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
         assert_select "#tab-content-channels datalist#ai-helper-users-datalist-ui_chat option", { minimum: 1 }
       end
 
+      should "render datalist option value as the user name with the user id in a data attribute" do
+        user = User.active.sorted.first
+
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_select "#tab-content-channels datalist#ai-helper-users-datalist-ui_chat option[value=?][data-user-id=?]",
+                      user.name, user.id.to_s
+      end
+
       should "display selected user name in text input on page reload when redmine_user_id is set" do
         user = User.active.sorted.first
         AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id)

--- a/test/javascript/ai_helper_chat_settings_test.js
+++ b/test/javascript/ai_helper_chat_settings_test.js
@@ -1,0 +1,172 @@
+// Tests for the channels tab settings JS (assets/javascripts/ai_helper_chat_settings.js).
+// These cover two fixes:
+//   1. syncHiddenInput must match datalist options by their `value` (the user
+//      name, what the browser actually writes into the text input when a
+//      suggestion is picked) and copy the id from `data-user-id`, not the
+//      option's textContent/value pair used before the fix.
+//   2. setupBindingFormIsolation must disable every other adapter's
+//      "add binding" fields before a submit so same-named fields from other
+//      adapters are not sent along with the clicked adapter's binding.
+//
+// To run these tests, a JavaScript test environment (e.g., Jest + jsdom) is
+// required. If no JS test environment is available, verify manually using
+// the running app: PR #354 review comments on
+// app/views/ai_helper_settings/_channels_tab.html.erb and
+// assets/javascripts/ai_helper_chat_settings.js describe the original bugs.
+
+/**
+ * Helper: build a minimal datalist + text input + hidden input trio,
+ * matching the markup rendered by _channels_tab.html.erb.
+ */
+function createDatalistDOM(channelType, users) {
+  const container = document.createElement("div");
+
+  const textInput = document.createElement("input");
+  textInput.setAttribute("list", `ai-helper-users-datalist-${channelType}`);
+  container.appendChild(textInput);
+
+  const hiddenInput = document.createElement("input");
+  hiddenInput.type = "hidden";
+  hiddenInput.name = `chat_adapter_settings[${channelType}][redmine_user_id]`;
+  container.appendChild(hiddenInput);
+
+  const datalist = document.createElement("datalist");
+  datalist.id = `ai-helper-users-datalist-${channelType}`;
+  users.forEach(function (user) {
+    const option = document.createElement("option");
+    option.setAttribute("value", user.name);
+    option.setAttribute("data-user-id", String(user.id));
+    datalist.appendChild(option);
+  });
+  container.appendChild(datalist);
+
+  document.body.appendChild(container);
+  return { container, textInput, hiddenInput };
+}
+
+// Test 1: selecting a datalist option (browser writes its `value`, the user
+// name, into the input) resolves the correct user id into the hidden field.
+function testSyncHiddenInputMatchesByNameValue() {
+  const { container, textInput, hiddenInput } = createDatalistDOM("ui_chat", [
+    { id: 3, name: "Dave Lopper" },
+    { id: 7, name: "Redmine Admin" }
+  ]);
+
+  textInput.value = "Dave Lopper";
+  textInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+  console.assert(hiddenInput.value === "3",
+    `Test 1 FAILED: expected hidden user id '3', got '${hiddenInput.value}'`);
+
+  container.remove();
+  console.log("Test 1 PASSED: selecting an option by its name value resolves the correct user id");
+}
+
+// Test 2: text that does not match any option clears the hidden id.
+function testSyncHiddenInputClearsOnNoMatch() {
+  const { container, textInput, hiddenInput } = createDatalistDOM("ui_chat", [
+    { id: 3, name: "Dave Lopper" }
+  ]);
+
+  textInput.value = "Someone Else";
+  textInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+  console.assert(hiddenInput.value === "",
+    `Test 2 FAILED: expected hidden user id to be cleared, got '${hiddenInput.value}'`);
+
+  container.remove();
+  console.log("Test 2 PASSED: non-matching text clears the hidden user id");
+}
+
+/**
+ * Helper: build two adapter binding fieldsets sharing the same field names,
+ * matching the markup rendered once per adapter by _channels_tab.html.erb.
+ */
+function createBindingFieldsets(channelTypes) {
+  const container = document.createElement("div");
+  const fieldsets = {};
+
+  channelTypes.forEach(function (channelType) {
+    const fieldset = document.createElement("fieldset");
+    fieldset.id = `adapter-bindings-${channelType}`;
+
+    const channelTypeInput = document.createElement("input");
+    channelTypeInput.type = "hidden";
+    channelTypeInput.name = "ai_helper_channel_binding[channel_type]";
+    channelTypeInput.value = channelType;
+    fieldset.appendChild(channelTypeInput);
+
+    const channelIdInput = document.createElement("input");
+    channelIdInput.type = "text";
+    channelIdInput.name = "ai_helper_channel_binding[channel_id]";
+    fieldset.appendChild(channelIdInput);
+
+    const submitButton = document.createElement("input");
+    submitButton.type = "submit";
+    submitButton.setAttribute("formaction", "/ai_helper_channel_bindings");
+    fieldset.appendChild(submitButton);
+
+    container.appendChild(fieldset);
+    fieldsets[channelType] = { fieldset, channelTypeInput, channelIdInput, submitButton };
+  });
+
+  document.body.appendChild(container);
+  return { container, fieldsets };
+}
+
+// Test 3: clicking one adapter's "add binding" submit disables every other
+// adapter's same-named fields, so only the clicked adapter's fields would be
+// serialized on submit.
+function testBindingFormIsolationDisablesOtherAdapters() {
+  const { container, fieldsets } = createBindingFieldsets(["ui_chat", "fake_other"]);
+
+  setupBindingFormIsolation();
+  fieldsets.ui_chat.submitButton.click();
+
+  console.assert(fieldsets.ui_chat.channelIdInput.disabled === false,
+    "Test 3 FAILED: the clicked adapter's own fields must stay enabled");
+  console.assert(fieldsets.fake_other.channelIdInput.disabled === true,
+    "Test 3 FAILED: the other adapter's fields must be disabled");
+  console.assert(fieldsets.fake_other.channelTypeInput.disabled === true,
+    "Test 3 FAILED: the other adapter's hidden channel_type field must be disabled");
+
+  container.remove();
+  console.log("Test 3 PASSED: clicking an adapter's add-binding button isolates its fields");
+}
+
+// Test 4: clicking the other adapter's submit afterwards flips which
+// fieldset is enabled/disabled.
+function testBindingFormIsolationSwitchesActiveAdapter() {
+  const { container, fieldsets } = createBindingFieldsets(["ui_chat", "fake_other"]);
+
+  setupBindingFormIsolation();
+  fieldsets.ui_chat.submitButton.click();
+  fieldsets.fake_other.submitButton.click();
+
+  console.assert(fieldsets.fake_other.channelIdInput.disabled === false,
+    "Test 4 FAILED: the newly clicked adapter's fields must be re-enabled");
+  console.assert(fieldsets.ui_chat.channelIdInput.disabled === true,
+    "Test 4 FAILED: the previously active adapter's fields must now be disabled");
+
+  container.remove();
+  console.log("Test 4 PASSED: switching the clicked adapter re-isolates fields correctly");
+}
+
+// Run all tests
+function runAllTests() {
+  console.log("=== Chat Settings JS Fix Tests ===\n");
+
+  testSyncHiddenInputMatchesByNameValue();
+  testSyncHiddenInputClearsOnNoMatch();
+  testBindingFormIsolationDisablesOtherAdapters();
+  testBindingFormIsolationSwitchesActiveAdapter();
+
+  console.log("\n=== All tests completed ===");
+}
+
+// Export for module environments, or run directly
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { runAllTests };
+} else if (typeof window !== "undefined") {
+  window.runChatSettingsTests = runAllTests;
+}

--- a/test/unit/ai_helper_chat_adapter_setting_test.rb
+++ b/test/unit/ai_helper_chat_adapter_setting_test.rb
@@ -59,6 +59,37 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
 
       assert_predicate setting, :valid?
     end
+
+    should "be valid when redmine_user_name is blank and redmine_user_id is blank" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat", enabled: true,
+        app_token: "xapp-test", bot_token: "xoxb-test",
+        redmine_user_name: "", redmine_user_id: nil
+      )
+
+      assert_predicate setting, :valid?
+    end
+
+    should "be valid when both redmine_user_name and redmine_user_id are present" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat", enabled: true,
+        app_token: "xapp-test", bot_token: "xoxb-test",
+        redmine_user_name: "User 2", redmine_user_id: 2
+      )
+
+      assert_predicate setting, :valid?
+    end
+
+    should "reject redmine_user_name when redmine_user_id is blank" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat", enabled: true,
+        app_token: "xapp-test", bot_token: "xoxb-test",
+        redmine_user_name: "Nonexistent User", redmine_user_id: ""
+      )
+
+      assert_not setting.valid?
+      assert_predicate setting.errors[:redmine_user_name], :present?
+    end
   end
 
   context "safe_attributes" do


### PR DESCRIPTION
## Changes

- Toggle each adapter's settings visibility based on its "enabled" checkbox
- Replace the Redmine user select with an incremental-search text input backed by a datalist
- Move the channel bindings table and add-binding form inside each adapter's fieldset, removing the chat tool dropdown
- Validate `redmine_user_name` against actual users server-side when `redmine_user_id` is blank
- Hide the channel bindings fieldset together with the adapter settings when the adapter is disabled