### PR TITLE
Fix invisible stuff todo menu icon on Redmine 7.0

### DIFF
--- a/assets/stylesheets/ai_helper_stuff_todo.css
+++ b/assets/stylesheets/ai_helper_stuff_todo.css
@@ -1,6 +1,6 @@
 /* Stuff Todo Modal Styles */
 
-/* Menu link in top menu - use Redmine's standard link styles.
+/* Menu link in account menu - use Redmine's standard link styles.
    Follow the menu text color so the icon stays visible on both the
    dark header (Redmine 6.x) and the light account dropdown (Redmine 7.0). */
 #ai-helper-stuff-todo-link svg.s18.icon-svg {

--- a/assets/stylesheets/ai_helper_stuff_todo.css
+++ b/assets/stylesheets/ai_helper_stuff_todo.css
@@ -1,8 +1,10 @@
 /* Stuff Todo Modal Styles */
 
-/* Menu link in top menu - use Redmine's standard link styles */
+/* Menu link in top menu - use Redmine's standard link styles.
+   Follow the menu text color so the icon stays visible on both the
+   dark header (Redmine 6.x) and the light account dropdown (Redmine 7.0). */
 #ai-helper-stuff-todo-link svg.s18.icon-svg {
-  stroke: #ffffff;
+  stroke: currentColor;
 }
 
 /* Modal overlay */


### PR DESCRIPTION
## Changes

- The account menu "To Do" (やること) icon was hardcoded to white (`stroke: #ffffff`).
- On Redmine 7.0 the account menu moved to a light-background dropdown, so the white icon blended in and became invisible.
- Changed the icon to `stroke: currentColor` so it follows the menu text color, keeping it visible on both the Redmine 6.x dark header and the Redmine 7.0 light dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)