### PR TITLE
Fix adapter settings toggle when bindings fieldset is absent

### DIFF
--- a/assets/javascripts/ai_helper_chat_settings.js
+++ b/assets/javascripts/ai_helper_chat_settings.js
@@ -5,11 +5,13 @@ function setAdapterSettingsVisible(channelType) {
     `input[type=checkbox][data-adapter-type="${channelType}"]`
   );
   const settingsDiv = document.getElementById(`adapter-settings-${channelType}`);
+  // The bindings fieldset is only rendered once the adapter is configured,
+  // so it may be absent — the settings div must still toggle without it.
   const bindingsFieldset = document.getElementById(`adapter-bindings-${channelType}`);
-  if (!checkbox || !settingsDiv || !bindingsFieldset) return;
+  if (!checkbox || !settingsDiv) return;
   const display = checkbox.checked ? "" : "none";
   settingsDiv.style.display = display;
-  bindingsFieldset.style.display = display;
+  if (bindingsFieldset) bindingsFieldset.style.display = display;
 }
 
 function setupAdapterCheckboxListeners() {


### PR DESCRIPTION
## Changes

- Fix the adapter settings toggle so it still works when the channel bindings fieldset is not rendered (i.e., before the adapter is configured)
- Toggle the bindings fieldset visibility only when it exists instead of bailing out entirely