### PR TITLE
Add sort option support to search_issues tool

### DIFF
--- a/.devcontainer/regression-check.sh
+++ b/.devcontainer/regression-check.sh
@@ -6,7 +6,7 @@ cd $(dirname $0)
 cd ..
 yard stats --list-undoc | tee /dev/stderr |  grep -q "100.00%"
 
-rubocop
+rubocop --ignore-parent-exclusion
 
 cd /usr/local/redmine
 

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/031-chat-default-project"
+  "feature_directory": "specs/032-issue-search-sort"
 }

--- a/lib/redmine_ai_helper/tools/issue_search_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_search_tools.rb
@@ -368,7 +368,7 @@ module RedmineAiHelper
           setup_query(project, user)
           scope = @query.base_scope
           scope.includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
-               .order(@sort[:field] => @sort[:direction]).limit(limit).to_a
+               .reorder(@sort[:field] => @sort[:direction]).limit(limit).to_a
         end
 
         # Returns the total count of matching issues

--- a/lib/redmine_ai_helper/tools/issue_search_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_search_tools.rb
@@ -4,6 +4,10 @@ module RedmineAiHelper
   module Tools
     # A class that provides functionality to the Agent for retrieving issue information
     class IssueSearchTools < RedmineAiHelper::BaseTools
+      # Sort fields supported by search_issues. Only attributes the Issue model holds directly;
+      # related-object sorting (e.g. assignee name) is out of scope.
+      SUPPORTED_SORT_FIELDS = %w[id created_on updated_on due_date start_date done_ratio].freeze
+
       define_function :search_issues, description: "Search issues based on the filter conditions and return matching issues. For search items with '_id', specify the ID instead of the name of the search target. If you do not know the ID, you need to call capable_issue_properties in advance to obtain the ID. Default limit is 50 issues." do
         property :project_id, type: "integer", description: "The project ID of the project to search in.", required: true
         property :limit, type: "integer", description: "Maximum number of issues to return. Default is 50.", required: false
@@ -70,6 +74,10 @@ module RedmineAiHelper
             end
           end
         end
+        property :sort, type: "object", description: "Sort order for the results. Defaults to id descending (newest first) when omitted.", required: false do
+          property :field, type: "string", description: "Sort field. One of: id, created_on, updated_on, due_date, start_date, done_ratio.", required: true
+          property :direction, type: "string", description: "Sort direction. asc or desc. Defaults to desc.", required: false
+        end
       end
       # Search issues based on filter conditions and return matching issues
       # @param project_id [Integer] The project ID of the project to search in.
@@ -81,8 +89,9 @@ module RedmineAiHelper
       # @param text_fields [Array] Text search fields for the issue.
       # @param status_field [Array] Status search fields for the issue.
       # @param custom_fields [Array] Custom field search filters.
+      # @param sort [Hash] Sort order with :field (one of SUPPORTED_SORT_FIELDS) and optional :direction (asc/desc, default desc). Defaults to id descending when omitted.
       # @return [Hash] A hash containing issues array and total_count.
-      def search_issues(project_id:, limit: 50, fields: [], date_fields: [], time_fields: [], number_fields: [], text_fields: [], status_field: [], custom_fields: [])
+      def search_issues(project_id:, limit: 50, fields: [], date_fields: [], time_fields: [], number_fields: [], text_fields: [], status_field: [], custom_fields: [], sort: nil)
         fields = deep_symbolize_array(fields)
         date_fields = deep_symbolize_array(date_fields)
         time_fields = deep_symbolize_array(time_fields)
@@ -90,15 +99,17 @@ module RedmineAiHelper
         text_fields = deep_symbolize_array(text_fields)
         status_field = deep_symbolize_array(status_field)
         custom_fields = deep_symbolize_array(custom_fields)
+        sort = normalize_sort_param(deep_symbolize_hash(sort))
 
         limit = [ limit.to_i, 1 ].max
         project = Project.find(project_id)
 
         if fields.empty? && date_fields.empty? && time_fields.empty? && number_fields.empty? && text_fields.empty? && status_field.empty? && custom_fields.empty?
           # No conditions: return open visible issues for the project (same as Redmine default)
+          order = sort ? { sort[:field] => sort[:direction] } : { id: :desc }
           issues = Issue.visible(User.current).open.where(project_id: project_id)
                         .includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
-                        .order(id: :desc).limit(limit)
+                        .order(order).limit(limit)
           total_count = Issue.visible(User.current).open.where(project_id: project_id).count
           return { issues: format_issues(issues), total_count: total_count }
         end
@@ -147,7 +158,7 @@ module RedmineAiHelper
           params[:values][field[:field_name]] = field[:values].map(&:to_s)
         end
 
-        builder = IssueQueryBuilder.new(params)
+        builder = IssueQueryBuilder.new(params, sort: sort)
         custom_fields.each do |field|
           builder.add_custom_field_filter(field[:field_id], field[:operator], field[:values].map(&:to_s))
         end
@@ -190,6 +201,30 @@ module RedmineAiHelper
         issue.custom_field_values.map do |cfv|
           { id: cfv.custom_field.id, name: cfv.custom_field.name, value: cfv.value }
         end
+      end
+
+      # Validate and normalize the sort param for the search_issues tool
+      # @param sort [Hash, nil] Raw sort param with :field (required) and :direction (optional)
+      # @return [Hash, nil] Normalized { field: Symbol, direction: Symbol }, or nil if sort was nil
+      def normalize_sort_param(sort)
+        return nil if sort.nil?
+
+        field = sort[:field]
+        if field.nil?
+          raise "sort.field is required. Supported sort fields are: #{SUPPORTED_SORT_FIELDS.join(', ')}."
+        end
+
+        field = field.to_s
+        unless SUPPORTED_SORT_FIELDS.include?(field)
+          raise "Unsupported sort field '#{field}'. Supported sort fields are: #{SUPPORTED_SORT_FIELDS.join(', ')}."
+        end
+
+        direction = sort[:direction].nil? ? "desc" : sort[:direction].to_s.downcase
+        unless %w[asc desc].include?(direction)
+          raise "Invalid sort direction '#{sort[:direction]}'. Direction must be 'asc' or 'desc'."
+        end
+
+        { field: field.to_sym, direction: direction.to_sym }
       end
 
       # Validate the parameters for the search_issues tool
@@ -282,12 +317,14 @@ module RedmineAiHelper
       class IssueQueryBuilder
         # Initializes a new IssueQueryBuilder instance.
         # @param params [Hash] The parameters for the query.
+        # @param sort [Hash, nil] Normalized sort with :field and :direction. Defaults to id descending when nil.
         # @return [IssueQueryBuilder] The initialized IssueQueryBuilder instance.
-        def initialize(params)
+        def initialize(params, sort: nil)
           @query = IssueQuery.new(name: "_")
           @params = params
+          @sort = sort || { field: :id, direction: :desc }
           @query.column_names = [ "project", "tracker", "status", "subject", "priority", "assigned_to", "updated_on" ]
-          @query.sort_criteria = [ [ "id", "desc" ] ]
+          @query.sort_criteria = [ [ @sort[:field].to_s, @sort[:direction].to_s ] ]
           # Keep the default status filter (open issues only) unless explicitly specified
         end
 
@@ -331,7 +368,7 @@ module RedmineAiHelper
           setup_query(project, user)
           scope = @query.base_scope
           scope.includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
-               .order(id: :desc).limit(limit).to_a
+               .order(@sort[:field] => @sort[:direction]).limit(limit).to_a
         end
 
         # Returns the total count of matching issues

--- a/test/unit/tools/issue_search_tools_test.rb
+++ b/test/unit/tools/issue_search_tools_test.rb
@@ -235,6 +235,136 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
     end
   end
 
+  context "search_issues sort" do
+    setup do
+      @project = Project.find(1)
+      @tracker = Tracker.find(1)
+      @other_tracker = Tracker.find(2)
+      @user = User.find(2)
+      @previous_user = User.current
+      User.current = @user
+
+      # due_date/start_date/done_ratio must be set at creation time: update_column silently
+      # no-ops for these attributes (Issue overrides their accessors), so it can't be used to
+      # backfill them after the fact.
+      @issue_a = Issue.create!(
+        project: @project, tracker: @tracker, subject: "Sort Issue A",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first,
+        start_date: Date.current - 3, due_date: Date.current + 1, done_ratio: 0
+      )
+      @issue_b = Issue.create!(
+        project: @project, tracker: @tracker, subject: "Sort Issue B",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first,
+        start_date: Date.current - 2, due_date: Date.current + 2, done_ratio: 40
+      )
+      @issue_c = Issue.create!(
+        project: @project, tracker: @other_tracker, subject: "Sort Issue C",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first,
+        start_date: Date.current - 1, due_date: Date.current + 3, done_ratio: 80
+      )
+
+      # Force a deterministic A < B < C ordering for created_on/updated_on too.
+      # id already ascends A < B < C by creation order.
+      base_time = Time.current
+      @issue_a.update_column(:created_on, base_time - 3.hours)
+      @issue_a.update_column(:updated_on, base_time - 3.hours)
+      @issue_b.update_column(:created_on, base_time - 2.hours)
+      @issue_b.update_column(:updated_on, base_time - 2.hours)
+      @issue_c.update_column(:created_on, base_time - 1.hour)
+      @issue_c.update_column(:updated_on, base_time - 1.hour)
+    end
+
+    teardown do
+      User.current = @previous_user
+      [ @issue_a, @issue_b, @issue_c ].each { |i| i&.destroy }
+    end
+
+    # C1
+    should "default to id descending order without error when sort is omitted" do
+      result = @provider.search_issues(project_id: @project.id)
+
+      ids = result[:issues].map { |i| i[:id] }
+      assert_equal ids.sort.reverse, ids
+    end
+
+    # C2
+    should "sort by created_on descending when direction is omitted" do
+      result = @provider.search_issues(project_id: @project.id, sort: { field: "created_on" })
+
+      our_ids = result[:issues].map { |i| i[:id] }.select { |id| [ @issue_a.id, @issue_b.id, @issue_c.id ].include?(id) }
+      assert_equal [ @issue_c.id, @issue_b.id, @issue_a.id ], our_ids
+    end
+
+    # C3
+    should "sort by updated_on ascending when direction is asc" do
+      result = @provider.search_issues(project_id: @project.id, sort: { field: "updated_on", direction: "asc" })
+
+      our_ids = result[:issues].map { |i| i[:id] }.select { |id| [ @issue_a.id, @issue_b.id, @issue_c.id ].include?(id) }
+      assert_equal [ @issue_a.id, @issue_b.id, @issue_c.id ], our_ids
+    end
+
+    # C4
+    should "apply sort to filtered results without breaking limit or visibility" do
+      result = @provider.search_issues(
+        project_id: @project.id,
+        fields: [ { field_name: "tracker_id", operator: "=", values: [ @tracker.id.to_s ] } ],
+        sort: { field: "updated_on", direction: "desc" }
+      )
+
+      returned_ids = result[:issues].map { |i| i[:id] }
+      assert_includes returned_ids, @issue_a.id
+      assert_includes returned_ids, @issue_b.id
+      assert_not_includes returned_ids, @issue_c.id, "issue with a different tracker must not be included"
+
+      our_ids = returned_ids.select { |id| [ @issue_a.id, @issue_b.id ].include?(id) }
+      assert_equal [ @issue_b.id, @issue_a.id ], our_ids
+    end
+
+    # C8
+    RedmineAiHelper::Tools::IssueSearchTools::SUPPORTED_SORT_FIELDS.each do |sort_field|
+      should "sort by #{sort_field} ascending and descending" do
+        asc_result = @provider.search_issues(project_id: @project.id, sort: { field: sort_field, direction: "asc" })
+        asc_ids = asc_result[:issues].map { |i| i[:id] }.select { |id| [ @issue_a.id, @issue_b.id, @issue_c.id ].include?(id) }
+        assert_equal [ @issue_a.id, @issue_b.id, @issue_c.id ], asc_ids
+
+        desc_result = @provider.search_issues(project_id: @project.id, sort: { field: sort_field, direction: "desc" })
+        desc_ids = desc_result[:issues].map { |i| i[:id] }.select { |id| [ @issue_a.id, @issue_b.id, @issue_c.id ].include?(id) }
+        assert_equal [ @issue_c.id, @issue_b.id, @issue_a.id ], desc_ids
+      end
+    end
+
+    # C5
+    should "raise a clear error listing supported fields when field is unsupported" do
+      error = assert_raises(RuntimeError) do
+        @provider.search_issues(project_id: @project.id, sort: { field: "assigned_to" })
+      end
+
+      assert_match(/assigned_to/, error.message)
+      %w[id created_on updated_on due_date start_date done_ratio].each do |field|
+        assert_match(/#{field}/, error.message)
+      end
+    end
+
+    # C6
+    should "raise a clear error when field is missing from sort" do
+      error = assert_raises(RuntimeError) do
+        @provider.search_issues(project_id: @project.id, sort: { direction: "asc" })
+      end
+
+      assert_match(/field/i, error.message)
+    end
+
+    # C7
+    should "raise a clear error when direction is invalid" do
+      error = assert_raises(RuntimeError) do
+        @provider.search_issues(project_id: @project.id, sort: { field: "id", direction: "sideways" })
+      end
+
+      assert_match(/asc/i, error.message)
+      assert_match(/desc/i, error.message)
+    end
+  end
+
   context "validate_search_params" do
     # T003
     context "when fields is nil" do

--- a/test/unit/tools/issue_search_tools_test.rb
+++ b/test/unit/tools/issue_search_tools_test.rb
@@ -263,6 +263,11 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
         start_date: Date.current - 1, due_date: Date.current + 3, done_ratio: 80
       )
 
+      # Issue#create! bumps lock_version via an internal callback save without syncing the
+      # in-memory attribute, so update_column's optimistic-locking WHERE clause matches 0 rows
+      # and silently no-ops (mysql2/postgresql) unless we reload to pick up the real lock_version.
+      [ @issue_a, @issue_b, @issue_c ].each(&:reload)
+
       # Force a deterministic A < B < C ordering for created_on/updated_on too.
       # id already ascends A < B < C by creation order.
       base_time = Time.current

--- a/test/unit/tools/issue_search_tools_test.rb
+++ b/test/unit/tools/issue_search_tools_test.rb
@@ -310,6 +310,14 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
 
     # C4
     should "apply sort to filtered results without breaking limit or visibility" do
+      # Make updated_on intentionally *not* correlate with id: the older issue (A) gets the
+      # newer updated_on. This way a "updated_on desc" result of [A, B] can only happen if the
+      # sort is actually applied in the filtered/query-builder path; if sort were ignored it would
+      # fall back to id desc and yield [B, A], failing the assertion below.
+      now = Time.current
+      @issue_a.update_column(:updated_on, now)
+      @issue_b.update_column(:updated_on, now - 1.hour)
+
       result = @provider.search_issues(
         project_id: @project.id,
         fields: [ { field_name: "tracker_id", operator: "=", values: [ @tracker.id.to_s ] } ],
@@ -322,7 +330,7 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
       assert_not_includes returned_ids, @issue_c.id, "issue with a different tracker must not be included"
 
       our_ids = returned_ids.select { |id| [ @issue_a.id, @issue_b.id ].include?(id) }
-      assert_equal [ @issue_b.id, @issue_a.id ], our_ids
+      assert_equal [ @issue_a.id, @issue_b.id ], our_ids
     end
 
     # C8


### PR DESCRIPTION
## Changes

- Add a `sort` option to the `search_issues` tool, supporting `id`, `created_on`, `updated_on`, `due_date`, `start_date`, and `done_ratio` fields with ascending/descending direction (default: descending)
- Fix the `unknown keyword: :sort (ArgumentError)` that occurred when the AI agent tried to request a sorted issue list (e.g. "show the latest 10 issues")
- Fix the regression-check script so the RuboCop step actually inspects files
- Reload issues before `update_column` in sort tests to avoid stale state