### PR TITLE
Rename DM default project to general default project and use it for unbound channels

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/030-discord-adapter"
+  "feature_directory": "specs/031-chat-default-project"
 }

--- a/app/models/ai_helper_chat_adapter_setting.rb
+++ b/app/models/ai_helper_chat_adapter_setting.rb
@@ -112,7 +112,7 @@ class AiHelperChatAdapterSetting < ApplicationRecord
   def default_project_present_when_enabled
     return unless enabled?
 
-    errors.add(:default_project_id, :blank) if dm_default_project_id.blank?
+    errors.add(:default_project_id, :blank) if default_project_id.blank?
   end
 
   # Validates that the submitted redmine_user_name corresponds to an actual

--- a/app/models/ai_helper_chat_adapter_setting.rb
+++ b/app/models/ai_helper_chat_adapter_setting.rb
@@ -7,7 +7,12 @@
 class AiHelperChatAdapterSetting < ApplicationRecord
   include Redmine::SafeAttributes
 
-  belongs_to :dm_default_project, class_name: "Project", optional: true
+  # The default project is the fallback context for direct messages and for
+  # regular channels that have no channel binding. Stored in the existing
+  # physical column dm_default_project_id (kept for backward compatibility);
+  # the Ruby-layer name drops the "dm_" prefix because the meaning is no
+  # longer limited to direct messages.
+  belongs_to :default_project, class_name: "Project", foreign_key: "dm_default_project_id", inverse_of: false, optional: true
   belongs_to :redmine_user, class_name: "User", optional: true
 
   attr_accessor :redmine_user_name
@@ -15,9 +20,22 @@ class AiHelperChatAdapterSetting < ApplicationRecord
   validates :channel_type, presence: true, uniqueness: true
   validate :required_fields_present_when_enabled
   validate :service_account_present_when_enabled
+  validate :default_project_present_when_enabled
   validate :redmine_user_name_matches_existing_user
 
-  safe_attributes "enabled", "app_token", "bot_token", "dm_default_project_id", "redmine_user_id", "redmine_user_name"
+  safe_attributes "enabled", "app_token", "bot_token", "default_project_id", "redmine_user_id", "redmine_user_name"
+
+  # Reads the default project id from the physical dm_default_project_id column.
+  # @return [Integer, nil]
+  def default_project_id
+    dm_default_project_id
+  end
+
+  # Writes the default project id to the physical dm_default_project_id column.
+  # @param value [Integer, String, nil]
+  def default_project_id=(value)
+    self.dm_default_project_id = value
+  end
 
   class << self
     # Returns the setting row for the given adapter, or a new unsaved record
@@ -85,6 +103,16 @@ class AiHelperChatAdapterSetting < ApplicationRecord
     return unless enabled?
 
     errors.add(:redmine_user_id, :blank) if redmine_user_id.blank?
+  end
+
+  # Validates that a default project is set when the integration is enabled.
+  # An enabled adapter must resolve every message to a project (direct messages
+  # and unbound channels fall back to the default project), so enabling without
+  # one is rejected. A disabled adapter may be saved as a draft without it.
+  def default_project_present_when_enabled
+    return unless enabled?
+
+    errors.add(:default_project_id, :blank) if dm_default_project_id.blank?
   end
 
   # Validates that the submitted redmine_user_name corresponds to an actual

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -46,9 +46,9 @@
         <em class="info"><%= t("ai_helper.chat_channel.settings.redmine_user_info") %></em>
       </p>
       <p>
-        <label><%= t("ai_helper.chat_channel.settings.dm_default_project") %></label>
-        <%= select_tag "chat_adapter_settings[#{channel_type}][dm_default_project_id]",
-                       options_from_collection_for_select(@ai_helper_projects, :id, :name, adapter_setting.dm_default_project_id),
+        <label><%= t("ai_helper.chat_channel.settings.default_project") %> <span class="required">*</span></label>
+        <%= select_tag "chat_adapter_settings[#{channel_type}][default_project_id]",
+                       options_from_collection_for_select(@ai_helper_projects, :id, :name, adapter_setting.default_project_id),
                        include_blank: true, id: nil %>
       </p>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
         bot_token: "Bot Token"
         redmine_user: "Execution account"
         redmine_user_info: "All questions from the chat tool are processed with this Redmine user's permissions. Restrict this account's roles to limit what the gateway can do."
-        dm_default_project: "Default project for direct messages"
+        default_project: "Default project"
         bindings: "Channel bindings"
         adapter: "Chat tool"
         channel_id: "Channel ID"
@@ -58,8 +58,7 @@ en:
       errors:
         service_account_not_configured: "No active execution account is configured for this chat integration, so the request could not be processed. Please ask your administrator to configure the execution account."
         service_account_unavailable: "The configured execution account has been deleted or deactivated, so the request could not be processed. Please ask your administrator to reconfigure the execution account."
-        channel_not_bound: "This channel is not associated with any Redmine project. Please ask your administrator to configure the channel mapping."
-        dm_not_configured: "No default project is configured for direct messages. Please ask your administrator to configure it."
+        default_project_not_configured: "No default project is configured for this chat integration. Please ask your administrator to configure it."
         module_disabled: "The AI helper module is disabled for the associated project."
         processing_failed: "An error occurred while generating the answer. Please check the AI helper log for details."
     notice_sub_issues_added: "Sub-issues have been added"
@@ -252,6 +251,8 @@ en:
           attributes:
             redmine_user_name:
               invalid: "does not match any user"
+            default_project_id:
+              blank: "can't be blank"
     models:
       ai_helper_model_profile: "Model Profile"
       ai_helper_setting: "AI Helper Setting"
@@ -301,5 +302,7 @@ en:
         prompt: "Prompt"
         description: "Description"
         user_scope: "Scope"
+      ai_helper_chat_adapter_setting:
+        default_project_id: "Default project"
 
   field_id: "ID"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -47,7 +47,7 @@ ja:
         bot_token: "Bot Token"
         redmine_user: "実行アカウント"
         redmine_user_info: "チャットツールからのすべての質問はこのRedmineユーザーの権限で処理されます。このアカウントのロールを絞ることで、ゲートウェイ経由で可能な操作を制限できます。"
-        dm_default_project: "ダイレクトメッセージ用の既定プロジェクト"
+        default_project: "既定プロジェクト"
         bindings: "チャンネル対応付け"
         adapter: "チャットツール"
         channel_id: "チャンネルID"
@@ -58,8 +58,7 @@ ja:
       errors:
         service_account_not_configured: "このチャット連携に有効な実行アカウントが設定されていないため、処理できませんでした。管理者に実行アカウントの設定を依頼してください。"
         service_account_unavailable: "設定されていた実行アカウントが削除または無効化されているため、処理できませんでした。管理者に実行アカウントの再設定を依頼してください。"
-        channel_not_bound: "このチャンネルはRedmineプロジェクトに対応付けられていません。管理者にチャンネル対応付けの設定を依頼してください。"
-        dm_not_configured: "ダイレクトメッセージ用の既定プロジェクトが設定されていません。管理者に設定を依頼してください。"
+        default_project_not_configured: "このチャット連携に既定プロジェクトが設定されていません。管理者に設定を依頼してください。"
         module_disabled: "対応付けられたプロジェクトでAIヘルパーモジュールが無効になっています。"
         processing_failed: "回答の生成中にエラーが発生しました。詳細はAIヘルパーのログを確認してください。"
     notice_sub_issues_added: "子チケットが追加されました"
@@ -252,6 +251,8 @@ ja:
           attributes:
             redmine_user_name:
               invalid: "一致するユーザーが見つかりません"
+            default_project_id:
+              blank: "を入力してください"
     models:
       ai_helper_model_profile: "モデルプロファイル"
       ai_helper_setting: "AIヘルパー設定"
@@ -301,5 +302,7 @@ ja:
         prompt: "プロンプト"
         description: "説明"
         user_scope: "スコープ"
+      ai_helper_chat_adapter_setting:
+        default_project_id: "既定プロジェクト"
 
   field_id: "ID"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -47,7 +47,7 @@ tr:
         bot_token: "Bot Token'ı"
         redmine_user: "Çalıştırma hesabı"
         redmine_user_info: "Sohbet aracından gelen tüm sorular bu Redmine kullanıcısının izinleriyle işlenir. Ağ geçidinin yapabileceklerini sınırlamak için bu hesabın rollerini kısıtlayın."
-        dm_default_project: "Doğrudan mesajlar için varsayılan proje"
+        default_project: "Varsayılan proje"
         bindings: "Kanal bağlamaları"
         adapter: "Sohbet aracı"
         channel_id: "Kanal ID'si"
@@ -55,8 +55,7 @@ tr:
         add_binding: "Bağlama ekle"
       errors:
         service_account_not_configured: "Bu sohbet entegrasyonu için etkin bir çalıştırma hesabı yapılandırılmadığı için istek işlenemedi. Lütfen yöneticinizden çalıştırma hesabını yapılandırmasını isteyin."
-        channel_not_bound: "Bu kanal herhangi bir Redmine projesiyle ilişkilendirilmemiş. Lütfen yöneticinizden kanal eşlemesini yapılandırmasını isteyin."
-        dm_not_configured: "Doğrudan mesajlar için varsayılan bir proje yapılandırılmamış. Lütfen yöneticinizden bunu yapılandırmasını isteyin."
+        default_project_not_configured: "Bu sohbet entegrasyonu için varsayılan bir proje yapılandırılmamış. Lütfen yöneticinizden bunu yapılandırmasını isteyin."
         module_disabled: "İlişkili proje için AI Asistan modülü devre dışı bırakılmış."
         processing_failed: "Yanıt oluşturulurken bir hata oluştu. Ayrıntılar için AI Asistan günlüğünü kontrol edin."
     notice_sub_issues_added: "Alt işler eklendi"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -248,6 +248,8 @@ tr:
           attributes:
             redmine_user_name:
               invalid: "hiçbir kullanıcıyla eşleşmiyor"
+            default_project_id:
+              blank: "boş olamaz"
     models:
       ai_helper_model_profile: "Model Profili"
       ai_helper_setting: "AI Asistan Ayarı"
@@ -297,5 +299,7 @@ tr:
         prompt: "Prompt"
         description: "Açıklama"
         user_scope: "Kapsam"
+      ai_helper_chat_adapter_setting:
+        default_project_id: "Varsayılan proje"
 
   field_id: "ID"

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -44,8 +44,7 @@ module RedmineAiHelper
 
         project = resolve_project(message)
         unless project
-          key = message.dm? ? :dm_not_configured : :channel_not_bound
-          return reply(message, guidance(key, user))
+          return reply(message, guidance(:default_project_not_configured, user))
         end
         return reply(message, guidance(:module_disabled, user)) unless project.module_enabled?(:ai_helper)
 
@@ -68,15 +67,16 @@ module RedmineAiHelper
         AiHelperChatAdapterSetting.for_channel(message.channel_type)
       end
 
-      # Resolves the target project from the channel binding, or from the
-      # adapter's DM default project for direct messages.
+      # Resolves the target project for the message. Direct messages use the
+      # adapter's default project. Regular channels prefer their channel
+      # binding and fall back to the default project when no binding exists.
       # @return [Project, nil]
       def resolve_project(message)
-        if message.dm?
-          adapter_settings(message).dm_default_project
-        else
-          AiHelperChannelBinding.for_channel(message.channel_type, message.channel_id).first&.project
-        end
+        settings = adapter_settings(message)
+        return settings.default_project if message.dm?
+
+        binding = AiHelperChannelBinding.for_channel(message.channel_type, message.channel_id).first
+        binding&.project || settings.default_project
       end
 
       # Appends the question to the thread's conversation and runs the LLM

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -631,17 +631,17 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_response :success
       assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][enabled]']"
       assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][bot_token]'][type=password]"
-      assert_select "#tab-content-channels select[name='chat_adapter_settings[ui_chat][dm_default_project_id]']"
+      assert_select "#tab-content-channels select[name='chat_adapter_settings[ui_chat][default_project_id]']"
       assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][redmine_user_id]'][type=hidden]"
       assert_select "#tab-content-channels input[name='chat_adapter_settings[ui_chat][redmine_user_name]'][type=text]"
     end
 
-    should "save adapter settings from the channels tab" do
+    should "save adapter settings from the channels tab (C2)" do
       post :update, params: {
         tab: "channels",
         ai_helper_setting: { additional_instructions: "keep" },
         chat_adapter_settings: {
-          "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-ui", "dm_default_project_id" => "1", "redmine_user_id" => "2" }
+          "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-ui", "default_project_id" => "1", "redmine_user_id" => "2" }
         }
       }
 
@@ -649,8 +649,38 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       setting = AiHelperChatAdapterSetting.for_channel("ui_chat")
       assert setting.enabled
       assert_equal "xoxb-ui", setting.bot_token
-      assert_equal 1, setting.dm_default_project_id
+      assert_equal 1, setting.default_project_id
       assert_equal 2, setting.redmine_user_id
+    end
+
+    should "reject enabling an adapter without a default project (C1)" do
+      post :update, params: {
+        tab: "general",
+        ai_helper_setting: {},
+        chat_adapter_settings: {
+          "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-ui", "redmine_user_id" => "2", "default_project_id" => "" }
+        }
+      }
+
+      assert_response :success
+      assert_equal "channels", assigns(:selected_tab)
+      assert_not AiHelperChatAdapterSetting.enabled?("ui_chat")
+      assert_select "#errorExplanation"
+    end
+
+    should "save a disabled adapter without a default project (C3)" do
+      post :update, params: {
+        tab: "channels",
+        ai_helper_setting: {},
+        chat_adapter_settings: {
+          "ui_chat" => { "enabled" => "0", "bot_token" => "xoxb-ui", "default_project_id" => "" }
+        }
+      }
+
+      assert_redirected_to controller: "ai_helper_settings", action: :index, tab: "channels"
+      setting = AiHelperChatAdapterSetting.for_channel("ui_chat")
+      assert_not setting.enabled
+      assert_nil setting.default_project_id
     end
 
     should "re-render the channels tab when adapter settings are invalid" do
@@ -665,6 +695,16 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert_response :success
       assert_equal "channels", assigns(:selected_tab)
       assert_not AiHelperChatAdapterSetting.enabled?("ui_chat")
+    end
+
+    should "label the default project field without a direct-message-only qualifier (C4)" do
+      get :index, params: { tab: "channels" }
+
+      assert_response :success
+      label = I18n.t("ai_helper.chat_channel.settings.default_project")
+      assert_select "#tab-content-channels label", text: /#{Regexp.escape(label)}/
+      assert_no_match(/for direct messages/i, @response.body)
+      assert_no_match(/ダイレクトメッセージ用/, @response.body)
     end
 
     should "list existing channel bindings in the channels tab" do
@@ -715,7 +755,8 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
     should "not render the raw app or bot token value in the HTML source" do
       AiHelperChatAdapterSetting.create!(
-        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-supersecret-value", redmine_user_id: 2
+        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-supersecret-value", redmine_user_id: 2,
+        default_project_id: 1
       )
 
       get :index, params: { tab: "channels" }
@@ -728,7 +769,8 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
     should "render the masked token next to the field when a token is stored" do
       AiHelperChatAdapterSetting.create!(
-        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-supersecret-value", redmine_user_id: 2
+        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-supersecret-value", redmine_user_id: 2,
+        default_project_id: 1
       )
 
       get :index, params: { tab: "channels" }
@@ -739,7 +781,8 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
     should "preserve the stored token when the dummy value is submitted unchanged" do
       AiHelperChatAdapterSetting.create!(
-        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-original", redmine_user_id: 2
+        channel_type: "ui_chat", enabled: true, bot_token: "xoxb-original", redmine_user_id: 2,
+        default_project_id: 1
       )
 
       post :update, params: {
@@ -775,7 +818,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
     context "US1: adapter enabled checkbox toggle visibility" do
       should "render adapter-settings div wrapping settings fields when enabled" do
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: 2)
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: 2, default_project_id: 1)
 
         get :index, params: { tab: "channels" }
 
@@ -794,7 +837,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       end
 
       should "render adapter-bindings fieldset with an id so JS can toggle it alongside adapter-settings" do
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: 2)
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: 2, default_project_id: 1)
 
         get :index, params: { tab: "channels" }
 
@@ -849,7 +892,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
       should "display selected user name in text input on page reload when redmine_user_id is set" do
         user = User.active.sorted.first
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id)
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id, default_project_id: 1)
 
         get :index, params: { tab: "channels" }
 
@@ -865,7 +908,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
           tab: "channels",
           ai_helper_setting: {},
           chat_adapter_settings: {
-            "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-new", "redmine_user_id" => user.id.to_s, "redmine_user_name" => user.name }
+            "ui_chat" => { "enabled" => "1", "bot_token" => "xoxb-new", "redmine_user_id" => user.id.to_s, "redmine_user_name" => user.name, "default_project_id" => "1" }
           }
         }
 
@@ -932,7 +975,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
       should "clear redmine_user_id when both name and id are blank and the adapter is disabled" do
         user = User.active.sorted.first
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id)
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id, default_project_id: 1)
 
         post :update, params: {
           tab: "channels",
@@ -949,7 +992,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
       should "reject clearing redmine_user_id while the adapter stays enabled" do
         user = User.active.sorted.first
-        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id)
+        AiHelperChatAdapterSetting.create!(channel_type: "ui_chat", enabled: true, bot_token: "xoxb-test", redmine_user_id: user.id, default_project_id: 1)
 
         post :update, params: {
           tab: "channels",
@@ -1013,7 +1056,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
         chat_adapter_settings: {
           "discord" => { "enabled" => "1", "bot_token" => "discord-bot-xyz",
                          "redmine_user_id" => @user.id.to_s, "redmine_user_name" => @user.name,
-                         "dm_default_project_id" => "1" }
+                         "default_project_id" => "1" }
         }
       }
 
@@ -1022,7 +1065,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
       assert setting.enabled
       assert_equal "discord-bot-xyz", setting.bot_token
       assert_equal @user.id, setting.redmine_user_id
-      assert_equal 1, setting.dm_default_project_id
+      assert_equal 1, setting.default_project_id
     end
 
     should "reject enabling discord without a bot token" do

--- a/test/unit/ai_helper_chat_adapter_setting_test.rb
+++ b/test/unit/ai_helper_chat_adapter_setting_test.rb
@@ -48,7 +48,8 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
     should "be valid when enabled with all required fields present" do
       setting = AiHelperChatAdapterSetting.new(
         channel_type: "fake_setting_chat", enabled: true,
-        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2
+        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2,
+        default_project_id: 1
       )
 
       assert_predicate setting, :valid?
@@ -90,7 +91,26 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
       setting = AiHelperChatAdapterSetting.new(
         channel_type: "fake_setting_chat", enabled: true,
         app_token: "xapp-test", bot_token: "xoxb-test",
-        redmine_user_name: "User 2", redmine_user_id: 2
+        redmine_user_name: "User 2", redmine_user_id: 2, default_project_id: 1
+      )
+
+      assert_predicate setting, :valid?
+    end
+
+    should "require a default project when enabled" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat", enabled: true,
+        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2,
+        default_project_id: nil
+      )
+
+      assert_not setting.valid?
+      assert_predicate setting.errors[:default_project_id], :present?
+    end
+
+    should "not require a default project when disabled" do
+      setting = AiHelperChatAdapterSetting.new(
+        channel_type: "fake_setting_chat", enabled: false, default_project_id: nil
       )
 
       assert_predicate setting, :valid?
@@ -109,19 +129,20 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
   end
 
   context "safe_attributes" do
-    should "accept enabled, tokens, dm_default_project_id and redmine_user_id" do
+    should "accept enabled, tokens, default_project_id and redmine_user_id" do
       setting = create(:ai_helper_chat_adapter_setting)
       setting.safe_attributes = {
         "enabled" => "1",
         "app_token" => "xapp-abc",
         "bot_token" => "xoxb-abc",
-        "dm_default_project_id" => "1",
+        "default_project_id" => "1",
         "redmine_user_id" => "2"
       }
 
       assert setting.enabled
       assert_equal "xapp-abc", setting.app_token
       assert_equal "xoxb-abc", setting.bot_token
+      assert_equal 1, setting.default_project_id
       assert_equal 1, setting.dm_default_project_id
       assert_equal 2, setting.redmine_user_id
     end
@@ -151,7 +172,7 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
 
   context "class method enabled?" do
     should "return true when the setting row is enabled" do
-      create(:ai_helper_chat_adapter_setting, channel_type: "fake_setting_chat", enabled: true, app_token: "xapp-a", bot_token: "xoxb-b", redmine_user_id: 2)
+      create(:ai_helper_chat_adapter_setting, channel_type: "fake_setting_chat", enabled: true, app_token: "xapp-a", bot_token: "xoxb-b", redmine_user_id: 2, default_project_id: 1)
 
       assert AiHelperChatAdapterSetting.enabled?("fake_setting_chat")
     end
@@ -161,11 +182,20 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
     end
   end
 
-  context "dm_default_project" do
+  context "default_project" do
     should "return the associated project" do
+      setting = create(:ai_helper_chat_adapter_setting, default_project_id: 1)
+
+      assert_equal Project.find(1), setting.default_project
+    end
+
+    should "carry over an existing saved default project (backward compatibility)" do
+      # Simulates a record saved before the rename: the physical column
+      # dm_default_project_id still holds the value and default_project reads it.
       setting = create(:ai_helper_chat_adapter_setting, dm_default_project_id: 1)
 
-      assert_equal Project.find(1), setting.dm_default_project
+      assert_equal 1, setting.default_project_id
+      assert_equal Project.find(1), setting.default_project
     end
   end
 
@@ -205,7 +235,8 @@ class AiHelperChatAdapterSettingTest < ActiveSupport::TestCase
       setting = create(
         :ai_helper_chat_adapter_setting,
         channel_type: "fake_setting_chat", enabled: true,
-        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2
+        app_token: "xapp-test", bot_token: "xoxb-test", redmine_user_id: 2,
+        default_project_id: 1
       )
 
       assert setting.configured?

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -15,7 +15,8 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
   setup do
     AiHelperChatAdapterSetting.delete_all
     create(:ai_helper_chat_adapter_setting,
-           channel_type: "discord", enabled: true, bot_token: BOT_TOKEN, redmine_user_id: 2)
+           channel_type: "discord", enabled: true, bot_token: BOT_TOKEN, redmine_user_id: 2,
+           default_project_id: 1)
     @adapter = DiscordAdapter.new
     @adapter.instance_variable_set(:@bot_user_id, "BOT")
   end

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -9,7 +9,8 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
     AiHelperChatAdapterSetting.delete_all
     create(:ai_helper_chat_adapter_setting,
            channel_type: "slack", enabled: true,
-           app_token: "xapp-secret", bot_token: "xoxb-secret", redmine_user_id: 2)
+           app_token: "xapp-secret", bot_token: "xoxb-secret", redmine_user_id: 2,
+           default_project_id: 1)
     @adapter = RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.new
   end
 

--- a/test/unit/chat_channel/base_adapter_test.rb
+++ b/test/unit/chat_channel/base_adapter_test.rb
@@ -67,7 +67,7 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
     end
 
     should "be true when enabled and all required fields are present" do
-      create(:ai_helper_chat_adapter_setting, channel_type: "fake_chat", enabled: true, bot_token: "xoxb-token", redmine_user_id: 2)
+      create(:ai_helper_chat_adapter_setting, channel_type: "fake_chat", enabled: true, bot_token: "xoxb-token", redmine_user_id: 2, default_project_id: 1)
 
       assert_predicate FakeAdapter.new, :enabled?
     end

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -67,7 +67,7 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
     end
 
     should "reply that the execution account is unavailable when it is locked" do
-      @setting.update!(enabled: true)
+      @setting.update!(enabled: true, default_project_id: @project.id)
       @service_account.lock!
 
       @handler.handle(incoming)
@@ -82,7 +82,7 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       # on_delete: :nullify. Because FR-1 forbids saving an enabled adapter
       # without an account, an enabled row with a blank account can only mean
       # the previously configured account was removed.
-      @setting.update!(enabled: true)
+      @setting.update!(enabled: true, default_project_id: @project.id)
       @setting.update_column(:redmine_user_id, nil)
 
       @handler.handle(incoming)
@@ -92,22 +92,32 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       assert_equal 0, AiHelperConversation.count
     end
 
-    should "reply with guidance when the channel is not bound" do
-      message = incoming(channel_id: "UNBOUND")
-      @handler.handle(message)
+    should "fall back to the default project for an unbound channel (B1)" do
+      @setting.update!(default_project_id: @project.id)
+      RedmineAiHelper::Llm.any_instance.expects(:chat).with do |_conversation, _proc, option|
+        option[:project] == @project
+      end.returns(assistant_message("default answer"))
 
-      assert_equal error_text(:channel_not_bound), @adapter.sent_messages.first[:text]
+      @handler.handle(incoming(channel_id: "UNBOUND", thread_key: "UNBOUND:1.000001"))
+
+      assert_equal "default answer", @adapter.sent_messages.first[:text]
     end
 
-    should "reply with guidance for a DM without a default project" do
-      message = incoming(dm: true, channel_id: "D123", thread_key: "D123:1.000001")
-      @handler.handle(message)
+    should "prefer the channel binding over the default project for a bound channel (B2)" do
+      other_project = Project.find(2)
+      other_project.enable_module!("ai_helper")
+      @setting.update!(default_project_id: other_project.id)
+      RedmineAiHelper::Llm.any_instance.expects(:chat).with do |_conversation, _proc, option|
+        option[:project] == @project
+      end.returns(assistant_message("bound answer"))
 
-      assert_equal error_text(:dm_not_configured), @adapter.sent_messages.first[:text]
+      @handler.handle(incoming(channel_id: "CH1", thread_key: "CH1:2.000001"))
+
+      assert_equal "bound answer", @adapter.sent_messages.first[:text]
     end
 
-    should "use the DM default project for direct messages" do
-      @setting.update!(dm_default_project_id: @project.id)
+    should "use the default project for direct messages (B3)" do
+      @setting.update!(default_project_id: @project.id)
       RedmineAiHelper::Llm.any_instance.expects(:chat).with do |_conversation, _proc, option|
         option[:project] == @project
       end.returns(assistant_message("dm answer"))
@@ -115,6 +125,20 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       @handler.handle(incoming(dm: true, channel_id: "D123", thread_key: "D123:1.000001"))
 
       assert_equal "dm answer", @adapter.sent_messages.first[:text]
+    end
+
+    should "reply with guidance for an unbound channel when no default project exists (B5)" do
+      message = incoming(channel_id: "UNBOUND", thread_key: "UNBOUND:1.000001")
+      @handler.handle(message)
+
+      assert_equal error_text(:default_project_not_configured), @adapter.sent_messages.first[:text]
+    end
+
+    should "reply with guidance for a DM when no default project exists (B5)" do
+      message = incoming(dm: true, channel_id: "D123", thread_key: "D123:1.000001")
+      @handler.handle(message)
+
+      assert_equal error_text(:default_project_not_configured), @adapter.sent_messages.first[:text]
     end
 
     should "reply with guidance when the ai_helper module is disabled" do


### PR DESCRIPTION
## Changes

- Rename the adapter's "default project for direct messages" setting to a general "default project", used for both DMs and channels without an explicit channel mapping
- Fall back to the adapter's default project in `MessageHandler` when a channel has no project mapping
- Make the default project a required field when enabling an adapter, so an enabled adapter always resolves to a project (removing the "project cannot be determined" path)
- Update locales (en/ja/tr) for the renamed setting
- Update model, controller, and message-handler tests accordingly