### PR TITLE
Add Discord chat channel adapter

### DIFF
--- a/.claude/skills/regression-check/SKILL.md
+++ b/.claude/skills/regression-check/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: regression-check
+description: Run the full regression suite for the redmine_ai_helper plugin (YARD doc coverage, RuboCop, and the plugin test suite) via .devcontainer/regression-check.sh
+---
+
+# Regression Check
+
+Run the plugin's full regression check: YARD documentation coverage, RuboCop linting, and the complete Minitest suite.
+
+## Workflow
+
+### Step 1: Run the regression script
+
+```bash
+sh -x .devcontainer/regression-check.sh
+```
+
+The script (`.devcontainer/regression-check.sh`) does the following, in order, aborting on the first failure (`set -ex`):
+
+1. `cd` into the plugin root
+2. `yard stats --list-undoc | tee /dev/stderr | grep -q "100.00%"` — fails if documentation coverage drops below 100%
+3. `rubocop` — fails on any offense
+4. `cd /usr/local/redmine` then `bundle exec rake redmine:plugins:test` — runs the full Redmine test suite (all plugins, not just `NAME=redmine_ai_helper`)
+
+### Step 2: Triage failures
+
+- **YARD gap**: find the newly undocumented module/class/method/constant/attribute and add a doc comment.
+- **RuboCop offense**: fix per the `rubocop` skill's guidelines (see `.claude/skills/rubocop/SKILL.md`); never relax `.rubocop.yml` thresholds without explicit user approval.
+- **Test failure/error**: investigate the failing test, fix the underlying code (never disable or delete the test to make it pass), then re-run.
+
+### Step 3: Re-run until clean
+
+Re-run the script after each fix until it exits 0 with:
+- `100.00% documented`
+- `no offenses detected`
+- `0 failures, 0 errors, 0 skips`
+
+## Notes
+
+- Must be run from a shell that can `cd` into `/usr/local/redmine` — the script assumes the plugin lives at `/usr/local/redmine/plugins/redmine_ai_helper`.
+- This runs the *entire* Redmine test suite (all plugins), which takes noticeably longer than `rake redmine:plugins:test NAME=redmine_ai_helper`. Use the narrower `NAME=` form for quick iteration while fixing a single test, and this skill for the final full check.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/029-chat-gateway-settings-improve"
+  "feature_directory": "specs/030-discord-adapter"
 }

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -19,24 +19,18 @@
                         data: { adapter_type: channel_type }, class: "adapter-enabled-checkbox" %>
     </p>
     <div id="adapter-settings-<%= channel_type %>">
-      <p>
-        <label><%= t("ai_helper.chat_channel.settings.app_token") %></label>
-        <%= password_field_tag "chat_adapter_settings[#{channel_type}][app_token]",
-                               token_field_value(adapter_setting.app_token),
-                               size: 60, id: nil, autocomplete: "new-password" %>
-        <% if adapter_setting.app_token.present? %>
-          <em class="info"><%= adapter_setting.masked_app_token %></em>
-        <% end %>
-      </p>
-      <p>
-        <label><%= t("ai_helper.chat_channel.settings.bot_token") %></label>
-        <%= password_field_tag "chat_adapter_settings[#{channel_type}][bot_token]",
-                               token_field_value(adapter_setting.bot_token),
-                               size: 60, id: nil, autocomplete: "new-password" %>
-        <% if adapter_setting.bot_token.present? %>
-          <em class="info"><%= adapter_setting.masked_bot_token %></em>
-        <% end %>
-      </p>
+      <% token_fields = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type].required_setting_fields & [:app_token, :bot_token] %>
+      <% token_fields.each do |token_field| %>
+        <p>
+          <label><%= t("ai_helper.chat_channel.settings.#{token_field}") %></label>
+          <%= password_field_tag "chat_adapter_settings[#{channel_type}][#{token_field}]",
+                                 token_field_value(adapter_setting.send(token_field)),
+                                 size: 60, id: nil, autocomplete: "new-password" %>
+          <% if adapter_setting.send(token_field).present? %>
+            <em class="info"><%= adapter_setting.send("masked_#{token_field}") %></em>
+          <% end %>
+        </p>
+      <% end %>
       <p>
         <label><%= t("ai_helper.chat_channel.settings.redmine_user") %></label>
         <% selected_user = @ai_helper_users.find { |u| u.id == adapter_setting.redmine_user_id } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     chat_channel:
       adapters:
         slack: "Slack"
+        discord: "Discord"
       settings:
         enabled: "Enable"
         app_token: "App Token"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,6 +40,7 @@ ja:
     chat_channel:
       adapters:
         slack: "Slack"
+        discord: "Discord"
       settings:
         enabled: "有効にする"
         app_token: "App Token"

--- a/docs/adr/007-discord-adapter-connection-design.md
+++ b/docs/adr/007-discord-adapter-connection-design.md
@@ -59,12 +59,17 @@ conversation-level decisions:
      `GET /channels/{id}` resolves the thread's `parent_id`, so bindings match
      on the parent channel and `thread_key = "{parent_id}:{thread_id}"`.
    - **Reply mode** (DMs, and channels where a thread cannot be created):
-     replies are posted as Discord replies (`message_reference`) and the
-     conversation continues when a user replies to one of the bot's answers.
-     `thread_key = "{channel_id}:msg:{root_message_id}"`, where the root is
-     found by walking the reply chain back to its origin with
-     `GET /channels/{id}/messages/{id}`. A reply to a non-bot message, or a
-     referenced message that cannot be fetched, starts a new conversation.
+     replies are posted as Discord replies (`message_reference`).
+     `thread_key = "{channel_id}:msg:{root_message_id}"`. In DMs the
+     conversation continues when a user replies to one of the bot's answers,
+     the root found by walking the reply chain back to its origin with
+     `GET /channels/{id}/messages/{id}`; a reply to a non-bot message, or a
+     referenced message that cannot be fetched, starts a new conversation. In
+     guild reply mode, replying with `message_reference` is only the answer's
+     posting format (per FR-013/FR-007, spec.md:254-255) — it is not a
+     continuation mechanism, since `process_guild_message` does not inspect
+     `message_reference`; every mention in these channels starts a new
+     conversation.
 
 4. **Gateway fault isolation instead of single-adapter-crash-stops-all.** The
    gateway now keeps running while any adapter thread is alive: a crashed

--- a/docs/adr/007-discord-adapter-connection-design.md
+++ b/docs/adr/007-discord-adapter-connection-design.md
@@ -1,0 +1,120 @@
+# ADR-007: Discord adapter connection design
+
+**Date**: 2026-07-19
+**Status**: Accepted
+
+## Context
+
+Feature 030 adds Discord as the second chat integration on top of the
+abstraction layer built in feature 028 (ADR-006): a `ChatChannel::BaseAdapter`
+subclass, the shared tool-independent `MessageHandler`, and a resident gateway
+process. Discord differs from Slack in ways that force several connection- and
+conversation-level decisions:
+
+1. Discord has no Socket-Mode equivalent that hands out a per-connection URL
+   with a separate app-level token; a bot connects to the Gateway with one bot
+   token and must run its own heartbeat/identify handshake.
+2. Reading arbitrary message content now requires the **privileged
+   MESSAGE_CONTENT intent**, which needs extra Developer-Portal setup (and
+   review for large bots).
+3. Discord has first-class **threads** and **replies**, so "same conversation"
+   can be expressed in more than one way.
+4. Discord's Gateway supports session **Resume**, an optional but non-trivial
+   protocol for replaying missed events after a disconnect.
+5. FR-014 requires Slack and Discord to run in one gateway process so that one
+   integration's failure does not stop the other — the single-adapter crash
+   behavior from ADR-006 is no longer acceptable.
+
+## Decision
+
+1. **Minimal intents, no privileged MESSAGE_CONTENT.** The Identify payload
+   requests `GUILD_MESSAGES (512) + DIRECT_MESSAGES (4096) = 4608` only.
+   Discord still delivers the full `content` of messages that mention the bot
+   and of direct messages even without MESSAGE_CONTENT, which is exactly the
+   set this integration reacts to (bot mentions and DMs). Messages that do not
+   mention the bot arrive with empty `content` and are naturally ignored. This
+   keeps the operator's setup simple (SC-004) and is the least-privilege
+   configuration.
+
+2. **Re-Identify on every reconnect; no Resume.** All three reconnect triggers
+   — Reconnect/Invalid Session opcodes, socket errors (exponential backoff
+   1s→60s), and missed heartbeat acks (zombie-connection detection) — open a
+   fresh connection and send a new Identify. Resume (tracking
+   `resume_gateway_url`, `session_id` and the sequence number, plus Opcode 6
+   and event replay) is deliberately not implemented. Its only benefit is
+   avoiding a session-start-limit charge (default 1,000/day), and realistic
+   disconnect rates stay far below that. Missed messages during a disconnect
+   are already an accepted edge case. Authentication/configuration failures
+   (REST 401, close codes 4004/4013/4014) raise `DiscordApiError` and terminate
+   without retry, matching ADR-006's "credential problems are never retried".
+
+3. **Conversation identity via a `thread_key` with three modes.** The
+   `thread_key` both identifies the conversation and tells `send_message` where
+   to post, with no new database entity (028's constraint):
+   - **Thread mode** (guild, new mention in a normal channel): a thread is
+     created from the question message. Because a message-created thread's id
+     equals the message id, `thread_key = "{parent_channel_id}:{thread_id}"` is
+     decided at receive time with no extra state.
+   - **Thread continuation** (mention inside an existing thread):
+     `GET /channels/{id}` resolves the thread's `parent_id`, so bindings match
+     on the parent channel and `thread_key = "{parent_id}:{thread_id}"`.
+   - **Reply mode** (DMs, and channels where a thread cannot be created):
+     replies are posted as Discord replies (`message_reference`) and the
+     conversation continues when a user replies to one of the bot's answers.
+     `thread_key = "{channel_id}:msg:{root_message_id}"`, where the root is
+     found by walking the reply chain back to its origin with
+     `GET /channels/{id}/messages/{id}`. A reply to a non-bot message, or a
+     referenced message that cannot be fetched, starts a new conversation.
+
+4. **Gateway fault isolation instead of single-adapter-crash-stops-all.** The
+   gateway now keeps running while any adapter thread is alive: a crashed
+   adapter is logged (distinguishing configuration/credential errors) but not
+   restarted, and the gateway shuts down only when the last adapter exits. When
+   all adapters have died, it raises `ConfigurationError` if every death was a
+   configuration/credential error (exit 0, no supervisor retry) or the first
+   genuine runtime error otherwise (supervisor retries). A graceful shutdown
+   (SIGTERM/SIGINT) never reports past adapter deaths as an error. With a single
+   adapter the behavior is identical to ADR-006 (crash = zero adapters =
+   shutdown), so the change is backward compatible.
+
+## Consequences
+
+**Positive**:
+
+- Operator setup needs no privileged intents and no public URL (outgoing WSS
+  only), consistent with the Slack integration.
+- Reply-chain resolution is stateless, so DM conversations survive a gateway
+  restart without persisting any mapping.
+- Slack and Discord run in one process; a bad Discord token no longer takes
+  Slack down (FR-014). SC-006 holds: `MessageHandler`, `IncomingMessage`,
+  `BaseAdapter` and the Slack adapter are unchanged.
+- No new gem, table, or migration; the adapter is one file auto-loaded and
+  auto-registered by the existing `inherited` hook.
+
+**Negative**:
+
+- Continuation in reply mode costs one REST call per chain hop to walk to the
+  root. This is negligible against LLM latency (SC-002) but is more traffic
+  than a stored mapping would need.
+- Without Resume, events published during a disconnect are lost (accepted edge
+  case), and frequent reconnects consume session-start budget.
+- Reacting in a newly created thread requires remembering the message's real
+  channel in an in-memory map, which is process-local (rebuilt on restart, in
+  lockstep with the also-lost in-flight queue, so no inconsistency).
+
+## Alternatives Considered
+
+- **Use the MESSAGE_CONTENT privileged intent**: rejected — unnecessary for a
+  mention/DM-only bot and it complicates operator setup.
+- **`discordrb` gem**: rejected — a large library with its own event loop and
+  many dependencies, disproportionate to a single low-traffic connection (same
+  reasoning that rejected `slack-ruby-client` in ADR-006).
+- **Implement Gateway Resume**: rejected — significant protocol and test
+  complexity for a benefit (avoiding session-start-limit consumption) that does
+  not matter at this scale; re-Identify is simpler and sufficient.
+- **Persist a message-id → conversation map for DM continuation**: rejected —
+  would add a new entity, violating 028's "no new entities" design; stateless
+  reply-chain walking is restart-safe and needs no schema.
+- **Keep the single-adapter-crash-stops-all gateway**: rejected — directly
+  contradicts FR-014; one integration's credential problem must not stop the
+  other.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,5 @@ Briefly describe alternatives that were rejected and why.
 | [003](./003-vector-target-project-selection.md) | Select which projects are registered in the vector database | Proposed |
 | [004](./004-structured-output-native-and-fallback.md) | Two-tier structured output — native API schema enforcement with a prompt-based fallback pipeline | Proposed |
 | [005](./005-write-tool-classification-for-read-only-mode.md) | Write-tool classification via a `define_function` DSL attribute for read-only mode | Proposed |
+| [006](./006-chat-channel-gateway-architecture.md) | External chat tool gateway with Socket Mode and a serialized worker | Accepted |
+| [007](./007-discord-adapter-connection-design.md) | Discord adapter connection design | Accepted |

--- a/docs/discord_gateway_setup.md
+++ b/docs/discord_gateway_setup.md
@@ -31,7 +31,7 @@ which uses two tokens), and it does **not** require any privileged intents.
 3. Under **Privileged Gateway Intents**, leave **Message Content Intent**
    **OFF**. This integration only reacts to messages that mention the bot and
    to direct messages, both of which Discord delivers in full without the
-   privileged intent. Leaving it off keeps the bot at least privilege and needs
+   privileged intent. Leaving it off keeps the bot least-privileged and needs
    no Discord review.
 
 ## 2. Invite the bot to your server

--- a/docs/discord_gateway_setup.md
+++ b/docs/discord_gateway_setup.md
@@ -1,0 +1,105 @@
+# Discord Gateway Setup Guide
+
+This guide explains how to connect the Redmine AI Helper to a Discord server so
+users can ask the AI Helper questions from Discord channels or direct messages
+and receive answers in the same thread.
+
+The integration uses the Discord **Gateway API**: the gateway process opens an
+outgoing WebSocket connection to Discord, so **no public URL is required** for
+your Redmine server. The bot needs only a single **bot token** (unlike Slack,
+which uses two tokens), and it does **not** require any privileged intents.
+
+## Requirements
+
+- Redmine 6.x with the `redmine_ai_helper` plugin installed, migrated, and a
+  working model profile (the web chat must already work).
+- Permission to create an application in the Discord Developer Portal and to
+  invite a bot to the target Discord server.
+- A dedicated Redmine **service account** (e.g. a user named `ai_helper`) that
+  the gateway runs as. Add it to the relevant projects with an appropriate
+  role — every question from Discord is answered with **this account's
+  permissions**, regardless of who asks. Restricting the account's roles is how
+  you limit what the gateway can read and do (e.g. read-only, or no issue
+  deletion).
+
+## 1. Create the Discord bot
+
+1. Open <https://discord.com/developers/applications> and choose **New
+   Application**. Give it a name (this becomes the bot's name).
+2. In the **Bot** section, click **Reset Token** (or **Add Bot**) and copy the
+   **bot token**. Store it securely — Discord shows it only once.
+3. Under **Privileged Gateway Intents**, leave **Message Content Intent**
+   **OFF**. This integration only reacts to messages that mention the bot and
+   to direct messages, both of which Discord delivers in full without the
+   privileged intent. Leaving it off keeps the bot at least privilege and needs
+   no Discord review.
+
+## 2. Invite the bot to your server
+
+1. In the **OAuth2 → URL Generator** section, select the `bot` scope.
+2. Under **Bot Permissions**, select:
+   - **View Channels** — see the channels it is used in
+   - **Send Messages** — post answers
+   - **Send Messages in Threads** — answer inside threads
+   - **Create Public Threads** — start a thread from a question
+   - **Add Reactions** — show the "processing" reaction (⏳)
+   - **Read Message History** — follow reply chains for continued conversations
+3. Open the generated URL, choose the target server, and authorize. You need
+   **Manage Server** permission on that server to complete the invite.
+
+## 3. Configure Redmine
+
+1. Go to **Administration → AI Helper → Chat integrations** tab.
+2. In the **Discord** section, check **Enable** and paste the **Bot Token**.
+   (Discord uses one token only; there is no App Token field here.)
+3. Select the **Execution account** — the Redmine service account all Discord
+   questions run as. Without an active execution account, the bot answers every
+   question with a guidance message. Speakers are **not** mapped to individual
+   Redmine users; anyone who can post in a bound channel (or DM the bot) uses
+   this account's permissions, so keep its roles as narrow as the use case
+   allows.
+4. Optionally select a **Default project for direct messages**. DMs to the bot
+   are answered in this project's context; without it, DMs receive a guidance
+   message. Save.
+5. Under **Channel bindings**, map each Discord channel to a Redmine project:
+   - Channel ID: enable **Developer Mode** in Discord
+     (**User Settings → Advanced → Developer Mode**), then right-click the
+     channel and choose **Copy Channel ID**. Register the **parent channel's**
+     ID — not a thread's — because the bot resolves thread messages to their
+     parent channel before matching.
+   - Channel name is optional display text for this screen.
+   - One channel maps to exactly one project. The project must have the **AI
+     Helper** module enabled.
+
+## 4. Run the gateway
+
+The gateway is a resident process, separate from the Redmine web server, and it
+runs every enabled adapter (Slack and Discord together):
+
+```bash
+cd /path/to/redmine
+bundle exec rake redmine:plugins:ai_helper:chat_channel:gateway RAILS_ENV=production
+```
+
+On success, `log/ai_helper.log` records the connection establishment (`READY`
+received). With an invalid bot token the gateway logs the authentication error
+and (when Discord is the only integration) exits with status **0** so the
+supervisor does not keep retrying — fix the token and start it again. When Slack
+is also configured, a broken Discord token is logged and Discord stops while
+Slack keeps running, and vice versa.
+
+The gateway reconnects automatically on Discord's Reconnect / Invalid Session
+requests, on network errors (exponential backoff up to 60 s), and on missed
+heartbeat acknowledgements (zombie-connection detection). Stop it with
+`SIGTERM` or `Ctrl+C`; queued messages are drained before exit.
+
+## 5. Use it
+
+- **In a bound channel**: mention the bot (`@YourBot how many open issues?`).
+  The bot adds a ⏳ reaction and posts the answer in a thread started from your
+  question. Continue by mentioning the bot again inside that thread.
+- **In a direct message**: just send your question (no mention needed). The bot
+  replies to your message; continue the conversation by replying to the bot's
+  answer. A new, non-reply message starts a fresh conversation.
+- Answers longer than Discord's 2,000-character limit are split across several
+  messages with no content lost.

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -46,6 +46,10 @@ module RedmineAiHelper
 
         # Base URL of the Discord REST API (v10).
         DISCORD_API_BASE = "https://discord.com/api/v10"
+        # Gateway API version and payload encoding. Both are required query
+        # params on the gateway WebSocket URL; omitting them connects to
+        # Discord's current default version, which can change unannounced.
+        GATEWAY_QUERY_STRING = "v=10&encoding=json"
         # Open/read timeout for every REST call (contract: 10 seconds).
         HTTP_TIMEOUT_SECONDS = 10
         # Upper bound of the exponential reconnect backoff.
@@ -60,7 +64,7 @@ module RedmineAiHelper
         # Poll interval while waiting for the Hello opcode that carries the
         # real heartbeat interval.
         HELLO_WAIT_SECONDS = 1
-        # Channel types that are threads (public, private, announcement).
+        # Channel types that are threads (announcement, public, private).
         THREAD_CHANNEL_TYPES = [ 10, 11, 12 ].freeze
         # Message types this integration reacts to: DEFAULT and REPLY.
         REPLYABLE_MESSAGE_TYPES = [ 0, 19 ].freeze
@@ -72,6 +76,18 @@ module RedmineAiHelper
         THREAD_NAME_MAX_LENGTH = 100
         # Reaction shown while a question is being processed (FR-009).
         PROCESSING_EMOJI = "\u{23F3}" # ⏳
+        # Upper bound on @reply_targets: the gateway is a resident process, and
+        # reply-mode entries have no other eviction path, so the map is capped
+        # and the oldest entry is dropped once it is exceeded (FIFO). Losing an
+        # old entry only widens the message #send_message references (the root
+        # id fallback still resolves the right conversation).
+        MAX_REPLY_TARGETS = 500
+        # Upper bound on reply-chain hops walked by #walk_to_root. Each hop is
+        # a blocking REST call on the WebSocket receive thread, so an
+        # unbounded chain would stall heartbeat processing long enough to be
+        # mistaken for a zombie connection. Beyond the limit, the
+        # farthest-resolved message is treated as the root.
+        MAX_REPLY_CHAIN_HOPS = 20
 
         # Gateway opcode 0: a dispatch event (READY, MESSAGE_CREATE, ...).
         OP_DISPATCH = 0
@@ -270,7 +286,7 @@ module RedmineAiHelper
           @last_sequence = nil
           @fatal_close = nil
           adapter = self
-          @ws = WebSocket::Client::Simple.connect(url) do |ws|
+          @ws = WebSocket::Client::Simple.connect("#{url}?#{GATEWAY_QUERY_STRING}") do |ws|
             ws.on(:message) do |msg|
               case msg.type
               when :text  then adapter.send(:handle_gateway_message, msg.data)
@@ -460,14 +476,17 @@ module RedmineAiHelper
         # @return [String] the origin message id
         def walk_to_root(channel_id, message)
           current = message
+          hops = 0
           loop do
             referenced_id = current.dig("message_reference", "message_id")
             return current["id"] if referenced_id.blank?
+            return current["id"] if hops >= MAX_REPLY_CHAIN_HOPS
 
             parent = safe_fetch_message(channel_id, referenced_id)
             return current["id"] if parent.nil?
 
             current = parent
+            hops += 1
           end
         end
 
@@ -513,7 +532,9 @@ module RedmineAiHelper
         # @param message_id [String] the question message id
         # @return [void]
         def record_reply_target(thread_key, message_id)
+          @reply_targets.delete(thread_key)
           @reply_targets[thread_key] = message_id
+          @reply_targets.delete(@reply_targets.each_key.first) while @reply_targets.size > MAX_REPLY_TARGETS
         end
 
         # Records the channel a received message actually arrived in, so the
@@ -749,7 +770,8 @@ module RedmineAiHelper
         def retry_after_seconds(response)
           body = JSON.parse(response.body.to_s)
           body["retry_after"].to_f
-        rescue JSON::ParserError
+        rescue JSON::ParserError => e
+          ai_helper_logger.debug "discord: could not parse retry_after from 429 body (#{e.message}); falling back to 1s"
           1.0
         end
 

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -413,7 +413,8 @@ module RedmineAiHelper
           channel_id = data["channel_id"]
           message_id = data["id"]
           text = strip_mention(content)
-          channel = fetch_channel(channel_id)
+          channel = safe_fetch_channel(channel_id)
+          return unless channel
 
           if THREAD_CHANNEL_TYPES.include?(channel["type"])
             parent_id = channel["parent_id"]
@@ -488,6 +489,24 @@ module RedmineAiHelper
             current = parent
             hops += 1
           end
+        end
+
+        # Fetches a channel, logging and swallowing non-fatal failures (a
+        # permission problem or transient network error while resolving a
+        # channel's type must drop only this message, not tear down the
+        # gateway connection: raising here would escape into the WebSocket
+        # gem's per-message rescue and force an immediate, unthrottled
+        # reconnect). Fatal auth errors still propagate so #start can
+        # terminate without retry.
+        # @param channel_id [String] the channel id
+        # @return [Hash, nil] the channel, or nil when it cannot be fetched
+        def safe_fetch_channel(channel_id)
+          fetch_channel(channel_id)
+        rescue DiscordApiError
+          raise
+        rescue => e
+          ai_helper_logger.warn "discord: failed to fetch channel #{channel_id}: #{e.message}"
+          nil
         end
 
         # Whether the message was authored by the bot itself.
@@ -635,10 +654,15 @@ module RedmineAiHelper
           request(:post, "/channels/#{channel_id}/messages/#{message_id}/threads",
                   body: { name: thread_name(text) })
           message_id
+        rescue DiscordApiError
+          raise
         rescue DiscordRequestError => e
           return message_id if e.code == THREAD_ALREADY_EXISTS_CODE
 
           ai_helper_logger.warn "discord: could not create thread (HTTP #{e.status}); falling back to reply mode"
+          nil
+        rescue => e
+          ai_helper_logger.warn "discord: could not create thread (#{e.message}); falling back to reply mode"
           nil
         end
 

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -309,7 +309,7 @@ module RedmineAiHelper
         def heartbeat_loop
           until stopped? || @reconnect_requested
             wait = @heartbeat_interval || HELLO_WAIT_SECONDS
-            break if @connection_ended.pop(timeout: wait)
+            break if self.class.timed_queue_pop(@connection_ended, wait)
             next if @heartbeat_interval.nil?
 
             unless @heartbeat_acked

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -1,0 +1,767 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+require "websocket-client-simple"
+require "redmine_ai_helper/chat_channel/base_adapter"
+
+module RedmineAiHelper
+  module ChatChannel
+    module Adapters
+      # Discord adapter using the Gateway API (v10): an outgoing WebSocket
+      # connection to Discord, so no public URL is required. REST calls
+      # (/users/@me, /gateway/bot, /channels/...) go through Net::HTTP with the
+      # bot token. Only the GUILD_MESSAGES and DIRECT_MESSAGES intents are used;
+      # the privileged MESSAGE_CONTENT intent is not required because Discord
+      # still delivers the full content of messages that mention the bot and of
+      # direct messages, which is exactly what this integration reacts to. The
+      # bot token is never written to the log or to any exception message.
+      class DiscordAdapter < BaseAdapter
+        # Raised on authentication/configuration failures (REST 401, gateway
+        # close codes 4004/4013/4014). Classified as a fatal config error so
+        # the gateway exits cleanly and the supervisor does not retry into the
+        # same broken credentials (ADR-006). Token values never appear here.
+        class DiscordApiError < StandardError; end
+
+        # Raised on non-authentication REST failures (other 4xx/5xx, exhausted
+        # rate-limit retries). Not fatal: the supervisor may restart. Carries
+        # the HTTP status and the Discord error code so callers can react to
+        # specific conditions (e.g. "thread already exists").
+        class DiscordRequestError < StandardError
+          # @return [Integer, nil] the HTTP status code
+          attr_reader :status
+          # @return [Integer, nil] the Discord JSON error code, when present
+          attr_reader :code
+
+          # @param message [String] human-readable error (never the token)
+          # @param status [Integer, nil] HTTP status code
+          # @param code [Integer, nil] Discord error code
+          def initialize(message, status: nil, code: nil)
+            super(message)
+            @status = status
+            @code = code
+          end
+        end
+
+        # Base URL of the Discord REST API (v10).
+        DISCORD_API_BASE = "https://discord.com/api/v10"
+        # Open/read timeout for every REST call (contract: 10 seconds).
+        HTTP_TIMEOUT_SECONDS = 10
+        # Upper bound of the exponential reconnect backoff.
+        MAX_BACKOFF_SECONDS = 60
+        # Replies longer than this are split before posting (Discord's hard
+        # limit is 2,000; 1,900 leaves headroom).
+        MAX_MESSAGE_LENGTH = 1900
+        # GUILD_MESSAGES (1<<9) + DIRECT_MESSAGES (1<<12). No privileged intent.
+        GATEWAY_INTENTS = 4608
+        # Maximum number of times a 429 response is retried before giving up.
+        MAX_RATE_LIMIT_RETRIES = 3
+        # Poll interval while waiting for the Hello opcode that carries the
+        # real heartbeat interval.
+        HELLO_WAIT_SECONDS = 1
+        # Channel types that are threads (public, private, announcement).
+        THREAD_CHANNEL_TYPES = [ 10, 11, 12 ].freeze
+        # Message types this integration reacts to: DEFAULT and REPLY.
+        REPLYABLE_MESSAGE_TYPES = [ 0, 19 ].freeze
+        # Gateway close codes that indicate a fatal configuration problem.
+        FATAL_CLOSE_CODES = [ 4004, 4013, 4014 ].freeze
+        # Discord error code returned when a message already has a thread.
+        THREAD_ALREADY_EXISTS_CODE = 160004
+        # Maximum length of an auto-generated thread name (Discord limit: 100).
+        THREAD_NAME_MAX_LENGTH = 100
+        # Reaction shown while a question is being processed (FR-009).
+        PROCESSING_EMOJI = "\u{23F3}" # ⏳
+
+        # Gateway opcode 0: a dispatch event (READY, MESSAGE_CREATE, ...).
+        OP_DISPATCH = 0
+        # Gateway opcode 1: heartbeat (sent by us, or requested by the server).
+        OP_HEARTBEAT = 1
+        # Gateway opcode 2: Identify, sent after Hello to authenticate.
+        OP_IDENTIFY = 2
+        # Gateway opcode 7: the server asks us to reconnect.
+        OP_RECONNECT = 7
+        # Gateway opcode 9: the session is invalid; reconnect and re-Identify.
+        OP_INVALID_SESSION = 9
+        # Gateway opcode 10: Hello, carrying the heartbeat interval.
+        OP_HELLO = 10
+        # Gateway opcode 11: acknowledgement of one of our heartbeats.
+        OP_HEARTBEAT_ACK = 11
+
+        class << self
+          # @return [String] the adapter identifier
+          def channel_type
+            "discord"
+          end
+
+          # Discord connects and posts with a single bot token; app_token is
+          # unused.
+          # @return [Array<Symbol>]
+          def required_setting_fields
+            [ :bot_token ]
+          end
+        end
+
+        # The bot's own Discord user id, fetched via /users/@me on start.
+        # @return [String, nil]
+        attr_reader :bot_user_id
+
+        def initialize
+          super
+          @stopped = false
+          @reconnect_requested = false
+          @connected = false
+          @backoff = 1
+          @heartbeat_acked = true
+          @reply_targets = {}
+          @actual_channels = {}
+        end
+
+        # Connects to the Discord gateway and blocks while receiving events.
+        # Reconnects on Reconnect/Invalid Session opcodes, on missed heartbeat
+        # acks (zombie connection), on socket errors and on clean closes that
+        # never reached READY (all with exponential backoff). Authentication
+        # failures (REST 401, close 4004/4013/4014) terminate without retry.
+        # @return [void]
+        def start
+          @stopped = false
+          @bot_user_id = fetch_bot_user_id
+          ai_helper_logger.info "discord: starting gateway connection (bot user #{@bot_user_id})"
+          until stopped?
+            url = gateway_url
+            begin
+              listen(url)
+              if @reconnect_requested
+                reset_backoff
+              elsif !@connected
+                ai_helper_logger.warn "discord: connection ended before READY; backing off before reconnect"
+                sleep(next_backoff) unless stopped?
+              end
+            rescue DiscordApiError
+              raise
+            rescue => e
+              ai_helper_logger.error "discord: socket error: #{e.full_message}"
+              sleep(next_backoff) unless stopped?
+            end
+          end
+          ai_helper_logger.info "discord: adapter stopped"
+        end
+
+        # Closes the connection and lets #start return.
+        # @return [void]
+        def stop
+          @stopped = true
+          @connection_ended&.push(true)
+          close_socket
+        end
+
+        # Whether READY has been received on the current socket.
+        # @return [Boolean]
+        def connected?
+          @connected
+        end
+
+        # Handles one raw gateway payload (JSON text frame).
+        # @param raw [String] the raw JSON payload
+        # @return [void]
+        def handle_gateway_message(raw)
+          payload = JSON.parse(raw)
+          @last_sequence = payload["s"] if payload["s"]
+          case payload["op"]
+          when OP_HELLO
+            @heartbeat_interval = payload.dig("d", "heartbeat_interval").to_f / 1000.0
+            send_identify
+          when OP_HEARTBEAT
+            send_heartbeat
+          when OP_HEARTBEAT_ACK
+            @heartbeat_acked = true
+          when OP_RECONNECT, OP_INVALID_SESSION
+            ai_helper_logger.info "discord: reconnect requested by gateway (op #{payload["op"]})"
+            request_reconnect
+          when OP_DISPATCH
+            handle_dispatch(payload["t"], payload["d"] || {})
+          else
+            ai_helper_logger.debug "discord: ignoring opcode #{payload["op"].inspect}"
+          end
+        rescue JSON::ParserError => e
+          ai_helper_logger.error "discord: failed to parse gateway payload: #{e.message}"
+        end
+
+        # Reacts to a gateway close frame, capturing fatal authentication
+        # close codes so #start can terminate without retry.
+        # @param code [Integer, nil] the WebSocket close code
+        # @return [void]
+        def handle_close_frame(code)
+          if FATAL_CLOSE_CODES.include?(code)
+            @fatal_close = DiscordApiError.new("Discord gateway closed with fatal code #{code}")
+            ai_helper_logger.error "discord: gateway closed with fatal code #{code}"
+          else
+            ai_helper_logger.info "discord: gateway close frame received (code #{code})"
+          end
+          @connection_ended&.push(true)
+        end
+
+        # Posts a reply to the destination encoded in the thread_key, splitting
+        # texts longer than the Discord message limit. In reply mode the first
+        # chunk references the question message (message_reference).
+        # @param channel_id [String] the channel the conversation is bound to
+        #   (the post destination in reply mode)
+        # @param thread_key [String] "{cid}:{tid}" or "{cid}:msg:{root}"
+        # @param text [String] the reply body (Markdown as-is)
+        # @return [void]
+        def send_message(channel_id:, thread_key:, text:)
+          target, reply_to = resolve_destination(channel_id, thread_key)
+          split_text(text).each_with_index do |chunk, index|
+            body = { content: chunk }
+            body[:message_reference] = { message_id: reply_to } if reply_to && index.zero?
+            post_message(target, body)
+          end
+        end
+
+        # Adds the processing reaction (⏳) to the received message in the
+        # channel it actually arrived in (FR-009).
+        # @param message [IncomingMessage] the message being processed
+        # @return [void]
+        def notify_processing(message:)
+          channel = actual_channel_for(message)
+          add_reaction(channel, message.message_ts)
+        end
+
+        # Classifies DiscordApiError as a fatal configuration/credential error
+        # so the gateway exits cleanly (exit 0) rather than retrying broken
+        # credentials (ADR-006).
+        # @param error [Exception] the error raised by the adapter
+        # @return [Boolean]
+        def fatal_config_error?(error)
+          error.is_a?(DiscordApiError)
+        end
+
+        private
+
+        # Whether #stop has been called.
+        # @return [Boolean]
+        def stopped?
+          @stopped
+        end
+
+        # Fetches the bot's own user id and validates the bot token.
+        # @return [String]
+        def fetch_bot_user_id
+          request(:get, "/users/@me")["id"]
+        end
+
+        # Fetches a fresh gateway WebSocket URL.
+        # @return [String] the wss:// URL
+        def gateway_url
+          request(:get, "/gateway/bot")["url"]
+        end
+
+        # Connects the WebSocket and blocks until the connection ends, a
+        # reconnect is requested, or the adapter is stopped. Re-raises a fatal
+        # close error captured on the receive thread.
+        # @param url [String] the wss:// gateway URL
+        # @return [void]
+        def listen(url)
+          @connection_ended = Queue.new
+          @reconnect_requested = false
+          @connected = false
+          @heartbeat_interval = nil
+          @heartbeat_acked = true
+          @last_sequence = nil
+          @fatal_close = nil
+          adapter = self
+          @ws = WebSocket::Client::Simple.connect(url) do |ws|
+            ws.on(:message) do |msg|
+              case msg.type
+              when :text  then adapter.send(:handle_gateway_message, msg.data)
+              when :close then adapter.send(:handle_close_frame, msg.code)
+              end
+            end
+            ws.on(:close) { |_error| adapter.send(:connection_ended!) }
+            ws.on(:error) { |error| adapter.send(:socket_errored, error) }
+          end
+          heartbeat_loop
+          raise @fatal_close if @fatal_close
+        ensure
+          close_socket
+        end
+
+        # Sends heartbeats on the interval announced in Hello. A heartbeat
+        # whose ack never arrived before the next tick is a zombie connection
+        # and forces a reconnect.
+        # @return [void]
+        def heartbeat_loop
+          until stopped? || @reconnect_requested
+            wait = @heartbeat_interval || HELLO_WAIT_SECONDS
+            break if @connection_ended.pop(timeout: wait)
+            next if @heartbeat_interval.nil?
+
+            unless @heartbeat_acked
+              ai_helper_logger.warn "discord: heartbeat not acknowledged; reconnecting (zombie connection)"
+              request_reconnect
+              break
+            end
+            @heartbeat_acked = false
+            send_heartbeat
+          end
+        end
+
+        # Sends the Identify payload with the minimal intents (no privileged
+        # MESSAGE_CONTENT).
+        # @return [void]
+        def send_identify
+          send_json(
+            op: OP_IDENTIFY,
+            d: {
+              token: settings.bot_token,
+              intents: GATEWAY_INTENTS,
+              properties: { os: "linux", browser: "redmine_ai_helper", device: "redmine_ai_helper" }
+            }
+          )
+        end
+
+        # Sends a heartbeat carrying the last received sequence number.
+        # @return [void]
+        def send_heartbeat
+          send_json(op: OP_HEARTBEAT, d: @last_sequence)
+        end
+
+        # Serializes and sends a gateway payload over the socket.
+        # @param payload [Hash] the gateway payload
+        # @return [void]
+        def send_json(payload)
+          @ws&.send(payload.to_json)
+        end
+
+        # Dispatches a gateway dispatch event (opcode 0).
+        # @param type [String] the dispatch event name
+        # @param data [Hash] the event payload
+        # @return [void]
+        def handle_dispatch(type, data)
+          case type
+          when "READY"
+            @connected = true
+            reset_backoff
+            ai_helper_logger.info "discord: connection established (READY received)"
+          when "MESSAGE_CREATE"
+            process_message(data)
+          end
+        end
+
+        # Converts a MESSAGE_CREATE event into an IncomingMessage and
+        # dispatches it. Bot messages, the bot's own messages, system messages
+        # and (in guilds) messages that do not mention the bot are ignored.
+        # @param data [Hash] the MESSAGE_CREATE payload
+        # @return [void]
+        def process_message(data)
+          return if data.dig("author", "bot")
+
+          author_id = data.dig("author", "id")
+          return if author_id.blank? || author_id == @bot_user_id
+          return unless REPLYABLE_MESSAGE_TYPES.include?(data["type"])
+
+          if data["guild_id"].blank?
+            process_dm(data)
+          else
+            process_guild_message(data)
+          end
+        end
+
+        # Handles a direct message: every message is a question. Continuation
+        # is resolved by following the reply chain back to its root when the
+        # message replies to one of the bot's answers.
+        # @param data [Hash] the MESSAGE_CREATE payload
+        # @return [void]
+        def process_dm(data)
+          channel_id = data["channel_id"]
+          message_id = data["id"]
+          thread_key = resolve_dm_thread_key(data, channel_id, message_id)
+          record_reply_target(thread_key, message_id)
+          record_actual_channel(message_id, channel_id)
+          dispatch(IncomingMessage.new(
+            channel_type: channel_type, channel_id: channel_id, thread_key: thread_key,
+            message_ts: message_id, text: data["content"].to_s.strip, dm: true
+          ))
+        end
+
+        # Handles a guild message that mentions the bot. In an existing thread
+        # the conversation continues there (bindings resolve on the parent
+        # channel); in a normal channel a thread is created, falling back to
+        # reply mode when that is not possible.
+        # @param data [Hash] the MESSAGE_CREATE payload
+        # @return [void]
+        def process_guild_message(data)
+          content = data["content"].to_s
+          return unless mentions_bot?(content)
+
+          channel_id = data["channel_id"]
+          message_id = data["id"]
+          text = strip_mention(content)
+          channel = fetch_channel(channel_id)
+
+          if THREAD_CHANNEL_TYPES.include?(channel["type"])
+            parent_id = channel["parent_id"]
+            record_actual_channel(message_id, channel_id)
+            dispatch(IncomingMessage.new(
+              channel_type: channel_type, channel_id: parent_id,
+              thread_key: "#{parent_id}:#{channel_id}", message_ts: message_id, text: text, dm: false
+            ))
+          else
+            dispatch_with_thread(channel_id, message_id, text)
+          end
+        end
+
+        # Creates a thread from the question message and dispatches into it;
+        # falls back to reply mode when the thread cannot be created.
+        # @param channel_id [String] the parent channel id
+        # @param message_id [String] the question message id
+        # @param text [String] the mention-stripped question text
+        # @return [void]
+        def dispatch_with_thread(channel_id, message_id, text)
+          thread_id = create_thread(channel_id, message_id, text)
+          record_actual_channel(message_id, channel_id)
+          if thread_id
+            dispatch(IncomingMessage.new(
+              channel_type: channel_type, channel_id: channel_id,
+              thread_key: "#{channel_id}:#{thread_id}", message_ts: message_id, text: text, dm: false
+            ))
+          else
+            thread_key = "#{channel_id}:msg:#{message_id}"
+            record_reply_target(thread_key, message_id)
+            dispatch(IncomingMessage.new(
+              channel_type: channel_type, channel_id: channel_id,
+              thread_key: thread_key, message_ts: message_id, text: text, dm: false
+            ))
+          end
+        end
+
+        # Resolves the DM thread_key, following the reply chain to its root
+        # when the message replies to one of the bot's answers. A reply to a
+        # non-bot message, or a referenced message that cannot be fetched,
+        # starts a new conversation.
+        # @param data [Hash] the MESSAGE_CREATE payload
+        # @param channel_id [String] the DM channel id
+        # @param message_id [String] this message's id
+        # @return [String] the thread_key
+        def resolve_dm_thread_key(data, channel_id, message_id)
+          referenced_id = data.dig("message_reference", "message_id")
+          return "#{channel_id}:msg:#{message_id}" if referenced_id.blank?
+
+          referenced = safe_fetch_message(channel_id, referenced_id)
+          return "#{channel_id}:msg:#{message_id}" unless referenced && bot_authored?(referenced)
+
+          "#{channel_id}:msg:#{walk_to_root(channel_id, referenced)}"
+        end
+
+        # Walks a reply chain back to its origin (the message with no
+        # message_reference) and returns that message's id.
+        # @param channel_id [String] the channel the chain lives in
+        # @param message [Hash] the message to start walking from
+        # @return [String] the origin message id
+        def walk_to_root(channel_id, message)
+          current = message
+          loop do
+            referenced_id = current.dig("message_reference", "message_id")
+            return current["id"] if referenced_id.blank?
+
+            parent = safe_fetch_message(channel_id, referenced_id)
+            return current["id"] if parent.nil?
+
+            current = parent
+          end
+        end
+
+        # Whether the message was authored by the bot itself.
+        # @param message [Hash] a message object
+        # @return [Boolean]
+        def bot_authored?(message)
+          message.dig("author", "id") == @bot_user_id
+        end
+
+        # Fetches a message, logging and swallowing failures (a deleted or
+        # inaccessible referenced message must not abort processing).
+        # @param channel_id [String] the channel id
+        # @param message_id [String] the message id
+        # @return [Hash, nil] the message, or nil when it cannot be fetched
+        def safe_fetch_message(channel_id, message_id)
+          fetch_message(channel_id, message_id)
+        rescue DiscordApiError
+          raise
+        rescue => e
+          ai_helper_logger.warn "discord: failed to fetch referenced message: #{e.message}"
+          nil
+        end
+
+        # Whether the content contains an explicit mention of the bot.
+        # @param content [String] the message content
+        # @return [Boolean]
+        def mentions_bot?(content)
+          content.include?("<@#{@bot_user_id}>") || content.include?("<@!#{@bot_user_id}>")
+        end
+
+        # Removes the bot mention markup from the question text.
+        # @param content [String] the message content
+        # @return [String]
+        def strip_mention(content)
+          content.gsub(/<@!?#{Regexp.escape(@bot_user_id.to_s)}>/, "").strip
+        end
+
+        # Records the question message id to reference when replying in reply
+        # mode. Keyed by thread_key so a continuing conversation references its
+        # latest question.
+        # @param thread_key [String] the conversation thread_key
+        # @param message_id [String] the question message id
+        # @return [void]
+        def record_reply_target(thread_key, message_id)
+          @reply_targets[thread_key] = message_id
+        end
+
+        # Records the channel a received message actually arrived in, so the
+        # processing reaction lands on the right message.
+        # @param message_id [String] the message id
+        # @param channel_id [String] the real channel the message is in
+        # @return [void]
+        def record_actual_channel(message_id, channel_id)
+          @actual_channels[message_id] = channel_id
+        end
+
+        # The channel to react in for a message: the recorded real channel,
+        # falling back to the thread_key (thread id in thread mode, channel id
+        # in reply mode). Consumes the recorded entry.
+        # @param message [IncomingMessage] the message being processed
+        # @return [String] the channel id to react in
+        def actual_channel_for(message)
+          recorded = @actual_channels.delete(message.message_ts)
+          return recorded if recorded
+
+          if message.thread_key.include?(":msg:")
+            message.thread_key.split(":msg:", 2).first
+          else
+            message.thread_key.split(":", 2).last
+          end
+        end
+
+        # Parses a thread_key into the REST destination and the message to
+        # reply to. Thread mode posts into the thread with no reference; reply
+        # mode posts into the bound channel referencing the latest question.
+        # @param channel_id [String] the bound channel (reply-mode destination)
+        # @param thread_key [String] the conversation thread_key
+        # @return [Array(String, String)] destination channel id and reply-to
+        #   message id (nil in thread mode)
+        def resolve_destination(channel_id, thread_key)
+          if thread_key.include?(":msg:")
+            root = thread_key.split(":msg:", 2).last
+            [ channel_id, @reply_targets[thread_key] || root ]
+          else
+            [ thread_key.split(":", 2).last, nil ]
+          end
+        end
+
+        # Asks the receive loop to end so #start reconnects with a fresh URL.
+        # @return [void]
+        def request_reconnect
+          @reconnect_requested = true
+          @connection_ended&.push(true)
+        end
+
+        # The socket was closed by the remote side.
+        # @return [void]
+        def connection_ended!
+          @connection_ended&.push(true)
+        end
+
+        # A socket error occurred; end the connection so #start can retry.
+        # @param error [Exception] the socket error
+        # @return [void]
+        def socket_errored(error)
+          ai_helper_logger.error "discord: websocket error: #{error.message}"
+          @connection_ended&.push(true)
+        end
+
+        # Closes the socket, ignoring the usual close-time IO errors.
+        # @return [void]
+        def close_socket
+          socket = @ws
+          @ws = nil
+          socket&.close
+        rescue IOError, SystemCallError => e
+          ai_helper_logger.debug "discord: error while closing socket: #{e.message}"
+        end
+
+        # Returns the current backoff delay and doubles it (capped).
+        # @return [Integer] seconds to wait
+        def next_backoff
+          current = @backoff
+          @backoff = [ @backoff * 2, MAX_BACKOFF_SECONDS ].min
+          current
+        end
+
+        # Resets the backoff after a successful connection.
+        # @return [void]
+        def reset_backoff
+          @backoff = 1
+        end
+
+        # Creates a thread from the question message. Returns the thread id
+        # (equal to the message id) on success or when the message already has
+        # a thread; returns nil (reply-mode fallback) when the thread cannot be
+        # created for channel-type or permission reasons.
+        # @param channel_id [String] the parent channel id
+        # @param message_id [String] the question message id
+        # @param text [String] the question text (used for the thread name)
+        # @return [String, nil] the thread id, or nil to fall back to replies
+        def create_thread(channel_id, message_id, text)
+          request(:post, "/channels/#{channel_id}/messages/#{message_id}/threads",
+                  body: { name: thread_name(text) })
+          message_id
+        rescue DiscordRequestError => e
+          return message_id if e.code == THREAD_ALREADY_EXISTS_CODE
+
+          ai_helper_logger.warn "discord: could not create thread (HTTP #{e.status}); falling back to reply mode"
+          nil
+        end
+
+        # Truncates the question text into a valid thread name.
+        # @param text [String] the question text
+        # @return [String]
+        def thread_name(text)
+          name = text.to_s.strip.truncate(THREAD_NAME_MAX_LENGTH)
+          name.empty? ? "AI Helper" : name
+        end
+
+        # Fetches a channel object.
+        # @param channel_id [String] the channel id
+        # @return [Hash] the channel object
+        def fetch_channel(channel_id)
+          request(:get, "/channels/#{channel_id}")
+        end
+
+        # Fetches a single message object.
+        # @param channel_id [String] the channel id
+        # @param message_id [String] the message id
+        # @return [Hash] the message object
+        def fetch_message(channel_id, message_id)
+          request(:get, "/channels/#{channel_id}/messages/#{message_id}")
+        end
+
+        # Posts a message to a channel.
+        # @param channel_id [String] the destination channel id
+        # @param body [Hash] the message JSON body
+        # @return [Hash] the created message object
+        def post_message(channel_id, body)
+          request(:post, "/channels/#{channel_id}/messages", body: body)
+        end
+
+        # Adds the processing reaction to a message.
+        # @param channel_id [String] the channel the message is in
+        # @param message_id [String] the message id
+        # @return [void]
+        def add_reaction(channel_id, message_id)
+          emoji = URI.encode_www_form_component(PROCESSING_EMOJI)
+          request(:put, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me")
+        end
+
+        # Splits a reply into chunks within the Discord message limit,
+        # preferring paragraph boundaries, then line boundaries, then a hard
+        # cut. No content is ever dropped.
+        # @param text [String] the full reply
+        # @return [Array<String>] the chunks to post in order
+        def split_text(text)
+          return [ text ] if text.length <= MAX_MESSAGE_LENGTH
+
+          chunks = []
+          remaining = text
+          while remaining.length > MAX_MESSAGE_LENGTH
+            slice = remaining[0, MAX_MESSAGE_LENGTH]
+            cut = slice.rindex("\n\n") || slice.rindex("\n") || MAX_MESSAGE_LENGTH
+            cut = MAX_MESSAGE_LENGTH if cut.zero?
+            chunks << remaining[0, cut]
+            remaining = remaining[cut..].to_s.sub(/\A\n+/, "")
+          end
+          chunks << remaining unless remaining.empty?
+          chunks
+        end
+
+        # Builds an HTTPS client with the contract timeouts.
+        # @param uri [URI] the request URI
+        # @return [Net::HTTP]
+        def build_http(uri)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true
+          http.open_timeout = HTTP_TIMEOUT_SECONDS
+          http.read_timeout = HTTP_TIMEOUT_SECONDS
+          http
+        end
+
+        # Performs a Discord REST call with the bot token. 401 raises
+        # DiscordApiError (fatal, no retry); 429 waits retry_after and retries
+        # up to the cap; other non-2xx responses raise DiscordRequestError. The
+        # token is never included in any message. Returns the parsed JSON body
+        # ({} when the body is empty, e.g. 204).
+        # @param http_method [Symbol] :get, :post or :put
+        # @param path [String] the API path (leading slash)
+        # @param body [Hash, nil] the JSON body for writes
+        # @return [Hash] the parsed response body
+        def request(http_method, path, body: nil)
+          uri = URI("#{DISCORD_API_BASE}#{path}")
+          attempts = 0
+          loop do
+            attempts += 1
+            response = build_http(uri).request(build_request(http_method, uri, body))
+            code = response.code.to_i
+            case code
+            when 200..299
+              return response.body.to_s.empty? ? {} : JSON.parse(response.body)
+            when 401
+              raise DiscordApiError, "Discord API #{http_method.upcase} #{path} failed: unauthorized"
+            when 429
+              raise DiscordRequestError.new("Discord API rate limit exceeded for #{path}", status: 429) if attempts > MAX_RATE_LIMIT_RETRIES
+
+              sleep(retry_after_seconds(response))
+            else
+              raise DiscordRequestError.new(
+                "Discord API #{http_method.upcase} #{path} failed: HTTP #{code}",
+                status: code, code: error_code(response)
+              )
+            end
+          end
+        end
+
+        # Builds a Net::HTTP request with the auth header and JSON body.
+        # @param http_method [Symbol] :get, :post or :put
+        # @param uri [URI] the request URI
+        # @param body [Hash, nil] the JSON body for writes
+        # @return [Net::HTTPRequest]
+        def build_request(http_method, uri, body)
+          klass = { get: Net::HTTP::Get, post: Net::HTTP::Post, put: Net::HTTP::Put }.fetch(http_method)
+          req = klass.new(uri.request_uri)
+          req["Authorization"] = "Bot #{settings.bot_token}"
+          if body
+            req["Content-Type"] = "application/json"
+            req.body = body.to_json
+          end
+          req
+        end
+
+        # The retry_after value (seconds) from a 429 response body.
+        # @param response [Net::HTTPResponse] the 429 response
+        # @return [Float] seconds to wait
+        def retry_after_seconds(response)
+          body = JSON.parse(response.body.to_s)
+          body["retry_after"].to_f
+        rescue JSON::ParserError
+          1.0
+        end
+
+        # The Discord error code from a non-2xx response body, if present.
+        # @param response [Net::HTTPResponse] the error response
+        # @return [Integer, nil]
+        def error_code(response)
+          JSON.parse(response.body.to_s)["code"]
+        rescue JSON::ParserError, TypeError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -209,7 +209,7 @@ module RedmineAiHelper
         # pongs beyond the threshold force a reconnect.
         def ping_loop
           until stopped? || @reconnect_requested
-            break if @connection_ended.pop(PING_INTERVAL_SECONDS)
+            break if self.class.timed_queue_pop(@connection_ended, PING_INTERVAL_SECONDS)
             if ping_tick
               ai_helper_logger.warn "slack: #{MAX_MISSED_PONGS} pongs missed, reconnecting"
               request_reconnect

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -48,6 +48,25 @@ module RedmineAiHelper
         def required_setting_fields
           []
         end
+
+        # Pops from queue, waiting up to timeout seconds for a value.
+        # Queue#pop's timeout: keyword was added in Ruby 3.2, but this plugin
+        # still supports Ruby 3.1, so waiting is implemented by polling a
+        # non-blocking pop instead.
+        # @param queue [Queue] the queue to pop from
+        # @param timeout [Numeric] seconds to wait before giving up
+        # @return [Object, nil] the popped value, or nil if the timeout elapsed
+        def timed_queue_pop(queue, timeout)
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+          loop do
+            return queue.pop(true)
+          rescue ThreadError
+            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            return nil if remaining <= 0
+
+            sleep [ remaining, 0.05 ].min
+          end
+        end
       end
 
       # The gateway this adapter dispatches messages through. Set by the

--- a/lib/redmine_ai_helper/chat_channel/gateway.rb
+++ b/lib/redmine_ai_helper/chat_channel/gateway.rb
@@ -31,6 +31,9 @@ module RedmineAiHelper
       def initialize
         @queue = SizedQueue.new(QUEUE_SIZE)
         @shutdown_requested = false
+        @graceful = false
+        @adapter_errors = []
+        @adapter_mutex = Mutex.new
       end
 
       # Queues a message received by an adapter thread for the worker.
@@ -57,19 +60,26 @@ module RedmineAiHelper
         end
 
         install_signal_handlers
+        @alive = @adapters.size
         ai_helper_logger.info "gateway: starting adapters: #{@adapters.map(&:channel_type).join(", ")}"
         threads = @adapters.map { |adapter| start_adapter_thread(adapter) }
         worker_loop
         threads.each { |thread| thread.join(5) }
         ai_helper_logger.info "gateway: stopped"
-        raise @adapter_error if @adapter_error
+        raise aggregated_adapter_error if @adapter_errors.any? && !@graceful
       end
 
-      # Stops all adapters and lets the worker drain the queue and exit.
+      # Stops all adapters and lets the worker drain the queue and exit. A
+      # graceful shutdown (SIGTERM/SIGINT, or an operator stop) does not report
+      # past adapter failures as an error; a shutdown triggered because the
+      # last running adapter died (+from_failure+) does.
+      # @param from_failure [Boolean] whether the last adapter died, forcing
+      #   the shutdown, rather than an external stop request
       # @return [void]
-      def shutdown
+      def shutdown(from_failure: false)
         return if @shutdown_requested
         @shutdown_requested = true
+        @graceful = !from_failure
         ai_helper_logger.info "gateway: shutdown requested"
         (@adapters || []).each do |adapter|
           adapter.stop
@@ -88,18 +98,55 @@ module RedmineAiHelper
       end
 
       # Runs one adapter's blocking receive loop in its own thread. A crashed
-      # adapter takes the gateway down: errors must surface, not idle.
-      # Configuration/credential errors are wrapped in ConfigurationError so
-      # the supervisor can tell them apart from genuine crashes.
+      # adapter no longer takes the whole gateway down while other adapters are
+      # still running (FR-014); the gateway only shuts down once no adapter
+      # remains. The dead adapter is not restarted — the operator fixes the
+      # configuration and restarts the gateway.
       def start_adapter_thread(adapter)
         adapter.dispatcher = self
         Thread.new do
           adapter.start
+          handle_adapter_exit(adapter, nil)
         rescue => e
-          ai_helper_logger.error "gateway: adapter #{adapter.channel_type} terminated: #{e.full_message}"
-          @adapter_error = adapter.fatal_config_error?(e) ? ConfigurationError.new(e.message) : e
-          shutdown
+          handle_adapter_exit(adapter, e)
         end
+      end
+
+      # Records an adapter thread's exit. When it crashed, the error is logged
+      # (distinguishing configuration/credential errors) and collected. The
+      # gateway keeps running while any adapter remains; when the last adapter
+      # exits it shuts itself down, so the run never idles without a live
+      # integration.
+      # @param adapter [BaseAdapter] the adapter whose thread ended
+      # @param error [Exception, nil] the error it crashed with, or nil
+      # @return [void]
+      def handle_adapter_exit(adapter, error)
+        remaining = @adapter_mutex.synchronize do
+          if error
+            fatal = adapter.fatal_config_error?(error)
+            @adapter_errors << { error: error, fatal: fatal }
+            kind = fatal ? "configuration/credential error" : "runtime error"
+            ai_helper_logger.error "gateway: adapter #{adapter.channel_type} terminated (#{kind}): #{error.full_message}"
+          end
+          @alive -= 1
+        end
+
+        if remaining.positive?
+          ai_helper_logger.info "gateway: #{remaining} adapter(s) still running after #{adapter.channel_type} exited; continuing" if error
+        elsif !@shutdown_requested
+          shutdown(from_failure: true)
+        end
+      end
+
+      # The error to raise when every adapter has died: ConfigurationError when
+      # all deaths were configuration/credential errors (exit 0, no supervisor
+      # retry), otherwise the first genuine runtime error (supervisor retries).
+      # @return [Exception]
+      def aggregated_adapter_error
+        runtime_error = @adapter_errors.find { |entry| !entry[:fatal] }
+        return runtime_error[:error] if runtime_error
+
+        ConfigurationError.new(@adapter_errors.first[:error].message)
       end
 
       # Processes queued messages one at a time until shutdown, draining

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -920,4 +920,63 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  # Discord adapter is auto-registered via the init.rb glob, so the existing
+  # settings controller handles its row with no controller changes (US1).
+  context "discord adapter channel settings" do
+    setup do
+      AiHelperChatAdapterSetting.delete_all
+      AiHelperChannelBinding.delete_all
+      @user = User.active.sorted.first
+    end
+
+    should "render only the bot token field for discord (required_setting_fields driven)" do
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[discord][bot_token]'][type=password]"
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[discord][app_token]']", { count: 0 }
+    end
+
+    should "render both token fields for slack (app_token and bot_token)" do
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[slack][app_token]'][type=password]"
+      assert_select "#tab-content-channels input[name='chat_adapter_settings[slack][bot_token]'][type=password]"
+    end
+
+    should "save a discord settings row without an app token" do
+      post :update, params: {
+        tab: "channels",
+        ai_helper_setting: {},
+        chat_adapter_settings: {
+          "discord" => { "enabled" => "1", "bot_token" => "discord-bot-xyz",
+                         "redmine_user_id" => @user.id.to_s, "redmine_user_name" => @user.name,
+                         "dm_default_project_id" => "1" }
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      setting = AiHelperChatAdapterSetting.for_channel("discord")
+      assert setting.enabled
+      assert_equal "discord-bot-xyz", setting.bot_token
+      assert_equal @user.id, setting.redmine_user_id
+      assert_equal 1, setting.dm_default_project_id
+    end
+
+    should "reject enabling discord without a bot token" do
+      post :update, params: {
+        tab: "channels",
+        ai_helper_setting: {},
+        chat_adapter_settings: {
+          "discord" => { "enabled" => "1", "bot_token" => "" }
+        }
+      }
+
+      assert_response :success
+      assert_equal "channels", assigns(:selected_tab)
+      assert_not AiHelperChatAdapterSetting.enabled?("discord")
+    end
+  end
 end

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -1,0 +1,460 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../../test_helper", __FILE__)
+
+class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  DiscordAdapter = RedmineAiHelper::ChatChannel::Adapters::DiscordAdapter
+  DiscordApiError = DiscordAdapter::DiscordApiError
+  DiscordRequestError = DiscordAdapter::DiscordRequestError
+  IncomingMessage = RedmineAiHelper::ChatChannel::IncomingMessage
+
+  BOT_TOKEN = "discord-bot-secret"
+
+  setup do
+    AiHelperChatAdapterSetting.delete_all
+    create(:ai_helper_chat_adapter_setting,
+           channel_type: "discord", enabled: true, bot_token: BOT_TOKEN)
+    @adapter = DiscordAdapter.new
+    @adapter.instance_variable_set(:@bot_user_id, "BOT")
+  end
+
+  # Records messages dispatched by the adapter in place of the gateway.
+  class RecordingDispatcher
+    attr_reader :messages
+
+    def initialize
+      @messages = []
+    end
+
+    def enqueue(_adapter, message)
+      @messages << message
+    end
+  end
+
+  def http_response(code, body)
+    stub(code: code.to_s, body: body.to_json)
+  end
+
+  def guild_message(content:, id: "M1", channel_id: "C1", type: 0, author_id: "U1",
+                    bot: false, guild_id: "G1", ref: nil, mentions: nil)
+    message = {
+      "id" => id, "channel_id" => channel_id, "type" => type, "guild_id" => guild_id,
+      "content" => content, "author" => { "id" => author_id, "bot" => bot }
+    }
+    message["message_reference"] = { "message_id" => ref } if ref
+    message["mentions"] = mentions if mentions
+    message
+  end
+
+  def dm_message(content:, id: "M1", channel_id: "D1", type: 0, author_id: "U1", bot: false, ref: nil)
+    message = {
+      "id" => id, "channel_id" => channel_id, "type" => type,
+      "content" => content, "author" => { "id" => author_id, "bot" => bot }
+    }
+    message["message_reference"] = { "message_id" => ref } if ref
+    message
+  end
+
+  context "registration and settings" do
+    should "declare channel_type discord and register itself" do
+      assert_equal "discord", DiscordAdapter.channel_type
+      assert_equal DiscordAdapter,
+                   RedmineAiHelper::ChatChannel::BaseAdapter.adapters["discord"]
+    end
+
+    should "require only the bot token" do
+      assert_equal [ :bot_token ], DiscordAdapter.required_setting_fields
+    end
+
+    should "be enabled with only the bot token present (no app_token)" do
+      assert_predicate @adapter, :enabled?
+    end
+  end
+
+  context "error classification" do
+    should "classify DiscordApiError as a fatal config error" do
+      assert @adapter.fatal_config_error?(DiscordApiError.new("unauthorized"))
+    end
+
+    should "not classify DiscordRequestError or generic errors as fatal" do
+      assert_not @adapter.fatal_config_error?(DiscordRequestError.new("boom", status: 500))
+      assert_not @adapter.fatal_config_error?(RuntimeError.new("boom"))
+    end
+  end
+
+  context "rest api" do
+    should "configure open and read timeouts of 10 seconds" do
+      http = @adapter.send(:build_http, URI("#{DiscordAdapter::DISCORD_API_BASE}/users/@me"))
+
+      assert_equal 10, http.open_timeout
+      assert_equal 10, http.read_timeout
+    end
+
+    should "authenticate with the bot token" do
+      request = @adapter.send(:build_request, :get, URI("#{DiscordAdapter::DISCORD_API_BASE}/users/@me"), nil)
+
+      assert_equal "Bot #{BOT_TOKEN}", request["Authorization"]
+    end
+
+    should "return the parsed body on success" do
+      Net::HTTP.any_instance.stubs(:request).returns(http_response(200, { "id" => "B1" }))
+
+      assert_equal "B1", @adapter.send(:request, :get, "/users/@me")["id"]
+    end
+
+    should "raise DiscordApiError on 401 without retry or leaking the token" do
+      Net::HTTP.any_instance.expects(:request).once.returns(http_response(401, { "message" => "401: Unauthorized" }))
+
+      error = assert_raises(DiscordApiError) { @adapter.send(:request, :get, "/users/@me") }
+      assert_no_match(/#{Regexp.escape(BOT_TOKEN)}/, error.message)
+    end
+
+    should "wait retry_after and resend on 429, then succeed" do
+      calls = sequence("http")
+      Net::HTTP.any_instance.expects(:request).twice.in_sequence(calls).returns(
+        http_response(429, { "retry_after" => 0.01 }),
+        http_response(200, { "id" => "B1" })
+      )
+      @adapter.stubs(:sleep)
+
+      assert_equal "B1", @adapter.send(:request, :get, "/users/@me")["id"]
+    end
+
+    should "raise DiscordRequestError after exhausting the 429 retry cap" do
+      Net::HTTP.any_instance.stubs(:request).returns(http_response(429, { "retry_after" => 0.01 }))
+      @adapter.stubs(:sleep)
+
+      assert_raises(DiscordRequestError) { @adapter.send(:request, :get, "/users/@me") }
+    end
+
+    should "raise DiscordRequestError with the status and code on other 4xx" do
+      Net::HTTP.any_instance.stubs(:request).returns(http_response(400, { "code" => 50035, "message" => "Invalid" }))
+
+      error = assert_raises(DiscordRequestError) { @adapter.send(:request, :post, "/channels/C1/messages", body: {}) }
+      assert_equal 400, error.status
+      assert_equal 50035, error.code
+    end
+  end
+
+  context "connection lifecycle" do
+    should "fetch the bot user id via /users/@me" do
+      @adapter.expects(:request).with(:get, "/users/@me").returns({ "id" => "B1" })
+
+      assert_equal "B1", @adapter.send(:fetch_bot_user_id)
+    end
+
+    should "obtain the gateway url via /gateway/bot" do
+      @adapter.expects(:request).with(:get, "/gateway/bot").returns({ "url" => "wss://gw" })
+
+      assert_equal "wss://gw", @adapter.send(:gateway_url)
+    end
+
+    should "terminate without retry when /users/@me returns 401" do
+      @adapter.expects(:fetch_bot_user_id).raises(DiscordApiError, "unauthorized")
+      @adapter.expects(:gateway_url).never
+
+      assert_raises(DiscordApiError) { @adapter.start }
+    end
+
+    should "stop cleanly after fetching the bot user id" do
+      @adapter.expects(:fetch_bot_user_id).returns("B1")
+      @adapter.stubs(:gateway_url).returns("wss://gw")
+      @adapter.stubs(:listen).with { @adapter.stop; true }
+
+      @adapter.start
+
+      assert_equal "B1", @adapter.bot_user_id
+    end
+
+    should "store the heartbeat interval and send Identify on Hello" do
+      ws = mock("ws")
+      ws.expects(:send).with do |raw|
+        payload = JSON.parse(raw)
+        payload["op"] == DiscordAdapter::OP_IDENTIFY &&
+          payload["d"]["intents"] == DiscordAdapter::GATEWAY_INTENTS &&
+          payload["d"]["token"] == BOT_TOKEN
+      end
+      @adapter.instance_variable_set(:@ws, ws)
+
+      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_HELLO, d: { heartbeat_interval: 41250 } }.to_json)
+
+      assert_in_delta 41.25, @adapter.instance_variable_get(:@heartbeat_interval), 0.001
+    end
+
+    should "mark connected and reset the backoff on READY" do
+      3.times { @adapter.send(:next_backoff) }
+
+      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_DISPATCH, t: "READY", s: 1, d: { "user" => { "id" => "B1" } } }.to_json)
+
+      assert_predicate @adapter, :connected?
+      assert_equal 1, @adapter.send(:next_backoff)
+    end
+
+    should "reply to a server heartbeat request immediately with the last sequence" do
+      ws = mock("ws")
+      ws.expects(:send).with { |raw| JSON.parse(raw) == { "op" => DiscordAdapter::OP_HEARTBEAT, "d" => 7 } }
+      @adapter.instance_variable_set(:@ws, ws)
+      @adapter.instance_variable_set(:@last_sequence, 7)
+
+      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_HEARTBEAT }.to_json)
+    end
+
+    should "record a heartbeat ack" do
+      @adapter.instance_variable_set(:@heartbeat_acked, false)
+
+      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_HEARTBEAT_ACK }.to_json)
+
+      assert @adapter.instance_variable_get(:@heartbeat_acked)
+    end
+
+    should "request a reconnect on Reconnect (op 7) and Invalid Session (op 9)" do
+      [ DiscordAdapter::OP_RECONNECT, DiscordAdapter::OP_INVALID_SESSION ].each do |op|
+        adapter = DiscordAdapter.new
+        adapter.instance_variable_set(:@connection_ended, Queue.new)
+
+        adapter.handle_gateway_message({ op: op }.to_json)
+
+        assert adapter.instance_variable_get(:@reconnect_requested), "op #{op} must request reconnect"
+      end
+    end
+
+    should "back off exponentially from 1 up to 60 seconds" do
+      expected = [ 1, 2, 4, 8, 16, 32, 60, 60 ]
+
+      assert_equal(expected, (1..8).map { @adapter.send(:next_backoff) })
+    end
+
+    should "capture a fatal DiscordApiError on authentication close codes" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+
+      @adapter.handle_close_frame(4004)
+
+      assert_kind_of DiscordApiError, @adapter.instance_variable_get(:@fatal_close)
+    end
+
+    should "not capture a fatal error on a transient close code" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+
+      @adapter.handle_close_frame(1006)
+
+      assert_nil @adapter.instance_variable_get(:@fatal_close)
+    end
+  end
+
+  context "message selection" do
+    setup do
+      @dispatcher = RecordingDispatcher.new
+      @adapter.dispatcher = @dispatcher
+    end
+
+    should "ignore messages from bots" do
+      @adapter.send(:process_message, guild_message(content: "<@BOT> hi", bot: true))
+
+      assert_empty @dispatcher.messages
+    end
+
+    should "ignore the bot's own messages" do
+      @adapter.send(:process_message, guild_message(content: "<@BOT> hi", author_id: "BOT"))
+
+      assert_empty @dispatcher.messages
+    end
+
+    should "ignore non-default, non-reply message types" do
+      @adapter.send(:process_message, guild_message(content: "<@BOT> hi", type: 6))
+
+      assert_empty @dispatcher.messages
+    end
+
+    should "ignore guild messages that do not mention the bot in the content" do
+      @adapter.expects(:fetch_channel).never
+
+      @adapter.send(:process_message, guild_message(content: "just chatting", mentions: [ { "id" => "BOT" } ]))
+
+      assert_empty @dispatcher.messages
+    end
+
+    should "accept an explicit guild mention and strip the mention markup" do
+      @adapter.stubs(:fetch_channel).returns({ "type" => 0 })
+      @adapter.stubs(:create_thread).returns("M1")
+
+      @adapter.send(:process_message, guild_message(content: "<@BOT> open issues?"))
+
+      message = @dispatcher.messages.first
+      assert_equal "discord", message.channel_type
+      assert_equal "C1", message.channel_id
+      assert_equal "C1:M1", message.thread_key
+      assert_equal "M1", message.message_ts
+      assert_equal "open issues?", message.text
+      assert_not message.dm?
+    end
+
+    should "accept every DM as a question" do
+      @adapter.send(:process_message, dm_message(content: "hello there"))
+
+      message = @dispatcher.messages.first
+      assert message.dm?
+      assert_equal "D1", message.channel_id
+      assert_equal "D1:msg:M1", message.thread_key
+      assert_equal "hello there", message.text
+    end
+  end
+
+  context "thread creation" do
+    setup do
+      @dispatcher = RecordingDispatcher.new
+      @adapter.dispatcher = @dispatcher
+    end
+
+    should "create a thread for a new mention in a normal channel" do
+      @adapter.stubs(:fetch_channel).returns({ "type" => 0 })
+      @adapter.expects(:create_thread).with("C1", "M1", "open issues?").returns("M1")
+
+      @adapter.send(:process_message, guild_message(content: "<@BOT> open issues?"))
+
+      assert_equal "C1:M1", @dispatcher.messages.first.thread_key
+    end
+
+    should "treat an already-existing thread as success on the same thread_key" do
+      @adapter.stubs(:request).raises(DiscordRequestError.new("exists", status: 400, code: DiscordAdapter::THREAD_ALREADY_EXISTS_CODE))
+
+      assert_equal "M1", @adapter.send(:create_thread, "C1", "M1", "q")
+    end
+
+    should "fall back to nil when thread creation is forbidden" do
+      @adapter.stubs(:request).raises(DiscordRequestError.new("forbidden", status: 403, code: 50013))
+
+      assert_nil @adapter.send(:create_thread, "C1", "M1", "q")
+    end
+
+    should "dispatch in reply mode when the thread cannot be created" do
+      @adapter.stubs(:fetch_channel).returns({ "type" => 0 })
+      @adapter.stubs(:create_thread).returns(nil)
+
+      @adapter.send(:process_message, guild_message(content: "<@BOT> help"))
+
+      message = @dispatcher.messages.first
+      assert_equal "C1:msg:M1", message.thread_key
+      assert_equal "C1", message.channel_id
+    end
+  end
+
+  context "thread and dm continuation" do
+    setup do
+      @dispatcher = RecordingDispatcher.new
+      @adapter.dispatcher = @dispatcher
+    end
+
+    should "continue inside an existing thread resolving the parent channel" do
+      @adapter.stubs(:fetch_channel).returns({ "type" => 11, "parent_id" => "P1" })
+
+      @adapter.send(:process_message, guild_message(content: "<@BOT> more", channel_id: "T1"))
+
+      message = @dispatcher.messages.first
+      assert_equal "P1", message.channel_id
+      assert_equal "P1:T1", message.thread_key
+    end
+
+    should "resolve a DM reply to a bot answer to the conversation root" do
+      @adapter.stubs(:fetch_message).with("D1", "B").returns(
+        { "id" => "B", "author" => { "id" => "BOT" }, "message_reference" => { "message_id" => "A" } }
+      )
+      @adapter.stubs(:fetch_message).with("D1", "A").returns({ "id" => "A", "author" => { "id" => "U1" } })
+
+      @adapter.send(:process_message, dm_message(id: "C", content: "more", ref: "B"))
+
+      assert_equal "D1:msg:A", @dispatcher.messages.first.thread_key
+    end
+
+    should "start a new DM conversation when replying to a non-bot message" do
+      @adapter.stubs(:fetch_message).with("D1", "X").returns({ "id" => "X", "author" => { "id" => "U9" } })
+
+      @adapter.send(:process_message, dm_message(id: "C", content: "more", ref: "X"))
+
+      assert_equal "D1:msg:C", @dispatcher.messages.first.thread_key
+    end
+
+    should "start a new DM conversation when the referenced message cannot be fetched" do
+      @adapter.stubs(:fetch_message).raises(DiscordRequestError.new("gone", status: 404))
+
+      @adapter.send(:process_message, dm_message(id: "C", content: "more", ref: "Z"))
+
+      assert_equal "D1:msg:C", @dispatcher.messages.first.thread_key
+    end
+  end
+
+  context "send_message" do
+    should "post into the thread without a reference in thread mode" do
+      @adapter.expects(:post_message).with("T1", { content: "answer" })
+
+      @adapter.send_message(channel_id: "C1", thread_key: "C1:T1", text: "answer")
+    end
+
+    should "reference the recorded question message in reply mode" do
+      @adapter.send(:record_reply_target, "D1:msg:A", "Q9")
+      @adapter.expects(:post_message).with("D1", { content: "answer", message_reference: { message_id: "Q9" } })
+
+      @adapter.send_message(channel_id: "D1", thread_key: "D1:msg:A", text: "answer")
+    end
+
+    should "fall back to the root id when no reply target is recorded" do
+      @adapter.expects(:post_message).with("D1", { content: "answer", message_reference: { message_id: "A" } })
+
+      @adapter.send_message(channel_id: "D1", thread_key: "D1:msg:A", text: "answer")
+    end
+
+    should "split long replies, referencing only the first chunk" do
+      first = "a" * 1000
+      second = "b" * 1500
+      @adapter.send(:record_reply_target, "D1:msg:A", "Q")
+      calls = sequence("posts")
+      @adapter.expects(:post_message).with("D1", { content: first, message_reference: { message_id: "Q" } }).in_sequence(calls)
+      @adapter.expects(:post_message).with("D1", { content: second }).in_sequence(calls)
+
+      @adapter.send_message(channel_id: "D1", thread_key: "D1:msg:A", text: "#{first}\n\n#{second}")
+    end
+
+    should "force-split when there is no newline and lose no content" do
+      text = "a" * 4000
+
+      chunks = @adapter.send(:split_text, text)
+
+      assert_equal [ 1900, 1900, 200 ], chunks.map(&:length)
+      assert_equal text, chunks.join
+    end
+  end
+
+  context "notify_processing" do
+    should "add the hourglass reaction in the recorded actual channel" do
+      @adapter.send(:record_actual_channel, "M1", "T9")
+      @adapter.expects(:add_reaction).with("T9", "M1")
+
+      @adapter.notify_processing(message: IncomingMessage.new(
+        channel_type: "discord", channel_id: "P1", thread_key: "P1:T9", message_ts: "M1", text: "q"
+      ))
+    end
+
+    should "fall back to the thread id in thread mode" do
+      @adapter.expects(:add_reaction).with("T9", "M1")
+
+      @adapter.notify_processing(message: IncomingMessage.new(
+        channel_type: "discord", channel_id: "P1", thread_key: "P1:T9", message_ts: "M1", text: "q"
+      ))
+    end
+
+    should "fall back to the channel id in reply mode" do
+      @adapter.expects(:add_reaction).with("D1", "M1")
+
+      @adapter.notify_processing(message: IncomingMessage.new(
+        channel_type: "discord", channel_id: "D1", thread_key: "D1:msg:A", message_ts: "M1", text: "q"
+      ))
+    end
+
+    should "url-encode the hourglass emoji in the reaction path" do
+      @adapter.expects(:request).with(:put, regexp_matches(%r{/reactions/%E2%8F%B3/@me\z}))
+
+      @adapter.send(:add_reaction, "C1", "M1")
+    end
+  end
+end

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -381,6 +381,18 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_nil @adapter.send(:create_thread, "C1", "M1", "q")
     end
 
+    should "fall back to nil when thread creation fails with a non-Discord error (e.g. a timeout)" do
+      @adapter.stubs(:request).raises(Net::OpenTimeout, "execution expired")
+
+      assert_nil @adapter.send(:create_thread, "C1", "M1", "q")
+    end
+
+    should "propagate a fatal DiscordApiError from thread creation instead of falling back" do
+      @adapter.stubs(:request).raises(DiscordApiError, "unauthorized")
+
+      assert_raises(DiscordApiError) { @adapter.send(:create_thread, "C1", "M1", "q") }
+    end
+
     should "dispatch in reply mode when the thread cannot be created" do
       @adapter.stubs(:fetch_channel).returns({ "type" => 0 })
       @adapter.stubs(:create_thread).returns(nil)
@@ -390,6 +402,30 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       message = @dispatcher.messages.first
       assert_equal "C1:msg:M1", message.thread_key
       assert_equal "C1", message.channel_id
+    end
+  end
+
+  context "channel lookup failures" do
+    setup do
+      @dispatcher = RecordingDispatcher.new
+      @adapter.dispatcher = @dispatcher
+    end
+
+    should "log a warning and drop the message when the channel lookup fails" do
+      @adapter.stubs(:fetch_channel).raises(DiscordRequestError.new("boom", status: 500))
+      logger = mock("logger")
+      logger.expects(:warn).with(regexp_matches(/failed to fetch channel/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:process_message, guild_message(content: "<@BOT> hi"))
+
+      assert_empty @dispatcher.messages
+    end
+
+    should "propagate a fatal DiscordApiError from the channel lookup instead of dropping the message" do
+      @adapter.stubs(:fetch_channel).raises(DiscordApiError, "unauthorized")
+
+      assert_raises(DiscordApiError) { @adapter.send(:process_message, guild_message(content: "<@BOT> hi")) }
     end
   end
 

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -129,6 +129,16 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_raises(DiscordRequestError) { @adapter.send(:request, :get, "/users/@me") }
     end
 
+    should "log a debug message and fall back to 1 second when the 429 body cannot be parsed" do
+      response = http_response(429, {})
+      response.stubs(:body).returns("not json")
+      logger = mock("logger")
+      logger.expects(:debug).with(regexp_matches(/retry_after/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_equal 1.0, @adapter.send(:retry_after_seconds, response)
+    end
+
     should "raise DiscordRequestError with the status and code on other 4xx" do
       Net::HTTP.any_instance.stubs(:request).returns(http_response(400, { "code" => 50035, "message" => "Invalid" }))
 
@@ -151,6 +161,16 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_equal "wss://gw", @adapter.send(:gateway_url)
     end
 
+    should "connect the websocket with the required v and encoding query params" do
+      @adapter.stubs(:heartbeat_loop)
+      ws = mock("ws")
+      ws.stubs(:on)
+      ws.stubs(:close)
+      WebSocket::Client::Simple.expects(:connect).with("wss://gw?v=10&encoding=json").returns(ws)
+
+      @adapter.send(:listen, "wss://gw")
+    end
+
     should "terminate without retry when /users/@me returns 401" do
       @adapter.expects(:fetch_bot_user_id).raises(DiscordApiError, "unauthorized")
       @adapter.expects(:gateway_url).never
@@ -166,6 +186,18 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       @adapter.start
 
       assert_equal "B1", @adapter.bot_user_id
+    end
+
+    should "terminate #start without retry when the gateway closes with a fatal code" do
+      @adapter.stubs(:fetch_bot_user_id).returns("B1")
+      @adapter.expects(:gateway_url).once.returns("wss://gw")
+      @adapter.stubs(:heartbeat_loop).with { @adapter.send(:handle_close_frame, 4004); true }
+      ws = mock("ws")
+      ws.stubs(:on)
+      ws.stubs(:close)
+      WebSocket::Client::Simple.stubs(:connect).returns(ws)
+
+      assert_raises(DiscordApiError) { @adapter.start }
     end
 
     should "store the heartbeat interval and send Identify on Hello" do
@@ -234,12 +266,33 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_kind_of DiscordApiError, @adapter.instance_variable_get(:@fatal_close)
     end
 
+    should "request a reconnect when a heartbeat ack is missing at the next send time (zombie connection)" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      @adapter.instance_variable_set(:@heartbeat_interval, 0.01)
+      @adapter.instance_variable_set(:@heartbeat_acked, false)
+      @adapter.stubs(:send_heartbeat)
+
+      @adapter.send(:heartbeat_loop)
+
+      assert @adapter.instance_variable_get(:@reconnect_requested)
+    end
+
     should "not capture a fatal error on a transient close code" do
       @adapter.instance_variable_set(:@connection_ended, Queue.new)
 
       @adapter.handle_close_frame(1006)
 
       assert_nil @adapter.instance_variable_get(:@fatal_close)
+    end
+
+    should "evict the oldest reply target once the cap is exceeded, keeping recent ones" do
+      cap = DiscordAdapter::MAX_REPLY_TARGETS
+      (cap + 1).times { |i| @adapter.send(:record_reply_target, "key#{i}", "msg#{i}") }
+
+      reply_targets = @adapter.instance_variable_get(:@reply_targets)
+      assert_equal cap, reply_targets.size
+      assert_not reply_targets.key?("key0"), "the oldest entry must be evicted"
+      assert reply_targets.key?("key#{cap}"), "the newest entry must be kept"
     end
   end
 
@@ -381,6 +434,22 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       @adapter.send(:process_message, dm_message(id: "C", content: "more", ref: "Z"))
 
       assert_equal "D1:msg:C", @dispatcher.messages.first.thread_key
+    end
+
+    should "stop walking the reply chain at the hop limit instead of recursing forever" do
+      limit = DiscordAdapter::MAX_REPLY_CHAIN_HOPS
+      # message "0" has no reference (the true root); "1".."limit+1" each
+      # reference the previous one, so the chain is longer than the limit.
+      @adapter.stubs(:fetch_message).with("D1", "0").returns({ "id" => "0", "author" => { "id" => "BOT" } })
+      (1..(limit + 1)).each do |i|
+        @adapter.stubs(:fetch_message).with("D1", i.to_s).returns(
+          { "id" => i.to_s, "author" => { "id" => "BOT" }, "message_reference" => { "message_id" => (i - 1).to_s } }
+        )
+      end
+
+      @adapter.send(:process_message, dm_message(id: "C", content: "more", ref: (limit + 1).to_s))
+
+      assert_equal "D1:msg:1", @dispatcher.messages.first.thread_key
     end
   end
 

--- a/test/unit/chat_channel/gateway_test.rb
+++ b/test/unit/chat_channel/gateway_test.rb
@@ -280,7 +280,7 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
     end
 
     def wait_until_started(timeout)
-      @started.pop(timeout: timeout)
+      self.class.timed_queue_pop(@started, timeout)
     end
 
     def stop
@@ -313,7 +313,7 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
 
       gateway_thread = Thread.new { @gateway.run }
       begin
-        assert handled.pop(timeout: 5), "the live adapter must keep processing after the other adapter dies"
+        assert RedmineAiHelper::ChatChannel::BaseAdapter.timed_queue_pop(handled, 5), "the live adapter must keep processing after the other adapter dies"
         @gateway.shutdown
         assert_nothing_raised { gateway_thread.value }
       ensure

--- a/test/unit/chat_channel/gateway_test.rb
+++ b/test/unit/chat_channel/gateway_test.rb
@@ -334,6 +334,13 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
       assert_match(/boom/, error.message)
     end
 
+    should "prefer the runtime error over a configuration error when all adapters die with a mix of both" do
+      @gateway.stubs(:build_enabled_adapters).returns([ ConfigErrorAdapter.new, RuntimeErrorAdapter.new ])
+
+      error = assert_raises(RuntimeError) { @gateway.run }
+      assert_match(/boom/, error.message)
+    end
+
     should "not raise after a graceful shutdown even if an adapter died earlier" do
       dead = ConfigErrorAdapter.new
       live = BlockingAdapter.new

--- a/test/unit/chat_channel/gateway_test.rb
+++ b/test/unit/chat_channel/gateway_test.rb
@@ -209,4 +209,144 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
       assert_equal [ message ], handler.handled.map(&:first)
     end
   end
+
+  # In-memory adapter that raises a configuration error the moment it starts.
+  class ConfigErrorAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    class << self
+      def channel_type
+        "us4_config_error"
+      end
+    end
+
+    def enabled?
+      true
+    end
+
+    def fatal_config_error?(_error)
+      true
+    end
+
+    def start
+      raise "invalid_auth"
+    end
+
+    def stop; end
+    def send_message(channel_id:, thread_key:, text:); end
+    def notify_processing(message:); end
+  end
+
+  # In-memory adapter that raises a non-configuration error when it starts.
+  class RuntimeErrorAdapter < ConfigErrorAdapter
+    class << self
+      def channel_type
+        "us4_runtime_error"
+      end
+    end
+
+    def fatal_config_error?(_error)
+      false
+    end
+
+    def start
+      raise "boom"
+    end
+  end
+
+  # In-memory adapter that blocks until stopped, optionally running a callback
+  # (e.g. dispatching a message) when it starts.
+  class BlockingAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    attr_accessor :on_start
+
+    class << self
+      def channel_type
+        "us4_blocking"
+      end
+    end
+
+    def initialize
+      super
+      @latch = Queue.new
+      @started = Queue.new
+    end
+
+    def enabled?
+      true
+    end
+
+    def start
+      @on_start&.call(self)
+      @started.push(true)
+      @latch.pop
+    end
+
+    def wait_until_started(timeout)
+      @started.pop(timeout: timeout)
+    end
+
+    def stop
+      @latch.push(true)
+    end
+
+    def send_message(channel_id:, thread_key:, text:); end
+    def notify_processing(message:); end
+  end
+
+  # Handler that signals a queue after handling a message.
+  class SignalingHandler
+    def initialize(signal_queue)
+      @signal_queue = signal_queue
+    end
+
+    def handle(_message)
+      @signal_queue.push(true)
+    end
+  end
+
+  context "multi-adapter fault isolation (US4)" do
+    should "keep processing on a live adapter after another dies with a config error" do
+      handled = Queue.new
+      dead = ConfigErrorAdapter.new
+      live = BlockingAdapter.new
+      live.instance_variable_set(:@handler, SignalingHandler.new(handled))
+      live.on_start = ->(adapter) { adapter.dispatch(incoming("hi")) }
+      @gateway.stubs(:build_enabled_adapters).returns([ dead, live ])
+
+      gateway_thread = Thread.new { @gateway.run }
+      begin
+        assert handled.pop(timeout: 5), "the live adapter must keep processing after the other adapter dies"
+        @gateway.shutdown
+        assert_nothing_raised { gateway_thread.value }
+      ensure
+        gateway_thread.join(5)
+      end
+    end
+
+    should "raise ConfigurationError when all adapters die with config errors" do
+      @gateway.stubs(:build_enabled_adapters).returns([ ConfigErrorAdapter.new, ConfigErrorAdapter.new ])
+
+      assert_raises(RedmineAiHelper::ChatChannel::Gateway::ConfigurationError) { @gateway.run }
+    end
+
+    should "raise the original error when all adapters die with runtime errors" do
+      @gateway.stubs(:build_enabled_adapters).returns([ RuntimeErrorAdapter.new, RuntimeErrorAdapter.new ])
+
+      error = assert_raises(RuntimeError) { @gateway.run }
+      assert_match(/boom/, error.message)
+    end
+
+    should "not raise after a graceful shutdown even if an adapter died earlier" do
+      dead = ConfigErrorAdapter.new
+      live = BlockingAdapter.new
+      @gateway.stubs(:build_enabled_adapters).returns([ dead, live ])
+
+      gateway_thread = Thread.new { @gateway.run }
+      begin
+        assert live.wait_until_started(5), "the live adapter must start"
+        @gateway.shutdown
+        assert_nothing_raised { gateway_thread.value }
+      ensure
+        gateway_thread.join(5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes

- Add a Discord adapter to the chat channel gateway, following the abstraction established by the Slack adapter (028)
- Support channel bindings and thread-scoped conversations, requiring an explicit bot mention to continue a thread
- Support DM conversations by treating replies to the bot's message as conversation continuations
- Add admin settings UI for configuring Discord channel bindings
- Swallow non-fatal errors during Discord channel/thread lookups and fix Queue timed pop compatibility with Ruby 3.1
- Add ADR and setup documentation for the Discord gateway connection design