### PR TITLE
Hide channel bindings form until adapter settings are configured

### DIFF
--- a/app/models/ai_helper_chat_adapter_setting.rb
+++ b/app/models/ai_helper_chat_adapter_setting.rb
@@ -45,6 +45,18 @@ class AiHelperChatAdapterSetting < ApplicationRecord
     user&.active? ? user : nil
   end
 
+  # Whether this adapter's settings are substantively filled in: the record is
+  # saved and all fields required to operate the integration (adapter tokens and
+  # the execution account) are present. Used to decide whether the channel
+  # bindings form should be shown — a bare, empty settings row is not enough.
+  # @return [Boolean]
+  def configured?
+    return false unless persisted?
+    return false if redmine_user_id.blank?
+
+    required_setting_fields.all? { |field| send(field).present? }
+  end
+
   # Masked app token for display (all but the first four characters hidden).
   # @return [String, nil]
   def masked_app_token

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -52,7 +52,7 @@
                        include_blank: true, id: nil %>
       </p>
     </div>
-    <% if adapter_setting.persisted? %>
+    <% if adapter_setting.configured? %>
       <fieldset class="box" id="adapter-bindings-<%= channel_type %>">
         <legend><%= t("ai_helper.chat_channel.settings.bindings") %></legend>
         <% adapter_bindings = @channel_bindings_by_type[channel_type] || [] %>

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -668,7 +668,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     end
 
     should "list existing channel bindings in the channels tab" do
-      AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui")
+      AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: 2)
       AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
 
       get :index, params: { tab: "channels" }
@@ -685,8 +685,26 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_select "#adapter-bindings-ui_chat", count: 0
     end
 
-    should "render the channel bindings form when the adapter setting is persisted" do
-      AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui")
+    should "not render the channel bindings form when a required token is blank" do
+      AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "", redmine_user_id: 2)
+
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#adapter-bindings-ui_chat", count: 0
+    end
+
+    should "not render the channel bindings form when the execution account is blank" do
+      AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: nil)
+
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      assert_select "#adapter-bindings-ui_chat", count: 0
+    end
+
+    should "render the channel bindings form when the adapter setting is configured" do
+      AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: 2)
 
       get :index, params: { tab: "channels" }
 
@@ -859,7 +877,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
     context "US3: channel bindings inside adapter" do
       should "render channel bindings table inside each adapter fieldset" do
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui")
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: 2)
         AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
 
         get :index, params: { tab: "channels" }
@@ -878,7 +896,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       end
 
       should "not render channel type column in bindings table" do
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui")
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: 2)
         AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
 
         get :index, params: { tab: "channels" }
@@ -888,7 +906,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       end
 
       should "render hidden field with channel_type in the add binding form" do
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui")
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: 2)
 
         get :index, params: { tab: "channels" }
 
@@ -899,8 +917,8 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       should "filter bindings by channel_type" do
         slack_project = Project.create!(name: "Slack Proj", identifier: "slack-proj")
         slack_project.enable_module!(:ai_helper)
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui")
-        AiHelperChatAdapterSetting.create!(channel_type: "fake_other", enabled: false, bot_token: "xoxb-other")
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: false, bot_token: "xoxb-ui", redmine_user_id: 2)
+        AiHelperChatAdapterSetting.create!(channel_type: "fake_other", enabled: false, bot_token: "xoxb-other", redmine_user_id: 2)
         AiHelperChannelBinding.create!(channel_type: "ui_chat", channel_id: "C111", channel_name: "#dev", project: Project.find(1))
         AiHelperChannelBinding.create!(channel_type: "fake_other", channel_id: "S222", channel_name: "#general", project: slack_project)
 

--- a/test/unit/ai_helper_chat_adapter_setting_test.rb
+++ b/test/unit/ai_helper_chat_adapter_setting_test.rb
@@ -191,6 +191,58 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
     end
   end
 
+  context "#configured?" do
+    should "return false for an unsaved record" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat",
+        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2
+      )
+
+      assert_not setting.configured?
+    end
+
+    should "return true when saved with all required tokens and an execution account" do
+      setting = create(
+        :ai_helper_chat_adapter_setting,
+        channel_type: "fake_setting_chat", enabled: true,
+        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2
+      )
+
+      assert setting.configured?
+    end
+
+    should "return false when a required token is blank" do
+      setting = create(
+        :ai_helper_chat_adapter_setting,
+        channel_type: "fake_setting_chat", enabled: false,
+        app_token: "xapp-test", bot_token: "", redmine_user_id: 2
+      )
+
+      assert_not setting.configured?
+    end
+
+    should "return false when the execution account is blank" do
+      setting = create(
+        :ai_helper_chat_adapter_setting,
+        channel_type: "fake_setting_chat", enabled: false,
+        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: nil
+      )
+
+      assert_not setting.configured?
+    end
+
+    should "return true for an adapter without required tokens once an execution account is set" do
+      # "tokenless_chat" has no registered adapter, so required_setting_fields
+      # is empty and only the execution account gates configured?.
+      setting = create(
+        :ai_helper_chat_adapter_setting,
+        channel_type: "tokenless_chat", redmine_user_id: 2
+      )
+
+      assert setting.configured?
+    end
+  end
+
   context "masked tokens" do
     should "mask all but the first four characters" do
       setting = AiHelperChatAdapterSetting.new(app_token: "xapp-123456", bot_token: "xoxb-abcdef")


### PR DESCRIPTION
## Changes

- Add `AiHelperChatAdapterSetting#configured?` to determine whether the chat adapter settings have been filled in
- Hide the channel bindings form on the chat settings tab until the adapter settings are configured, preventing bindings from being created against an unconfigured adapter
- Add unit and functional tests covering the new visibility behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)