### PR TITLE
Guard vector filter against nil key/condition/value

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/032-issue-search-sort"
+  "feature_directory": "specs/033-create-filter-nil-guard"
 }

--- a/lib/redmine_ai_helper/tools/vector_tools.rb
+++ b/lib/redmine_ai_helper/tools/vector_tools.rb
@@ -267,13 +267,18 @@ module RedmineAiHelper
       end
 
       # Create a filter for the Qdrant database query.
-      # Filter items with a nil key, condition, or value are skipped with a
-      # warning log (see lib/redmine_ai_helper/tools/CLAUDE.md "Skip and warn").
+      # Filter items that are nil, or have a nil key/condition/value, or an
+      # unrecognized condition, are skipped with a warning log (see
+      # lib/redmine_ai_helper/tools/CLAUDE.md "Skip and warn").
       # @param filter [Array<Hash>] The filter to create.
       # @return [Array<Hash>] The created filter.
       def create_filter(filter)
         filter_json = []
         filter.each do |f|
+          if f.nil?
+            ai_helper_logger.warn "Skipping nil filter item"
+            next
+          end
           if f[:key].nil?
             ai_helper_logger.warn "Skipping filter item with nil key: #{f.inspect}"
             next
@@ -298,6 +303,9 @@ module RedmineAiHelper
             item[:range] = {
               f[:condition] => value
             }
+          else
+            ai_helper_logger.warn "Skipping filter item with unrecognized condition: #{f.inspect}"
+            next
           end
 
           filter_json << item

--- a/lib/redmine_ai_helper/tools/vector_tools.rb
+++ b/lib/redmine_ai_helper/tools/vector_tools.rb
@@ -295,7 +295,7 @@ module RedmineAiHelper
           when "match"
             item[:match] = { value: value }
           when "lt", "lte", "gt", "gte"
-            item[:rante] = {
+            item[:range] = {
               f[:condition] => value
             }
           end

--- a/lib/redmine_ai_helper/tools/vector_tools.rb
+++ b/lib/redmine_ai_helper/tools/vector_tools.rb
@@ -267,11 +267,26 @@ module RedmineAiHelper
       end
 
       # Create a filter for the Qdrant database query.
+      # Filter items with a nil key, condition, or value are skipped with a
+      # warning log (see lib/redmine_ai_helper/tools/CLAUDE.md "Skip and warn").
       # @param filter [Array<Hash>] The filter to create.
       # @return [Array<Hash>] The created filter.
       def create_filter(filter)
         filter_json = []
         filter.each do |f|
+          if f[:key].nil?
+            ai_helper_logger.warn "Skipping filter item with nil key: #{f.inspect}"
+            next
+          end
+          if f[:condition].nil?
+            ai_helper_logger.warn "Skipping filter item with nil condition: #{f.inspect}"
+            next
+          end
+          if f[:value].nil?
+            ai_helper_logger.warn "Skipping filter item with nil value: #{f.inspect}"
+            next
+          end
+
           item = {}
           value = f[:value]
           value = f[:value].to_i if f[:key].end_with?("_id")

--- a/test/unit/tools/vector_tools_test.rb
+++ b/test/unit/tools/vector_tools_test.rb
@@ -155,6 +155,84 @@ class RedmineAiHelper::Tools::VectorToolsTest < ActiveSupport::TestCase
 
         assert_equal [ { key: "priority_id", rante: { "lt" => 5 } } ], result
       end
+
+      should "convert all valid items including match and range conditions without change (FR-007)" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          { key: "project_id", condition: "match", value: "123" },
+          { key: "priority_id", condition: "lt", value: "5" },
+          { key: "created_on", condition: "gte", value: "2024-01-01" }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal 3, result.length
+        assert_equal({ key: "project_id", match: { value: 123 } }, result[0])
+        assert_equal({ key: "priority_id", rante: { "lt" => 5 } }, result[1])
+        assert_equal({ key: "created_on", rante: { "gte" => "2024-01-01" } }, result[2])
+      end
+
+      should "skip item with nil key without raising and keep valid items (FR-001, FR-003)" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          { key: nil, condition: "match", value: "1" },
+          { key: "project_id", condition: "match", value: "2" }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal [ { key: "project_id", match: { value: 2 } } ], result
+      end
+
+      should "skip item with nil condition without raising (FR-002, FR-003)" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          { key: "status_id", condition: nil, value: "1" },
+          { key: "project_id", condition: "match", value: "5" }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal [ { key: "project_id", match: { value: 5 } } ], result
+      end
+
+      should "skip item with nil value and avoid unintended 0 match for _id keys (FR-008)" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          { key: "project_id", condition: "match", value: nil },
+          { key: "tracker_id", condition: "match", value: "3" }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal [ { key: "tracker_id", match: { value: 3 } } ], result
+        assert(result.none? { |item| item[:key] == "project_id" && item[:match] && item[:match][:value] == 0 })
+      end
+
+      should "return empty array when all items are invalid without raising (FR-006)" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          { key: nil, condition: "match", value: "1" },
+          { key: "project_id", condition: nil, value: "2" },
+          { key: "tracker_id", condition: "match", value: nil }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal [], result
+      end
+
+      context "skip logging (FR-004)" do
+        should "warn with reason when key is nil (US2 AC1)" do
+          @mock_logger.expects(:warn).with { |msg| msg.include?("key") }
+          @vector_tools.send(:create_filter, [ { key: nil, condition: "match", value: "1" } ])
+        end
+
+        should "warn with reason when condition is nil (US2 AC2)" do
+          @mock_logger.expects(:warn).with { |msg| msg.include?("condition") }
+          @vector_tools.send(:create_filter, [ { key: "project_id", condition: nil, value: "1" } ])
+        end
+
+        should "warn with reason when value is nil (US2 AC3)" do
+          @mock_logger.expects(:warn).with { |msg| msg.include?("value") }
+          @vector_tools.send(:create_filter, [ { key: "project_id", condition: "match", value: nil } ])
+        end
+      end
     end
 
     context "#vector_db" do

--- a/test/unit/tools/vector_tools_test.rb
+++ b/test/unit/tools/vector_tools_test.rb
@@ -153,7 +153,7 @@ class RedmineAiHelper::Tools::VectorToolsTest < ActiveSupport::TestCase
         ]
         result = @vector_tools.send(:create_filter, filter)
 
-        assert_equal [ { key: "priority_id", rante: { "lt" => 5 } } ], result
+        assert_equal [ { key: "priority_id", range: { "lt" => 5 } } ], result
       end
 
       should "convert all valid items including match and range conditions without change (FR-007)" do
@@ -167,8 +167,8 @@ class RedmineAiHelper::Tools::VectorToolsTest < ActiveSupport::TestCase
 
         assert_equal 3, result.length
         assert_equal({ key: "project_id", match: { value: 123 } }, result[0])
-        assert_equal({ key: "priority_id", rante: { "lt" => 5 } }, result[1])
-        assert_equal({ key: "created_on", rante: { "gte" => "2024-01-01" } }, result[2])
+        assert_equal({ key: "priority_id", range: { "lt" => 5 } }, result[1])
+        assert_equal({ key: "created_on", range: { "gte" => "2024-01-01" } }, result[2])
       end
 
       should "skip item with nil key without raising and keep valid items (FR-001, FR-003)" do

--- a/test/unit/tools/vector_tools_test.rb
+++ b/test/unit/tools/vector_tools_test.rb
@@ -217,6 +217,38 @@ class RedmineAiHelper::Tools::VectorToolsTest < ActiveSupport::TestCase
         assert_equal [], result
       end
 
+      should "skip nil filter item without raising and keep valid items" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          nil,
+          { key: "project_id", condition: "match", value: "2" }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal [ { key: "project_id", match: { value: 2 } } ], result
+      end
+
+      should "warn with reason when filter item is nil" do
+        @mock_logger.expects(:warn).with { |msg| msg.include?("nil") }
+        @vector_tools.send(:create_filter, [ nil ])
+      end
+
+      should "skip item with unrecognized condition without raising" do
+        @mock_logger.stubs(:warn)
+        filter = [
+          { key: "project_id", condition: "unknown", value: "1" },
+          { key: "tracker_id", condition: "match", value: "3" }
+        ]
+        result = @vector_tools.send(:create_filter, filter)
+
+        assert_equal [ { key: "tracker_id", match: { value: 3 } } ], result
+      end
+
+      should "warn with reason when condition is unrecognized" do
+        @mock_logger.expects(:warn).with { |msg| msg.include?("condition") }
+        @vector_tools.send(:create_filter, [ { key: "project_id", condition: "unknown", value: "1" } ])
+      end
+
       context "skip logging (FR-004)" do
         should "warn with reason when key is nil (US2 AC1)" do
           @mock_logger.expects(:warn).with { |msg| msg.include?("key") }


### PR DESCRIPTION
## Changes

- Skip filter items with a nil `key`, `condition`, or `value` in `VectorTools#create_filter`, logging a warning instead of raising, so LLM-generated filters with missing fields no longer crash the whole vector search
- Fix a typo (`rante` → `range`) in the range filter key used for `lt`/`lte`/`gt`/`gte` conditions
- Add unit tests covering valid filters, each nil-field skip case, the all-invalid case, and the warning log messages