### PR TITLE
Import chat channel context around mentions into conversations

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/033-create-filter-nil-guard"
+  "feature_directory": "specs/034-chat-history-context"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Follow TDD: write tests BEFORE implementing features.
 - If you believe the design has issues, **ASK THE USER FIRST** before implementing differently
 
 ## Commit & Pull Request Guidelines
+- **NEVER commit or push without explicit user permission** — always ask first
 - **Commit messages**: Concise, imperative, English (e.g., "Add health report history actions")
 - **PR body**: Summarize change set, list commands/tests executed, reference related Redmine issues
 - **UI changes**: Include screenshots
@@ -175,9 +176,3 @@ These rules apply only inside `/speckit.*` workflows. Conversational
 replies outside SDD steps are not affected.
 
 <!-- END token-budget concise-mode -->
-
-<!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan:
-specs/029-chat-gateway-settings-improve/plan.md
-<!-- SPECKIT END -->

--- a/app/models/ai_helper_channel_conversation.rb
+++ b/app/models/ai_helper_channel_conversation.rb
@@ -22,8 +22,8 @@ class AiHelperChannelConversation < ApplicationRecord
 
   # Returns the conversation bound to the given thread, creating both the
   # conversation and the binding when the thread is seen for the first time.
-  # The conversation owner stays the thread starter; later speakers are
-  # represented by User.current at message processing time.
+  # The conversation owner is always the configured service account; all
+  # messages are processed under that account's identity.
   # @param channel_type [String] Tool type (e.g. "slack")
   # @param thread_key [String] Tool-specific thread identifier
   # @param user [User] The user who starts the conversation

--- a/app/models/ai_helper_channel_conversation.rb
+++ b/app/models/ai_helper_channel_conversation.rb
@@ -2,6 +2,17 @@
 
 # Mapping between an external chat tool thread and an AI helper conversation.
 # One thread (channel_type + thread_key) maps to exactly one conversation.
+#
+# @!attribute [rw] last_imported_message_key
+#   The external message id (IncomingMessage#message_ts) of the most recent
+#   mention whose surrounding messages were imported into the conversation.
+#   Everything up to that message is already stored, so the next import only
+#   asks for messages after it, which rules out duplicates within a
+#   conversation and survives a gateway restart. The value is an opaque,
+#   adapter-specific string (Slack ts, Discord snowflake) that is only ever
+#   passed back to the adapter. nil means nothing has been imported yet, which
+#   is a normal state and therefore not validated.
+#   @return [String, nil]
 class AiHelperChannelConversation < ApplicationRecord
   belongs_to :conversation, class_name: "AiHelperConversation"
 

--- a/app/models/ai_helper_conversation.rb
+++ b/app/models/ai_helper_conversation.rb
@@ -2,7 +2,10 @@
 
 # AiHelperConversation model for managing AI Helper conversations
 class AiHelperConversation < ApplicationRecord
-  has_many :messages, class_name: "AiHelperMessage", foreign_key: "conversation_id", inverse_of: :conversation, dependent: :destroy
+  # Ordered explicitly: messages_for_openai merges runs of consecutive context
+  # messages, so it needs the conversation order guaranteed rather than
+  # relying on the order the rows happen to come back in.
+  has_many :messages, -> { order(:id) }, class_name: "AiHelperMessage", foreign_key: "conversation_id", inverse_of: :conversation, dependent: :destroy
   has_one :channel_conversation, class_name: "AiHelperChannelConversation", foreign_key: "conversation_id", inverse_of: :conversation, dependent: :destroy
   belongs_to :user
   validates :title, presence: true

--- a/app/models/ai_helper_conversation.rb
+++ b/app/models/ai_helper_conversation.rb
@@ -7,19 +7,70 @@ class AiHelperConversation < ApplicationRecord
   belongs_to :user
   validates :title, presence: true
 
-  # Returns the last message in the conversation
+  # Maximum total length of the context messages handed to the LLM. Older
+  # context messages are left out of the handover once it is exceeded; the
+  # stored records are never touched (FR-011).
+  CONTEXT_CHAR_LIMIT = 20_000
+
+  # Header prefixed to the merged context messages so the LLM can tell the
+  # imported chat channel messages from the questions addressed to it.
+  CONTEXT_HEADER = "Context from the chat channel (messages by other participants; not addressed to you):"
+
+  # The conversation in the format expected by the LLM. Messages imported from
+  # a chat channel (role "context") are not a role the LLM knows, so every run
+  # of consecutive context messages is merged into one headed user message.
+  # Conversations without context messages produce exactly the same result as
+  # a plain mapping of the stored messages.
+  # @return [Array<Hash>] role/content pairs in conversation order
   def messages_for_openai
-    messages.map do |message|
-      {
-        role: message.role,
-        content: message.content
-      }
+    stored = messages.to_a
+    skipped = context_messages_to_skip(stored)
+    result = []
+    context_run = []
+    context_seen = 0
+
+    stored.each do |message|
+      if message.role == "context"
+        context_seen += 1
+        context_run << message if context_seen > skipped
+        next
+      end
+
+      result << merged_context(context_run) unless context_run.empty?
+      context_run = []
+      result << { role: message.role, content: message.content }
     end
+    result << merged_context(context_run) unless context_run.empty?
+    result
   end
 
   # Clean up old conversations older than 6 months
   # @return [Array<AiHelperConversation>] The destroyed conversations
   def self.cleanup_old_conversations
     where(created_at: ...6.months.ago).destroy_all
+  end
+
+  private
+
+  # How many of the oldest context messages have to be left out so the rest
+  # fits into CONTEXT_CHAR_LIMIT.
+  # @param stored [Array<AiHelperMessage>] the conversation's messages
+  # @return [Integer] the number of context messages to skip
+  def context_messages_to_skip(stored)
+    lengths = stored.filter_map { |message| message.content.to_s.length if message.role == "context" }
+    total = lengths.sum
+    skipped = 0
+    while total > CONTEXT_CHAR_LIMIT && skipped < lengths.size
+      total -= lengths[skipped]
+      skipped += 1
+    end
+    skipped
+  end
+
+  # Merges a run of context messages into a single headed user message.
+  # @param context_run [Array<AiHelperMessage>] consecutive context messages
+  # @return [Hash] the merged role/content pair
+  def merged_context(context_run)
+    { role: "user", content: ([ CONTEXT_HEADER ] + context_run.map(&:content)).join("\n") }
   end
 end

--- a/app/models/ai_helper_conversation.rb
+++ b/app/models/ai_helper_conversation.rb
@@ -12,6 +12,9 @@ class AiHelperConversation < ApplicationRecord
   # stored records are never touched (FR-011).
   CONTEXT_CHAR_LIMIT = 20_000
 
+  # Role value for messages imported from a chat channel.
+  CONTEXT_ROLE = AiHelperMessage::CONTEXT_ROLE
+
   # Header prefixed to the merged context messages so the LLM can tell the
   # imported chat channel messages from the questions addressed to it.
   CONTEXT_HEADER = "Context from the chat channel (messages by other participants; not addressed to you):"
@@ -30,7 +33,7 @@ class AiHelperConversation < ApplicationRecord
     context_seen = 0
 
     stored.each do |message|
-      if message.role == "context"
+      if message.role == CONTEXT_ROLE
         context_seen += 1
         context_run << message if context_seen > skipped
         next
@@ -57,7 +60,7 @@ class AiHelperConversation < ApplicationRecord
   # @param stored [Array<AiHelperMessage>] the conversation's messages
   # @return [Integer] the number of context messages to skip
   def context_messages_to_skip(stored)
-    lengths = stored.filter_map { |message| message.content.to_s.length if message.role == "context" }
+    lengths = stored.filter_map { |message| message.content.to_s.length if message.role == CONTEXT_ROLE }
     total = lengths.sum
     skipped = 0
     while total > CONTEXT_CHAR_LIMIT && skipped < lengths.size

--- a/app/models/ai_helper_message.rb
+++ b/app/models/ai_helper_message.rb
@@ -2,7 +2,15 @@
 
 # AiHelperMessage model for managing AI Helper messages
 class AiHelperMessage < ApplicationRecord
+  # Allowed values for the +role+ column. Messages with +role "context"+ are
+  # imported from a chat channel and merged into a user message before LLM
+  # handover (see AiHelperConversation#messages_for_openai).
+  ROLES = [ "user", "assistant", "context" ].freeze
+
+  # Role for messages imported from an external chat channel.
+  CONTEXT_ROLE = "context"
+
   belongs_to :conversation, class_name: "AiHelperConversation", touch: true
   validates :content, presence: true
-  validates :role, presence: true
+  validates :role, presence: true, inclusion: { in: ROLES }
 end

--- a/app/views/ai_helper/chat/_chat.html.erb
+++ b/app/views/ai_helper/chat/_chat.html.erb
@@ -6,7 +6,14 @@
         <strong><%= link_to_user(@user) %></strong>
       </div>
     <% end %>
-    <% if message.role == 'user' %>
+    <% if message.role == 'context' %>
+      <div class="aihelper-message-user">
+        <strong><%= l("ai_helper.chat_channel.context.label") %></strong>
+      </div>
+    <% end %>
+    <% if message.role == 'user' || message.role == 'context' %>
+      <%# Imported chat channel messages are untrusted external input, so they
+          are rendered as escaped plain text and never through md_to_html. %>
       <pre><%= message.content %></pre>
     <% else %>
       <div>

--- a/app/views/ai_helper/chat/_chat.html.erb
+++ b/app/views/ai_helper/chat/_chat.html.erb
@@ -1,19 +1,19 @@
 <% @conversation.messages.each do |message| %>
   <div class="aihelper-message">
-    <%if message.role == 'user' %>
+    <% case message.role %>
+    <% when 'user' %>
       <div class="aihelper-message-user">
         <%= avatar(@user) %>
         <strong><%= link_to_user(@user) %></strong>
       </div>
-    <% end %>
-    <% if message.role == 'context' %>
+      <pre><%= message.content %></pre>
+    <% when 'context' %>
       <div class="aihelper-message-user">
         <strong><%= l("ai_helper.chat_channel.context.label") %></strong>
       </div>
-    <% end %>
-    <% if message.role == 'user' || message.role == 'context' %>
-      <%# Imported chat channel messages are untrusted external input, so they
-          are rendered as escaped plain text and never through md_to_html. %>
+      <%# User questions and imported chat channel messages are both rendered
+          as escaped plain text in a <pre> tag. Context messages are untrusted
+          external input, so they must never go through md_to_html. %>
       <pre><%= message.content %></pre>
     <% else %>
       <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,9 @@ en:
         default_project_not_configured: "No default project is configured for this chat integration. Please ask your administrator to configure it."
         module_disabled: "The AI helper module is disabled for the associated project."
         processing_failed: "An error occurred while generating the answer. Please check the AI helper log for details."
+        history_unavailable: "The recent messages of this conversation could not be retrieved, so the answer below does not take them into account."
+      context:
+        label: "Imported from the chat channel"
     notice_sub_issues_added: "Sub-issues have been added"
     error_invalid_assignee: "Invalid assignee for '%{subject}' - user is not authorized for this tracker"
     chat:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,6 +61,9 @@ ja:
         default_project_not_configured: "このチャット連携に既定プロジェクトが設定されていません。管理者に設定を依頼してください。"
         module_disabled: "対応付けられたプロジェクトでAIヘルパーモジュールが無効になっています。"
         processing_failed: "回答の生成中にエラーが発生しました。詳細はAIヘルパーのログを確認してください。"
+        history_unavailable: "直近の会話内容を取得できなかったため、それを踏まえずに回答します。"
+      context:
+        label: "チャットチャンネルから取り込んだ発言"
     notice_sub_issues_added: "子チケットが追加されました"
     error_invalid_assignee: "'%{subject}' の担当者が無効です。このトラッカーに対する権限がありません"
     chat:

--- a/db/migrate/20260801000000_add_last_imported_message_key_to_ai_helper_channel_conversations.rb
+++ b/db/migrate/20260801000000_add_last_imported_message_key_to_ai_helper_channel_conversations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Adds the import cursor to channel conversations: the external message id of
+# the most recent mention whose surrounding messages were imported. NULL means
+# nothing has been imported for the conversation yet. No index is added because
+# the column is only ever read from a row already fetched by its primary key or
+# the channel_type/thread_key unique index.
+class AddLastImportedMessageKeyToAiHelperChannelConversations < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ai_helper_channel_conversations, :last_imported_message_key, :string
+  end
+end

--- a/docs/adr/008-chat-channel-context-import.md
+++ b/docs/adr/008-chat-channel-context-import.md
@@ -1,0 +1,143 @@
+# ADR-008: Chat channel conversation context import
+
+**Date**: 2026-08-01
+**Status**: Accepted
+
+## Context
+
+Feature 028 (ADR-006) made the AI helper reachable from Slack, and feature 030
+(ADR-007) added Discord. In both, the only thing the assistant ever sees is the
+pair of messages Redmine stores itself: the question addressed to the bot and
+the answer it produced. Messages exchanged between humans in the same thread or
+channel never reach the LLM.
+
+Feature 034 changes that goal: the assistant is meant to behave as a
+*participant in the thread's conversation*, so it must be able to read messages
+that were not addressed to it. This forces several decisions:
+
+1. Chat tools expose history through tool-specific APIs with different
+   ordering, pagination and permission models, while ADR-006 requires the
+   tool-independent core (`MessageHandler`) to stay unchanged when a new
+   adapter is added — including an adapter that cannot read history at all.
+2. Mentions repeat over the lifetime of a thread. Something must record how far
+   a conversation has already imported, and it must survive a gateway restart,
+   without ever importing the same message twice into one conversation.
+3. Feature 028 deliberately did **not** persist third-party speakers' messages
+   on the Redmine side. Feature 034 reverses that so the stored conversation
+   explains why an answer was given.
+4. Threads can grow without bound, but the prompt sent to the LLM cannot.
+5. Discord gates message content behind the privileged MESSAGE_CONTENT intent.
+   ADR-007 deliberately identified with the minimal intent set (4608) so that
+   no Developer-Portal review is needed; feature 034 needs content the bot was
+   not mentioned in.
+
+## Decision
+
+1. **History access is an optional adapter capability, declared explicitly.**
+   `BaseAdapter` gains `supports_history?` (default `false`) plus
+   `fetch_thread_history` and `fetch_channel_history`, whose default
+   implementations raise `NotImplementedError`. The core skips import when the
+   capability is absent, so an adapter that cannot read history degrades to
+   exactly the pre-034 behaviour and nothing else. A default returning an empty
+   array was rejected because it makes "not supported" indistinguishable from
+   "no messages found" in behaviour and in the log.
+
+2. **Tool-specific filtering stays in the adapter.** Adapters return
+   `HistoryMessage(speaker:, text:)` values in ascending order, with the
+   gateway's own messages, messages that mention the bot, system messages
+   (joins/leaves) and empty-bodied messages already removed. Messages from
+   *other* bots (CI notifications and the like) are kept — they are part of the
+   discussion. Only the adapter knows its own bot id, its mention markup and
+   its system-message representation.
+
+3. **The import cursor is the message id of the last successfully imported
+   mention**, stored in a new
+   `ai_helper_channel_conversations.last_imported_message_key` column and
+   treated as an opaque, adapter-defined string. Everything up to that mention
+   is either already imported or already stored as the question, so fetching
+   strictly after it cannot produce a duplicate within the conversation. The
+   column is persistent, so restarts change nothing. On a failed import the
+   cursor is not advanced, which turns the next mention into a retry over the
+   same range. Storing external ids on every imported message and taking their
+   maximum was rejected: it would put the comparison of two incompatible id
+   schemes (Slack's float `ts`, Discord's snowflake) into the core, where
+   Discord's string ordering breaks across digit-length changes.
+
+4. **Imported messages are persisted as conversation messages with the new role
+   `"context"`.** They flow to the LLM through the existing
+   `AiHelperConversation#messages_for_openai` path, so no parallel handoff
+   mechanism exists, and the Redmine conversation history shows the evidence
+   behind an answer. This reverses feature 028's "no third-party records on the
+   Redmine side" position; the permission model is unchanged, since only the
+   chat display name and the message body are stored and speakers are still
+   never mapped to Redmine users.
+
+5. **Persistence and LLM handoff are separated.** Every imported message is
+   stored; `messages_for_openai` merges consecutive `"context"` messages into a
+   single `user` message with an explanatory header and drops the oldest of
+   them once their combined length exceeds 20,000 characters. Conversations
+   without `"context"` messages — every web-chat conversation — are unaffected.
+
+6. **Thread imports are unbounded; channel and DM imports are capped at 48
+   hours and 20 messages.** A thread is one continuous discussion, and a cap
+   would silently remove part of it; a channel's top-level messages are only
+   loosely related, so a bound limits the damage from unrelated topics. The
+   values are fixed constants with no settings screen (KISS/YAGNI).
+
+7. **Discord's Identify intents stay at 4608.** Discord decides message-content
+   visibility from the Developer-Portal toggle and applies it to both the
+   Gateway and the REST API, so enabling the toggle is enough for REST history
+   reads. Requesting a privileged intent that the portal has not enabled closes
+   the connection with code 4014, which ADR-007 classifies as fatal — adding
+   the bit would stop every existing gateway whose operator has not yet flipped
+   the toggle. Operators who do not enable it get empty message bodies, which
+   are filtered out as empty, leaving the integration working without context.
+
+8. **A failed history fetch is reported, never hidden.** The error is logged
+   with its full message and the answer is prefixed with a notice that the
+   context could not be retrieved; the answer itself is still generated and
+   posted. This is not the silent fallback the constitution forbids: the
+   failure is visible in the log and to the person who asked.
+
+## Consequences
+
+- Adding a chat tool that has no history API still requires only one file under
+  `adapters/`; `supports_history?` defaults to false and nothing else changes.
+- Slack integrations need four extra scopes (`channels:history`,
+  `groups:history`, `mpim:history`, `users:read`) and a reinstall. Discord
+  integrations need the Message Content Intent enabled, and verified apps need
+  Discord's approval for it. Both are one-time operator actions, documented in
+  the setup guides.
+- Slack resolves speaker display names through `users.info`, which costs one
+  call per previously unseen speaker. A per-adapter FIFO cache (500 entries,
+  the same shape as `MAX_REPLY_TARGETS`) keeps repeated mentions in one thread
+  free of extra calls.
+- Conversations bound to long-lived threads grow indefinitely in the database.
+  Only the handoff is bounded; the existing six-month
+  `AiHelperConversation.cleanup_old_conversations` remains the only reclamation
+  path.
+- Third-party chat messages now live in Redmine. They are readable by the
+  execution account and by administrators only, and they are rendered as
+  escaped plain text (never through `md_to_html`) because they are untrusted
+  external input.
+- Feature 028's decision not to record third-party speakers is superseded for
+  the chat-channel conversation store. ADR-006 itself is left unmodified, as
+  ADRs are append-only.
+
+## Alternatives Considered
+
+- **Import only on the first mention in a thread.** Rejected during
+  clarification: human discussion normally continues after the bot answers, so
+  a first-time-only import cannot make the assistant a participant.
+- **Build a context block per turn without persisting it.** Cheaper in storage,
+  but it makes the reasoning behind an answer unreconstructible and requires a
+  second handoff path alongside the conversation history.
+- **Add an `imported` boolean column to `ai_helper_messages` and keep the role
+  as `"user"`.** Rejected: the LLM could not tell context from questions, and
+  the view would need the extra column anyway to satisfy FR-006.
+- **Detect Discord close code 4014 and re-identify without MESSAGE_CONTENT.**
+  A fallback path with extra connection states, forbidden by the simplicity
+  principle, and unnecessary once the intent is only required in the portal.
+- **Expose the window (enabled/period/count) as administrator settings.**
+  Deferred until a concrete request exists (YAGNI); the fixed values are
+  48 hours and 20 messages.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,4 @@ Briefly describe alternatives that were rejected and why.
 | [005](./005-write-tool-classification-for-read-only-mode.md) | Write-tool classification via a `define_function` DSL attribute for read-only mode | Proposed |
 | [006](./006-chat-channel-gateway-architecture.md) | External chat tool gateway with Socket Mode and a serialized worker | Accepted |
 | [007](./007-discord-adapter-connection-design.md) | Discord adapter connection design | Accepted |
+| [008](./008-chat-channel-context-import.md) | Chat channel conversation context import | Accepted |

--- a/docs/discord_gateway_setup.md
+++ b/docs/discord_gateway_setup.md
@@ -7,7 +7,9 @@ and receive answers in the same thread.
 The integration uses the Discord **Gateway API**: the gateway process opens an
 outgoing WebSocket connection to Discord, so **no public URL is required** for
 your Redmine server. The bot needs only a single **bot token** (unlike Slack,
-which uses two tokens), and it does **not** require any privileged intents.
+which uses two tokens). It runs without any privileged intent; enabling the
+**Message Content Intent** is optional and only adds the ability to answer with
+the surrounding discussion in mind (see step 3).
 
 ## Requirements
 
@@ -26,11 +28,24 @@ which uses two tokens), and it does **not** require any privileged intents.
    Application**. Give it a name (this becomes the bot's name).
 2. In the **Bot** section, click **Reset Token** (or **Add Bot**) and copy the
    **bot token**. Store it securely — Discord shows it only once.
-3. Under **Privileged Gateway Intents**, leave **Message Content Intent**
-   **OFF**. This integration only reacts to messages that mention the bot and
-   to direct messages, both of which Discord delivers in full without the
-   privileged intent. Leaving it off keeps the bot least-privileged and needs
-   no Discord review.
+3. Under **Privileged Gateway Intents**, turn **Message Content Intent** **ON**
+   if you want the bot to answer with the surrounding discussion in mind.
+   Discord only reveals the body of messages that do not mention the bot when
+   this toggle is enabled, and the toggle governs both the Gateway and the REST
+   API the bot reads the history with.
+   - **Left OFF**: the bot works exactly as before. It still receives mentions
+     and direct messages in full, but the messages around them arrive with an
+     empty body, are skipped, and answers are produced without that context.
+     No notice is shown, because nothing failed.
+   - **Turned ON**: the bot imports the messages posted around a mention (the
+     whole thread, or the last 48 hours / 20 messages of a channel or DM) and
+     answers with them in mind.
+   - If your application is **verified**, enabling the intent requires approval
+     from Discord; request it through the Developer Portal.
+
+   The gateway always identifies with the same intent set (`4608`) whether or
+   not the toggle is on, so enabling it never breaks an existing installation —
+   restart the gateway after flipping it.
 
 ## 2. Invite the bot to your server
 

--- a/docs/slack_gateway_setup.md
+++ b/docs/slack_gateway_setup.md
@@ -15,13 +15,27 @@ The integration uses Slack **Socket Mode**: the gateway process opens an outgoin
 2. Under **Socket Mode**, enable Socket Mode and generate an **App-Level Token** with the `connections:write` scope. Note the token (starts with `xapp-`).
 3. Under **OAuth & Permissions → Bot Token Scopes**, add:
    - `app_mentions:read` — receive mentions in channels
-   - `im:history` — receive direct messages
+   - `im:history` — receive direct messages, and read the recent messages of a DM
    - `chat:write` — post replies
    - `reactions:write` — show the "processing" reaction
+   - `channels:history` — read the surrounding messages of public channels and their threads
+   - `groups:history` — the same for private channels
+   - `mpim:history` — the same for group direct messages
+   - `users:read` — resolve the display names of the speakers in those messages
+
+   The four history-related scopes let the bot read the messages posted around a
+   mention so it can answer with the discussion in mind. Without them the bot
+   still answers, but every answer starts with a notice that the recent
+   messages could not be retrieved.
 4. Under **Event Subscriptions → Subscribe to bot events**, add:
    - `app_mention`
    - `message.im`
 5. Install the app into the workspace and note the **Bot User OAuth Token** (starts with `xoxb-`).
+
+> **Upgrading an app installed before this feature existed**: adding scopes does
+> not change an existing installation. Open **OAuth & Permissions**, add the four
+> scopes above and choose **Reinstall to Workspace**, then restart the gateway.
+> The bot token stays valid, so the Redmine settings need no change.
 
 ## 2. Configure Redmine
 

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -5,6 +5,7 @@ require "net/http"
 require "uri"
 require "websocket-client-simple"
 require "redmine_ai_helper/chat_channel/base_adapter"
+require "redmine_ai_helper/chat_channel/history_message"
 
 module RedmineAiHelper
   module ChatChannel
@@ -74,6 +75,8 @@ module RedmineAiHelper
         THREAD_ALREADY_EXISTS_CODE = 160004
         # Maximum length of an auto-generated thread name (Discord limit: 100).
         THREAD_NAME_MAX_LENGTH = 100
+        # Messages requested per history page (Discord's maximum).
+        HISTORY_PAGE_LIMIT = 100
         # Upper bound on @reply_targets: the gateway is a resident process, and
         # reply-mode entries have no other eviction path, so the map is capped
         # and the oldest entry is dropped once it is exceeded (FIFO). Losing an
@@ -229,6 +232,54 @@ module RedmineAiHelper
             body[:message_reference] = { message_id: reply_to } if reply_to && index.zero?
             post_message(target, body)
           end
+        end
+
+        # Discord serves both thread and channel messages through the same
+        # REST endpoint. Whether the bodies actually arrive depends on the
+        # Message Content Intent being enabled in the Developer Portal; when it
+        # is not, the bodies are empty and every message is skipped as empty,
+        # so the gateway answers without context instead of failing.
+        # @return [Boolean]
+        def supports_history?
+          true
+        end
+
+        # Reads the messages of a thread, paging backwards until the import
+        # cursor is reached or the thread is exhausted. Only the backward
+        # direction is used: on an incremental import the first page already
+        # crosses the cursor.
+        # @param channel_id [String] the parent channel id (unused: the thread
+        #   itself is the REST resource)
+        # @param thread_key [String] "{parent_id}:{thread_id}"
+        # @param after [String, nil] only messages after this message id
+        # @return [Array<HistoryMessage>] ascending (oldest first)
+        def fetch_thread_history(channel_id:, thread_key:, after: nil) # rubocop:disable Lint/UnusedMethodArgument
+          thread_id = thread_key.split(":", 2).last
+          collected = []
+          before = nil
+          loop do
+            page = fetch_messages(thread_id, limit: HISTORY_PAGE_LIMIT, before: before)
+            break if page.empty?
+
+            newer_than_cursor = page.take_while { |raw| after.blank? || raw["id"].to_i > after.to_i }
+            collected.concat(newer_than_cursor)
+            break if newer_than_cursor.size < page.size || page.size < HISTORY_PAGE_LIMIT
+
+            before = page.last["id"]
+          end
+          history_messages(collected)
+        end
+
+        # Reads the most recent messages of a channel (or DM) that are younger
+        # than +since+.
+        # @param channel_id [String] the channel id (DM channel for DMs)
+        # @param before [String] only messages before this message id
+        # @param since [Time] only messages posted at or after this time
+        # @param limit [Integer] maximum number of messages
+        # @return [Array<HistoryMessage>] ascending (oldest first)
+        def fetch_channel_history(channel_id:, before:, since:, limit:)
+          page = fetch_messages(channel_id, limit: limit, before: before)
+          history_messages(page.select { |raw| Time.iso8601(raw["timestamp"].to_s) >= since })
         end
 
         # Classifies DiscordApiError as a fatal configuration/credential error
@@ -407,7 +458,8 @@ module RedmineAiHelper
             parent_id = channel["parent_id"]
             dispatch(IncomingMessage.new(
               channel_type: channel_type, channel_id: parent_id,
-              thread_key: "#{parent_id}:#{channel_id}", message_ts: message_id, text: text, dm: false
+              thread_key: "#{parent_id}:#{channel_id}", message_ts: message_id, text: text,
+              dm: false, in_thread: true
             ))
           else
             dispatch_with_thread(channel_id, message_id, text)
@@ -655,6 +707,52 @@ module RedmineAiHelper
         # @return [Hash] the created message object
         def post_message(channel_id, body)
           request(:post, "/channels/#{channel_id}/messages", body: body)
+        end
+
+        # Reads one page of messages, newest first.
+        # @param channel_id [String] the channel or thread id
+        # @param limit [Integer] the page size
+        # @param before [String, nil] only messages before this message id
+        # @return [Array<Hash>] the raw message objects, newest first
+        def fetch_messages(channel_id, limit:, before: nil)
+          params = { limit: limit }
+          params[:before] = before if before.present?
+          request(:get, "/channels/#{channel_id}/messages?#{URI.encode_www_form(params)}")
+        end
+
+        # Converts raw Discord messages into history messages, dropping the
+        # ones that must not be imported (FR-009) and restoring ascending
+        # order: Discord answers newest first.
+        # @param raw_messages [Array<Hash>] the raw message objects
+        # @return [Array<HistoryMessage>] ascending (oldest first)
+        def history_messages(raw_messages)
+          raw_messages.reverse.filter_map { |raw| history_message(raw) }
+        end
+
+        # Converts one raw message, or nil when it must not be imported.
+        # @param raw [Hash] the raw message object
+        # @return [HistoryMessage, nil]
+        def history_message(raw)
+          return nil unless REPLYABLE_MESSAGE_TYPES.include?(raw["type"])
+          return nil if bot_authored?(raw)
+
+          content = raw["content"].to_s
+          return nil if mentions_bot?(content)
+
+          text = content.strip
+          return nil if text.empty?
+
+          HistoryMessage.new(speaker: speaker_name(raw), text: text)
+        end
+
+        # The speaker's display name, taken from the payload: Discord needs no
+        # extra call to resolve it.
+        # @param raw [Hash] the raw message object
+        # @return [String]
+        def speaker_name(raw)
+          raw.dig("member", "nick").presence ||
+            raw.dig("author", "global_name").presence ||
+            raw.dig("author", "username").to_s
         end
 
         # Splits a reply into chunks within the Discord message limit,

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "net/http"
+require "time"
 require "uri"
 require "websocket-client-simple"
 require "redmine_ai_helper/chat_channel/base_adapter"
@@ -200,7 +201,7 @@ module RedmineAiHelper
             ai_helper_logger.debug "discord: ignoring opcode #{payload["op"].inspect}"
           end
         rescue JSON::ParserError => e
-          ai_helper_logger.error "discord: failed to parse gateway payload: #{e.message}"
+          ai_helper_logger.error "discord: failed to parse gateway payload: #{e.full_message}"
         end
 
         # Reacts to a gateway close frame, capturing fatal authentication
@@ -270,8 +271,8 @@ module RedmineAiHelper
           history_messages(collected)
         end
 
-        # Reads the most recent messages of a channel (or DM) that are younger
-        # than +since+.
+        # Reads the most recent messages of a channel (or DM) that are at or
+        # after +since+.
         # @param channel_id [String] the channel id (DM channel for DMs)
         # @param before [String] only messages before this message id
         # @param since [Time] only messages posted at or after this time
@@ -626,7 +627,7 @@ module RedmineAiHelper
         # @param error [Exception] the socket error
         # @return [void]
         def socket_errored(error)
-          ai_helper_logger.error "discord: websocket error: #{error.message}"
+          ai_helper_logger.error "discord: websocket error: #{error.full_message}"
           @connection_ended&.push(true)
         end
 
@@ -844,7 +845,7 @@ module RedmineAiHelper
           body = JSON.parse(response.body.to_s)
           body["retry_after"].to_f
         rescue JSON::ParserError => e
-          ai_helper_logger.debug "discord: could not parse retry_after from 429 body (#{e.message}); falling back to 1s"
+          ai_helper_logger.warn "discord: could not parse retry_after from 429 body (#{e.message}); falling back to 1s"
           1.0
         end
 
@@ -853,7 +854,8 @@ module RedmineAiHelper
         # @return [Integer, nil]
         def error_code(response)
           JSON.parse(response.body.to_s)["code"]
-        rescue JSON::ParserError, TypeError
+        rescue JSON::ParserError, TypeError => e
+          ai_helper_logger.debug "discord: could not parse error code from response body (#{e.message})"
           nil
         end
       end

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -137,7 +137,7 @@ module RedmineAiHelper
             ai_helper_logger.debug "slack: ignoring envelope type #{data["type"].inspect}"
           end
         rescue JSON::ParserError => e
-          ai_helper_logger.error "slack: failed to parse envelope: #{e.message}"
+          ai_helper_logger.error "slack: failed to parse envelope: #{e.full_message}"
         end
 
         # Posts a reply into the given thread, splitting texts longer than
@@ -298,7 +298,7 @@ module RedmineAiHelper
 
         # A socket error occurred; end the connection so #start can retry.
         def socket_errored(error)
-          ai_helper_logger.error "slack: websocket error: #{error.message}"
+          ai_helper_logger.error "slack: websocket error: #{error.full_message}"
           @connection_ended&.push(true)
         end
 

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -4,6 +4,7 @@ require "json"
 require "net/http"
 require "websocket-client-simple"
 require "redmine_ai_helper/chat_channel/base_adapter"
+require "redmine_ai_helper/chat_channel/history_message"
 
 module RedmineAiHelper
   module ChatChannel
@@ -30,6 +31,18 @@ module RedmineAiHelper
         MAX_MISSED_PONGS = 2
         # Replies longer than this are split before posting (research.md R-008).
         MAX_MESSAGE_LENGTH = 3900
+        # Messages requested per history page (Slack's maximum for a full page).
+        HISTORY_PAGE_LIMIT = 200
+        # Subtypes that carry an ordinary contribution to the discussion.
+        # Everything else (joins, leaves, edits, pins, ...) is a system message
+        # and is not imported. bot_message stays on the list because other
+        # bots' messages are part of the discussion (FR-009).
+        HISTORY_SUBTYPES = [ nil, "bot_message", "thread_broadcast", "file_share" ].freeze
+        # Upper bound on the user id to display name cache. The gateway is a
+        # resident process, so the map is capped and the oldest entry is
+        # dropped once it is exceeded (FIFO), same as @reply_targets in the
+        # Discord adapter. Losing an entry only costs one extra users.info call.
+        MAX_DISPLAY_NAMES = 500
 
         class << self
           # @return [String] the adapter identifier
@@ -55,6 +68,7 @@ module RedmineAiHelper
           @connected = false
           @backoff = 1
           @missed_pongs = 0
+          @display_names = {}
         end
 
         # Connects to Slack and blocks while receiving events. Reconnects on
@@ -140,6 +154,49 @@ module RedmineAiHelper
           end
         end
 
+        # Slack exposes both the thread replies and the channel history.
+        # @return [Boolean]
+        def supports_history?
+          true
+        end
+
+        # Reads the replies of a thread through conversations.replies, paging
+        # until Slack stops handing out a cursor.
+        # @param channel_id [String] the Slack channel id
+        # @param thread_key [String] "{channel_id}:{thread_ts}"
+        # @param after [String, nil] only messages after this ts are returned
+        # @return [Array<HistoryMessage>] ascending (oldest first)
+        def fetch_thread_history(channel_id:, thread_key:, after: nil)
+          params = { channel: channel_id, ts: thread_key.split(":", 2).last,
+                     inclusive: false, limit: HISTORY_PAGE_LIMIT }
+          params[:oldest] = after if after.present?
+          raw_messages = []
+          cursor = nil
+          loop do
+            page_params = cursor ? params.merge(cursor: cursor) : params
+            body = api_call("conversations.replies", token: settings.bot_token, params: page_params)
+            raw_messages.concat(body["messages"] || [])
+            cursor = body.dig("response_metadata", "next_cursor").presence
+            break unless cursor
+          end
+          history_messages(raw_messages)
+        end
+
+        # Reads the top-level messages of a channel (or DM) through
+        # conversations.history. Thread replies are not part of the result,
+        # which is exactly the "top-level messages" the import asks for.
+        # @param channel_id [String] the Slack channel id (DM channel for DMs)
+        # @param before [String] only messages before this ts are returned
+        # @param since [Time] only messages posted after this time
+        # @param limit [Integer] maximum number of messages
+        # @return [Array<HistoryMessage>] ascending (oldest first)
+        def fetch_channel_history(channel_id:, before:, since:, limit:)
+          params = { channel: channel_id, oldest: since.to_f, inclusive: false, limit: limit }
+          params[:latest] = before if before.present?
+          body = api_call("conversations.history", token: settings.bot_token, params: params)
+          history_messages(body["messages"] || [])
+        end
+
         # Marks a SlackApiError as a fatal configuration/credential error so
         # the gateway exits cleanly (exit 0) and is not restarted by the
         # supervisor into the same broken configuration (ADR-006).
@@ -156,10 +213,14 @@ module RedmineAiHelper
           @stopped
         end
 
-        # Fetches the bot's own user id and validates the bot token.
+        # Fetches the bot's own user id and validates the bot token. The bot id
+        # is kept as well: the gateway's own posts appear in the history with a
+        # bot_id rather than a user id.
         # @return [String]
         def fetch_bot_user_id
-          api_call("auth.test", token: settings.bot_token)["user_id"]
+          body = api_call("auth.test", token: settings.bot_token)
+          @bot_id = body["bot_id"]
+          body["user_id"]
         end
 
         # Opens a Socket Mode connection URL with the app-level token.
@@ -286,13 +347,98 @@ module RedmineAiHelper
             thread_key: "#{event["channel"]}:#{thread_ts}",
             message_ts: event["ts"],
             text: strip_mention(event["text"].to_s),
-            dm: dm
+            dm: dm,
+            in_thread: event["thread_ts"].present?
           ))
         end
 
         # Removes the bot mention markup from the question text.
         def strip_mention(text)
           text.gsub(/<@#{Regexp.escape(@bot_user_id.to_s)}>/, "").strip
+        end
+
+        # Converts raw Slack messages into history messages, dropping the ones
+        # that must not be imported (FR-009) and restoring ascending order:
+        # Slack answers newest first.
+        # @param raw_messages [Array<Hash>] the raw message objects
+        # @return [Array<HistoryMessage>] ascending (oldest first)
+        def history_messages(raw_messages)
+          raw_messages.reverse.filter_map { |raw| history_message(raw) }
+        end
+
+        # Converts one raw message, or nil when it must not be imported.
+        # @param raw [Hash] the raw message object
+        # @return [HistoryMessage, nil]
+        def history_message(raw)
+          return nil unless HISTORY_SUBTYPES.include?(raw["subtype"])
+          return nil if own_message?(raw)
+
+          text = raw["text"].to_s
+          return nil if mentions_bot?(text)
+
+          text = text.strip
+          return nil if text.empty?
+
+          HistoryMessage.new(speaker: speaker_name(raw), text: text)
+        end
+
+        # Whether the message was posted by the gateway itself, either as the
+        # bot user or through the app's bot identity.
+        # @param raw [Hash] the raw message object
+        # @return [Boolean]
+        def own_message?(raw)
+          return true if @bot_user_id.present? && raw["user"] == @bot_user_id
+
+          @bot_id.present? && raw["bot_id"] == @bot_id
+        end
+
+        # Whether the text addresses the bot, which means it is already stored
+        # as the question of this or another conversation.
+        # @param text [String] the message body
+        # @return [Boolean]
+        def mentions_bot?(text)
+          text.include?("<@#{@bot_user_id}>")
+        end
+
+        # The speaker's display name. Messages of other bots carry their name
+        # in the payload, so they need no users.info lookup.
+        # @param raw [Hash] the raw message object
+        # @return [String]
+        def speaker_name(raw)
+          if raw["bot_id"].present?
+            raw["username"].presence || raw.dig("bot_profile", "name").presence || raw["bot_id"]
+          else
+            user_display_name(raw["user"])
+          end
+        end
+
+        # Resolves a user id to a display name, caching the result for the
+        # lifetime of the adapter so repeated mentions in the same thread do
+        # not call users.info again.
+        # @param user_id [String, nil] the Slack user id
+        # @return [String]
+        def user_display_name(user_id)
+          return user_id.to_s if user_id.blank?
+
+          cached = @display_names[user_id]
+          return cached if cached
+
+          profile = api_call("users.info", token: settings.bot_token, params: { user: user_id })["user"] || {}
+          name = profile.dig("profile", "display_name").presence ||
+                 profile["real_name"].presence || profile["name"].presence || user_id
+          cache_display_name(user_id, name)
+          name
+        end
+
+        # Stores a display name, evicting the oldest entry once the cap is
+        # exceeded (FIFO).
+        # @param user_id [String] the Slack user id
+        # @param name [String] the resolved display name
+        # @return [void]
+        def cache_display_name(user_id, name)
+          @display_names.delete(user_id)
+          @display_names[user_id] = name
+          @display_names.delete(@display_names.each_key.first) while @display_names.size > MAX_DISPLAY_NAMES
         end
 
         # Splits a reply into chunks within the Slack message limit,

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -161,8 +161,8 @@ module RedmineAiHelper
 
       # Top-level messages of a channel (or DM), in ascending order.
       # @param channel_id [String] Channel identifier (DM channel id for DMs)
-      # @param before [String] Only messages before this external message id
-      #   are returned, which excludes the mention itself
+      # @param before [String, nil] Only messages before this external message
+      #   id are returned, which excludes the mention itself
       # @param since [Time] Only messages posted at or after this time
       # @param limit [Integer] Maximum number of messages, counted from the
       #   most recent one

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -139,6 +139,38 @@ module RedmineAiHelper
         raise NotImplementedError, "#{self.class.name} must implement #send_message"
       end
 
+      # Whether the adapter can retrieve past messages from the chat tool.
+      # History retrieval is optional: adapters that leave this at false keep
+      # working through the unchanged core, the only difference being that
+      # answers are generated without surrounding context (FR-010).
+      # @return [Boolean]
+      def supports_history?
+        false
+      end
+
+      # Messages posted in a thread, in ascending (oldest first) order. No
+      # count or age limit is applied.
+      # @param channel_id [String] Parent channel identifier
+      # @param thread_key [String] Thread identifier (same format as elsewhere)
+      # @param after [String, nil] Import cursor; only messages after this
+      #   external message id are returned. nil returns the whole thread.
+      # @return [Array<HistoryMessage>]
+      def fetch_thread_history(channel_id:, thread_key:, after: nil)
+        raise NotImplementedError, "#{self.class.name} must implement #fetch_thread_history"
+      end
+
+      # Top-level messages of a channel (or DM), in ascending order.
+      # @param channel_id [String] Channel identifier (DM channel id for DMs)
+      # @param before [String] Only messages before this external message id
+      #   are returned, which excludes the mention itself
+      # @param since [Time] Only messages posted at or after this time
+      # @param limit [Integer] Maximum number of messages, counted from the
+      #   most recent one
+      # @return [Array<HistoryMessage>]
+      def fetch_channel_history(channel_id:, before:, since:, limit:)
+        raise NotImplementedError, "#{self.class.name} must implement #fetch_channel_history"
+      end
+
       # Whether the given error is a fatal configuration/credential error
       # that the supervisor (systemd) must not retry. Defaults to false;
       # adapters override to classify their own credential errors so ADR-006

--- a/lib/redmine_ai_helper/chat_channel/context_importer.rb
+++ b/lib/redmine_ai_helper/chat_channel/context_importer.rb
@@ -27,8 +27,10 @@ module RedmineAiHelper
       # before the question itself is appended to the conversation, because the
       # conversation being empty is what distinguishes a new conversation
       # started outside a thread from a continuing one.
-      # @param conversation [AiHelperConversation] the thread's conversation
-      # @param message [IncomingMessage] the mention being processed
+      # @param conversation [AiHelperConversation] the thread's conversation;
+      #   must have an associated channel_conversation
+      # @param message [IncomingMessage] the mention being processed; +message_ts+
+      #   must not be nil (it becomes the import cursor)
       # @return [Integer] the number of imported messages
       # @raise [StandardError] when the adapter fails to retrieve the history
       def import(conversation:, message:)
@@ -76,15 +78,16 @@ module RedmineAiHelper
 
       # Appends the retrieved messages to the conversation and advances the
       # import cursor. Both happen in one transaction so a failure can never
-      # leave the cursor ahead of what was actually stored. The cursor is
-      # advanced even when nothing was retrieved, so the same range is not
-      # scanned again.
+      # leave the cursor ahead of what was actually stored. In thread mode the
+      # cursor prevents the same range from being scanned again; in channel
+      # mode it is advanced for consistency but channel mode only fires once
+      # (when the conversation is empty).
       # @return [void]
       def store(conversation:, message:, history:)
         AiHelperConversation.transaction do
           history.each do |imported|
             conversation.messages << AiHelperMessage.new(
-              role: "context", content: "#{imported.speaker}: #{imported.text}"
+              role: AiHelperMessage::CONTEXT_ROLE, content: "#{imported.speaker}: #{imported.text}"
             )
           end
           conversation.save!

--- a/lib/redmine_ai_helper/chat_channel/context_importer.rb
+++ b/lib/redmine_ai_helper/chat_channel/context_importer.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "redmine_ai_helper/logger"
+require "redmine_ai_helper/chat_channel/history_message"
+
+module RedmineAiHelper
+  module ChatChannel
+    # Imports the messages surrounding a mention into the conversation bound to
+    # the thread. The imported messages are stored as regular conversation
+    # messages with role "context", so they reach the LLM through the existing
+    # conversation handover and stay visible in the Redmine chat history.
+    class ContextImporter
+      include RedmineAiHelper::Logger
+
+      # Age of the oldest top-level message imported in channel mode.
+      CONTEXT_LOOKBACK_HOURS = 48
+
+      # Maximum number of top-level messages imported in channel mode.
+      CONTEXT_MESSAGE_LIMIT = 20
+
+      # @param adapter [BaseAdapter] the adapter retrieving the history
+      def initialize(adapter)
+        @adapter = adapter
+      end
+
+      # Imports the messages that have not been imported yet. Must be called
+      # before the question itself is appended to the conversation, because the
+      # conversation being empty is what distinguishes a new conversation
+      # started outside a thread from a continuing one.
+      # @param conversation [AiHelperConversation] the thread's conversation
+      # @param message [IncomingMessage] the mention being processed
+      # @return [Integer] the number of imported messages
+      # @raise [StandardError] when the adapter fails to retrieve the history
+      def import(conversation:, message:)
+        return 0 unless @adapter.supports_history?
+
+        source = import_source(conversation: conversation, message: message)
+        return 0 unless source
+
+        history = fetch_history(source: source, conversation: conversation, message: message)
+        store(conversation: conversation, message: message, history: history)
+        ai_helper_logger.info "chat channel: imported #{history.size} context messages " \
+                              "from #{source} (conversation #{conversation.id})"
+        history.size
+      end
+
+      private
+
+      # Which retrieval mode applies to this mention, or nil when nothing is
+      # imported. A mention outside a thread that continues an existing
+      # conversation imports nothing: following the channel along is out of
+      # scope for this feature.
+      # @return [Symbol, nil] :thread, :channel or nil
+      def import_source(conversation:, message:)
+        return :thread if message.in_thread?
+        return :channel if conversation.messages.empty?
+
+        nil
+      end
+
+      # Retrieves the not-yet-imported messages for the resolved mode.
+      # @return [Array<HistoryMessage>] ascending (oldest first)
+      def fetch_history(source:, conversation:, message:)
+        if source == :thread
+          @adapter.fetch_thread_history(
+            channel_id: message.channel_id, thread_key: message.thread_key,
+            after: conversation.channel_conversation.last_imported_message_key
+          )
+        else
+          @adapter.fetch_channel_history(
+            channel_id: message.channel_id, before: message.message_ts,
+            since: CONTEXT_LOOKBACK_HOURS.hours.ago, limit: CONTEXT_MESSAGE_LIMIT
+          )
+        end
+      end
+
+      # Appends the retrieved messages to the conversation and advances the
+      # import cursor. Both happen in one transaction so a failure can never
+      # leave the cursor ahead of what was actually stored. The cursor is
+      # advanced even when nothing was retrieved, so the same range is not
+      # scanned again.
+      # @return [void]
+      def store(conversation:, message:, history:)
+        AiHelperConversation.transaction do
+          history.each do |imported|
+            conversation.messages << AiHelperMessage.new(
+              role: "context", content: "#{imported.speaker}: #{imported.text}"
+            )
+          end
+          conversation.save!
+          conversation.channel_conversation.update!(last_imported_message_key: message.message_ts)
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/context_importer.rb
+++ b/lib/redmine_ai_helper/chat_channel/context_importer.rb
@@ -93,6 +93,14 @@ module RedmineAiHelper
           conversation.save!
           conversation.channel_conversation.update!(last_imported_message_key: message.message_ts)
         end
+      rescue
+        # The rollback removes the rows but leaves the appended records in the
+        # loaded association, from where the caller's next save would insert
+        # them again - behind the question and without the cursor being
+        # advanced. Dropping them restores the stored state before the error
+        # reaches the caller.
+        conversation.messages.reset
+        raise
       end
     end
   end

--- a/lib/redmine_ai_helper/chat_channel/history_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/history_message.rb
@@ -22,6 +22,7 @@ module RedmineAiHelper
       def initialize(speaker:, text:)
         @speaker = speaker
         @text = text
+        freeze
       end
     end
   end

--- a/lib/redmine_ai_helper/chat_channel/history_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/history_message.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RedmineAiHelper
+  module ChatChannel
+    # Value object holding one message retrieved from a chat tool's history.
+    # Adapters return these in ascending (oldest first) order with the
+    # tool-specific concerns already resolved: the speaker is a display name,
+    # the text has mention markup removed, and messages that must not be
+    # imported (own messages, mentions of the bot, system messages, empty
+    # bodies) have already been filtered out.
+    # No timestamp is carried: the retrieval window is applied inside the
+    # adapter and the order within the conversation expresses the sequence.
+    class HistoryMessage
+      # @return [String] the speaker's display name in the chat tool
+      attr_reader :speaker
+
+      # @return [String] the message body
+      attr_reader :text
+
+      # @param speaker [String] the speaker's display name (human or bot)
+      # @param text [String] the message body without mention markup
+      def initialize(speaker:, text:)
+        @speaker = speaker
+        @text = text
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/incoming_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/incoming_message.rb
@@ -20,19 +20,30 @@ module RedmineAiHelper
       #   within a thread each get their own notice instead of colliding on
       #   the thread's root message.
       # @param dm [Boolean] Whether the message is a direct message
-      def initialize(channel_type:, channel_id:, thread_key:, text:, message_ts: nil, dm: false)
+      # @param in_thread [Boolean] Whether the message was posted inside an
+      #   existing thread. Adapters that cannot tell (or that do not retrieve
+      #   history at all) leave this at false, which keeps the import in
+      #   channel mode or skips it entirely.
+      def initialize(channel_type:, channel_id:, thread_key:, text:, message_ts: nil, dm: false, in_thread: false)
         @channel_type = channel_type
         @channel_id = channel_id
         @thread_key = thread_key
         @message_ts = message_ts
         @text = text
         @dm = dm
+        @in_thread = in_thread
       end
 
       # Whether the message is a direct message.
       # @return [Boolean]
       def dm?
         @dm
+      end
+
+      # Whether the message was posted inside an existing thread.
+      # @return [Boolean]
+      def in_thread?
+        @in_thread
       end
     end
   end

--- a/lib/redmine_ai_helper/chat_channel/incoming_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/incoming_message.rb
@@ -8,17 +8,30 @@ module RedmineAiHelper
     # The speaker's identity is deliberately not carried: all questions are
     # processed as the configured service account (FR-004).
     class IncomingMessage
-      attr_reader :channel_type, :channel_id, :thread_key, :message_ts, :text
+      # @return [String] Adapter identifier (e.g. "slack")
+      attr_reader :channel_type
+      # @return [String] Channel identifier (DM channel id for DMs)
+      attr_reader :channel_id
+      # @return [String] Tool-specific thread identifier
+      attr_reader :thread_key
+      # @return [String, nil] Identifier of this individual message (Slack
+      #   +ts+, Discord snowflake). Used as the import cursor
+      #   (ContextImporter#store), the channel-history boundary
+      #   (ContextImporter#fetch_history), and to attach processing notices
+      #   to the message that was actually sent.
+      attr_reader :message_ts
+      # @return [String] Question body with mention markup removed
+      attr_reader :text
 
       # @param channel_type [String] Adapter identifier (e.g. "slack")
       # @param channel_id [String] Channel identifier (DM channel id for DMs)
       # @param thread_key [String] Tool-specific thread identifier
       # @param text [String] Question body with mention markup removed
       # @param message_ts [String, nil] Identifier of this individual message
-      #   (Slack +ts+), distinct from the thread key. Used to attach the
-      #   processing notice to the message that was actually sent, so replies
-      #   within a thread each get their own notice instead of colliding on
-      #   the thread's root message.
+      #   (Slack +ts+, Discord snowflake), distinct from the thread key. Used
+      #   as the differential-import cursor, the channel-history +before+
+      #   boundary, and to attach processing notices to the correct message so
+      #   replies within a thread each get their own notice.
       # @param dm [Boolean] Whether the message is a direct message
       # @param in_thread [Boolean] Whether the message was posted inside an
       #   existing thread. Adapters that cannot tell (or that do not retrieve
@@ -32,6 +45,7 @@ module RedmineAiHelper
         @text = text
         @dm = dm
         @in_thread = in_thread
+        freeze
       end
 
       # Whether the message is a direct message.

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "redmine_ai_helper/logger"
+require "redmine_ai_helper/chat_channel/context_importer"
 
 module RedmineAiHelper
   module ChatChannel
@@ -79,16 +80,20 @@ module RedmineAiHelper
         binding&.project || settings.default_project
       end
 
-      # Appends the question to the thread's conversation and runs the LLM
-      # under the service account's permissions.
+      # Imports the surrounding chat messages, appends the question to the
+      # thread's conversation and runs the LLM under the service account's
+      # permissions. The import runs before the question is appended, and
+      # after the checks in #handle, so a question that is refused never
+      # reaches the chat tool's history API (FR-013).
       # @return [AiHelperMessage] The assistant's answer
       def process_question(message, user, project)
         conversation = AiHelperChannelConversation.find_or_create_conversation(
           channel_type: message.channel_type, thread_key: message.thread_key, user: user
         )
-        if conversation.messages.empty?
-          conversation.title = message.text.truncate(TITLE_MAX_LENGTH)
-        end
+        new_conversation = conversation.messages.empty?
+        history_unavailable = import_context(conversation, message)
+
+        conversation.title = message.text.truncate(TITLE_MAX_LENGTH) if new_conversation
         conversation.messages << AiHelperMessage.new(role: "user", content: message.text)
         conversation.save!
 
@@ -102,9 +107,22 @@ module RedmineAiHelper
           I18n.locale = original_locale
         end
 
+        answer.content = "#{guidance(:history_unavailable, user)}\n\n#{answer.content}" if history_unavailable
         conversation.messages << answer
         conversation.save!
         answer
+      end
+
+      # Imports the messages surrounding the mention. A retrieval failure is
+      # logged and reported to the user (FR-008) instead of aborting the
+      # answer; the notice is added to the answer by the caller.
+      # @return [Boolean] whether the import failed
+      def import_context(conversation, message)
+        ContextImporter.new(@adapter).import(conversation: conversation, message: message)
+        false
+      rescue => e
+        ai_helper_logger.error "chat channel: could not import the conversation context: #{e.full_message}"
+        true
       end
 
       # Posts a reply into the thread the message came from.

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -34,7 +34,7 @@ module RedmineAiHelper
         setting = adapter_settings(message)
         user = setting.service_account
         unless user
-          # FR-1 forbids saving an enabled adapter without an execution
+          # FR-001 forbids saving an enabled adapter without an execution
           # account, so an enabled adapter that resolves no active account can
           # only mean the previously configured account was deleted (the FK
           # nullifies redmine_user_id) or locked. Distinguish that runtime
@@ -115,7 +115,10 @@ module RedmineAiHelper
 
       # Imports the messages surrounding the mention. A retrieval failure is
       # logged and reported to the user (FR-008) instead of aborting the
-      # answer; the notice is added to the answer by the caller.
+      # answer; the notice is added to the answer by the caller. This is a
+      # deliberate deviation from the general "never swallow errors" guideline:
+      # the error is fully logged with backtrace and explicitly surfaced to
+      # the user, so the fallback is not silent.
       # @return [Boolean] whether the import failed
       def import_context(conversation, message)
         ContextImporter.new(@adapter).import(conversation: conversation, message: message)

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -114,6 +114,31 @@ class AiHelperControllerTest < ActionController::TestCase
         assert_response :success
         assert_template partial: "ai_helper/chat/_chat"
       end
+
+      should "label messages imported from a chat channel" do
+        @conversation.messages << AiHelperMessage.new(role: "context", content: "Yamada: it crashes on save")
+        @conversation.save!
+
+        get :conversation, params: { id: @project.id, conversation_id: @conversation.id }
+
+        assert_response :success
+        assert_select "pre", text: "Yamada: it crashes on save"
+        assert_match(/#{Regexp.escape(I18n.t("ai_helper.chat_channel.context.label"))}/, @response.body)
+      end
+
+      should "render imported messages as escaped plain text instead of markdown" do
+        @conversation.messages << AiHelperMessage.new(
+          role: "context", content: "Yamada: **bold** <script>alert(1)</script>"
+        )
+        @conversation.save!
+
+        get :conversation, params: { id: @project.id, conversation_id: @conversation.id }
+
+        assert_response :success
+        assert_no_match(/<strong>bold<\/strong>/, @response.body)
+        assert_no_match(/<script>alert\(1\)<\/script>/, @response.body)
+        assert_match(/&lt;script&gt;/, @response.body)
+      end
     end
 
     context "#history" do

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -1903,7 +1903,7 @@ class AiHelperControllerTest < ActionController::TestCase
         begin
           post :project_health_pdf, params: { id: @project.id, health_report_content: "test", format: :json }
 
-          assert_includes [403, 422], response.code.to_i
+          assert_includes [ 403, 422 ], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1914,7 +1914,7 @@ class AiHelperControllerTest < ActionController::TestCase
         begin
           post :chat, params: { id: @project.id, ai_helper_message: { content: "Hello" }, format: :json }
 
-          assert_includes [403, 422], response.code.to_i
+          assert_includes [ 403, 422 ], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -139,6 +139,22 @@ class AiHelperControllerTest < ActionController::TestCase
         assert_no_match(/<script>alert\(1\)<\/script>/, @response.body)
         assert_match(/&lt;script&gt;/, @response.body)
       end
+
+      should "render context messages without an avatar while user messages have one" do
+        @conversation.messages << AiHelperMessage.new(role: "context", content: "Yamada: imported")
+        @conversation.save!
+
+        get :conversation, params: { id: @project.id, conversation_id: @conversation.id }
+
+        assert_response :success
+        assert_select ".aihelper-message-user strong",
+                      text: I18n.t("ai_helper.chat_channel.context.label")
+        assert_select ".aihelper-message-user strong",
+                      text: @user.name
+        context_html = @response.body.match(/aihelper-chat_channel.context.label.*?<\/strong>.*?<\/pre>/m)
+        assert_no_match(/<img/, context_html.to_s,
+                        "context messages must not render an avatar image")
+      end
     end
 
     context "#history" do

--- a/test/functional/ai_helper_controller_test.rb
+++ b/test/functional/ai_helper_controller_test.rb
@@ -1903,7 +1903,7 @@ class AiHelperControllerTest < ActionController::TestCase
         begin
           post :project_health_pdf, params: { id: @project.id, health_report_content: "test", format: :json }
 
-          assert_response :unprocessable_content
+          assert_includes [403, 422], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1914,7 +1914,7 @@ class AiHelperControllerTest < ActionController::TestCase
         begin
           post :chat, params: { id: @project.id, ai_helper_message: { content: "Hello" }, format: :json }
 
-          assert_response :unprocessable_content
+          assert_includes [403, 422], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end

--- a/test/functional/ai_helper_csrf_test.rb
+++ b/test/functional/ai_helper_csrf_test.rb
@@ -37,7 +37,7 @@ class AiHelperCsrfTest < ActionController::TestCase
          params: { id: @project.id, issue_id: 1 },
          body: { text: "test text", cursor_position: 4 }.to_json
 
-    assert_response :unprocessable_content
+    assert_includes [403, 422], response.code.to_i
   end
 
   def test_suggest_wiki_completion_rejects_post_without_csrf_token
@@ -46,14 +46,14 @@ class AiHelperCsrfTest < ActionController::TestCase
          params: { id: @project.id },
          body: { text: "test text", cursor_position: 4 }.to_json
 
-    assert_response :unprocessable_content
+    assert_includes [403, 422], response.code.to_i
   end
 
   def test_check_typos_rejects_post_without_csrf_token
     post :check_typos,
          params: { id: @project.id, text: "test text", context_type: "issue" }
 
-    assert_response :unprocessable_content
+    assert_includes [403, 422], response.code.to_i
   end
 
   def test_check_duplicates_rejects_post_without_csrf_token
@@ -62,7 +62,7 @@ class AiHelperCsrfTest < ActionController::TestCase
          params: { id: @project.id },
          body: { subject: "Test subject", description: "Test description" }.to_json
 
-    assert_response :unprocessable_content
+    assert_includes [403, 422], response.code.to_i
   end
 
   # --- Actions that SHOULD be exempt from CSRF protection ---
@@ -75,7 +75,7 @@ class AiHelperCsrfTest < ActionController::TestCase
 
     get :generate_project_health, params: { id: @project.id }
 
-    # Should not be 422 (CSRF rejection)
+    # Should not be a CSRF rejection (422 on Rails 7.x)
     assert_not_equal 422, @response.status
   end
 
@@ -86,7 +86,7 @@ class AiHelperCsrfTest < ActionController::TestCase
     post :api_create_health_report,
          params: { id: @project.id, format: :json, key: @user.api_key }
 
-    # Should not be 422 (CSRF rejection)
+    # Should not be a CSRF rejection (422 on Rails 7.x)
     assert_not_equal 422, @response.status
   end
 end

--- a/test/functional/ai_helper_csrf_test.rb
+++ b/test/functional/ai_helper_csrf_test.rb
@@ -37,7 +37,7 @@ class AiHelperCsrfTest < ActionController::TestCase
          params: { id: @project.id, issue_id: 1 },
          body: { text: "test text", cursor_position: 4 }.to_json
 
-    assert_includes [403, 422], response.code.to_i
+    assert_includes [ 403, 422 ], response.code.to_i
   end
 
   def test_suggest_wiki_completion_rejects_post_without_csrf_token
@@ -46,14 +46,14 @@ class AiHelperCsrfTest < ActionController::TestCase
          params: { id: @project.id },
          body: { text: "test text", cursor_position: 4 }.to_json
 
-    assert_includes [403, 422], response.code.to_i
+    assert_includes [ 403, 422 ], response.code.to_i
   end
 
   def test_check_typos_rejects_post_without_csrf_token
     post :check_typos,
          params: { id: @project.id, text: "test text", context_type: "issue" }
 
-    assert_includes [403, 422], response.code.to_i
+    assert_includes [ 403, 422 ], response.code.to_i
   end
 
   def test_check_duplicates_rejects_post_without_csrf_token
@@ -62,7 +62,7 @@ class AiHelperCsrfTest < ActionController::TestCase
          params: { id: @project.id },
          body: { subject: "Test subject", description: "Test description" }.to_json
 
-    assert_includes [403, 422], response.code.to_i
+    assert_includes [ 403, 422 ], response.code.to_i
   end
 
   # --- Actions that SHOULD be exempt from CSRF protection ---

--- a/test/functional/ai_helper_dashboard_controller_test.rb
+++ b/test/functional/ai_helper_dashboard_controller_test.rb
@@ -1248,7 +1248,7 @@ This is a test report."
         begin
           post :comparison_pdf, params: { id: @project.id, comparison_content: "test" }
 
-          assert_response :unprocessable_content
+          assert_includes [403, 422], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1265,7 +1265,7 @@ This is a test report."
         begin
           delete :health_report_destroy, params: { id: @project.id, report_id: report.id }
 
-          assert_response :unprocessable_content
+          assert_includes [403, 422], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1276,7 +1276,7 @@ This is a test report."
         begin
           post :comparison_pdf, params: { id: @project.id, content: "test", format: :json }
 
-          assert_response :unprocessable_content
+          assert_includes [302, 403, 422], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1293,7 +1293,7 @@ This is a test report."
         begin
           delete :health_report_destroy, params: { id: @project.id, report_id: report.id, format: :json }
 
-          assert_response :unprocessable_content
+          assert_includes [403, 422], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end

--- a/test/functional/ai_helper_dashboard_controller_test.rb
+++ b/test/functional/ai_helper_dashboard_controller_test.rb
@@ -1248,7 +1248,7 @@ This is a test report."
         begin
           post :comparison_pdf, params: { id: @project.id, comparison_content: "test" }
 
-          assert_includes [403, 422], response.code.to_i
+          assert_includes [ 403, 422 ], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1265,7 +1265,7 @@ This is a test report."
         begin
           delete :health_report_destroy, params: { id: @project.id, report_id: report.id }
 
-          assert_includes [403, 422], response.code.to_i
+          assert_includes [ 403, 422 ], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1276,7 +1276,7 @@ This is a test report."
         begin
           post :comparison_pdf, params: { id: @project.id, content: "test", format: :json }
 
-          assert_includes [302, 403, 422], response.code.to_i
+          assert_includes [ 302, 403, 422 ], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end
@@ -1293,7 +1293,7 @@ This is a test report."
         begin
           delete :health_report_destroy, params: { id: @project.id, report_id: report.id, format: :json }
 
-          assert_includes [403, 422], response.code.to_i
+          assert_includes [ 403, 422 ], response.code.to_i
         ensure
           ActionController::Base.allow_forgery_protection = false
         end

--- a/test/functional/ai_helper_model_profiles_controller_test.rb
+++ b/test/functional/ai_helper_model_profiles_controller_test.rb
@@ -84,7 +84,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       post :create, params: { ai_helper_model_profile: { name: "New", access_key: "key", llm_type: "OpenAI", llm_model: "model" } }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -95,7 +95,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       delete :destroy, params: { id: @model_profile.id }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -106,7 +106,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       post :create, params: { ai_helper_model_profile: { name: "New", access_key: "key", llm_type: "OpenAI", llm_model: "model" }, format: :json }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -117,7 +117,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       delete :destroy, params: { id: @model_profile.id, format: :json }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -211,7 +211,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
         }
       }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end

--- a/test/functional/ai_helper_model_profiles_controller_test.rb
+++ b/test/functional/ai_helper_model_profiles_controller_test.rb
@@ -84,7 +84,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       post :create, params: { ai_helper_model_profile: { name: "New", access_key: "key", llm_type: "OpenAI", llm_model: "model" } }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -95,7 +95,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       delete :destroy, params: { id: @model_profile.id }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -106,7 +106,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       post :create, params: { ai_helper_model_profile: { name: "New", access_key: "key", llm_type: "OpenAI", llm_model: "model" }, format: :json }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -117,7 +117,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
     begin
       delete :destroy, params: { id: @model_profile.id, format: :json }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -211,7 +211,7 @@ class AiHelperModelProfilesControllerTest < ActionController::TestCase
         }
       }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -42,7 +42,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     begin
       post :update, params: { ai_helper_setting: { model_profile_id: @model_profile.id } }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -53,7 +53,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     begin
       post :update, params: { ai_helper_setting: { model_profile_id: @model_profile.id }, format: :json }
 
-      assert_response :unprocessable_content
+      assert_includes [403, 422], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -42,7 +42,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     begin
       post :update, params: { ai_helper_setting: { model_profile_id: @model_profile.id } }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end
@@ -53,7 +53,7 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     begin
       post :update, params: { ai_helper_setting: { model_profile_id: @model_profile.id }, format: :json }
 
-      assert_includes [403, 422], response.code.to_i
+      assert_includes [ 403, 422 ], response.code.to_i
     ensure
       ActionController::Base.allow_forgery_protection = false
     end

--- a/test/unit/ai_helper_channel_conversation_test.rb
+++ b/test/unit/ai_helper_channel_conversation_test.rb
@@ -72,6 +72,22 @@ class AiHelperChannelConversationTest < ActiveSupport::TestCase
     end
   end
 
+  context "last_imported_message_key" do
+    should "default to nil for a newly created channel conversation" do
+      channel_conversation = create(:ai_helper_channel_conversation)
+
+      assert_nil channel_conversation.last_imported_message_key
+    end
+
+    should "persist the import cursor" do
+      channel_conversation = create(:ai_helper_channel_conversation)
+
+      channel_conversation.update!(last_imported_message_key: "1700000000.000500")
+
+      assert_equal "1700000000.000500", channel_conversation.reload.last_imported_message_key
+    end
+  end
+
   context "conversation deletion" do
     should "delete the channel conversation when the conversation is destroyed" do
       channel_conversation = create(:ai_helper_channel_conversation)

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -38,6 +38,34 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
     stub(code: code.to_s, body: body.to_json)
   end
 
+  # Answers the REST calls with the given bodies in call order and records the
+  # requests so their paths and query strings can be asserted.
+  def stub_discord_calls(*bodies)
+    @discord_requests = []
+    responses = bodies.map { |body| http_response(200, body) }
+    Net::HTTP.any_instance.stubs(:request).with { |request| @discord_requests << request; true }
+             .returns(*responses)
+  end
+
+  def discord_paths
+    @discord_requests.map(&:path)
+  end
+
+  def discord_query(index)
+    URI.decode_www_form(URI(@discord_requests[index].path).query.to_s).to_h
+  end
+
+  def history_raw(content:, id: "100", type: 0, author_id: "U1", username: "yamada",
+                  global_name: nil, nick: nil, timestamp: "2026-08-01T00:00:00.000000+00:00")
+    message = {
+      "id" => id, "type" => type, "content" => content, "timestamp" => timestamp,
+      "author" => { "id" => author_id, "username" => username }
+    }
+    message["author"]["global_name"] = global_name if global_name
+    message["member"] = { "nick" => nick } if nick
+    message
+  end
+
   def guild_message(content:, id: "M1", channel_id: "C1", type: 0, author_id: "U1",
                     bot: false, guild_id: "G1", ref: nil, mentions: nil)
     message = {
@@ -446,6 +474,33 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_equal "P1:T1", message.thread_key
     end
 
+    should "mark a mention inside a thread channel as in_thread" do
+      DiscordAdapter::THREAD_CHANNEL_TYPES.each do |channel_type|
+        dispatcher = RecordingDispatcher.new
+        @adapter.dispatcher = dispatcher
+        @adapter.stubs(:fetch_channel).returns({ "type" => channel_type, "parent_id" => "P1" })
+
+        @adapter.send(:process_message, guild_message(content: "<@BOT> more", channel_id: "T1"))
+
+        assert_predicate dispatcher.messages.first, :in_thread?
+      end
+    end
+
+    should "not mark a mention in a normal channel as in_thread" do
+      @adapter.stubs(:fetch_channel).returns({ "type" => 0 })
+      @adapter.stubs(:create_thread).returns("M1")
+
+      @adapter.send(:process_message, guild_message(content: "<@BOT> hi"))
+
+      assert_not_predicate @dispatcher.messages.first, :in_thread?
+    end
+
+    should "not mark a direct message as in_thread" do
+      @adapter.send(:process_message, dm_message(id: "C", content: "hi"))
+
+      assert_not_predicate @dispatcher.messages.first, :in_thread?
+    end
+
     should "resolve a DM reply to a bot answer to the conversation root" do
       @adapter.stubs(:fetch_message).with("D1", "B").returns(
         { "id" => "B", "author" => { "id" => "BOT" }, "message_reference" => { "message_id" => "A" } }
@@ -528,6 +583,190 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
 
       assert_equal [ 1900, 1900, 200 ], chunks.map(&:length)
       assert_equal text, chunks.join
+    end
+  end
+
+  context "history retrieval" do
+    should "declare history support" do
+      assert_predicate @adapter, :supports_history?
+    end
+
+    should "keep the gateway intents unchanged so existing installations still connect" do
+      assert_equal 4608, DiscordAdapter::GATEWAY_INTENTS
+    end
+
+    should "read the thread messages with the page limit" do
+      stub_discord_calls([])
+
+      @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+
+      assert_equal [ "/api/v10/channels/T1/messages?limit=100" ], discord_paths
+    end
+
+    should "return the messages in ascending order" do
+      stub_discord_calls([ history_raw(content: "second", id: "20"), history_raw(content: "first", id: "10") ])
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+
+      assert_equal [ "first", "second" ], history.map(&:text)
+    end
+
+    should "page backwards with before until a short page is returned" do
+      stub_discord_calls(
+        Array.new(100) { |i| history_raw(content: "message #{200 - i}", id: (200 - i).to_s) },
+        [ history_raw(content: "message 1", id: "1") ]
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+
+      assert_equal 2, discord_paths.size
+      assert_equal "101", discord_query(1)["before"]
+      assert_equal 101, history.size
+      assert_equal "message 1", history.first.text
+    end
+
+    should "stop paging as soon as the cursor is reached" do
+      stub_discord_calls(
+        Array.new(100) { |i| history_raw(content: "message #{200 - i}", id: (200 - i).to_s) },
+        [ history_raw(content: "message 1", id: "1") ]
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1", after: "150")
+
+      assert_equal 1, discord_paths.size, "the cursor must end the pagination"
+      assert_equal 50, history.size
+      assert_equal "message 151", history.first.text
+    end
+
+    should "exclude the cursor message itself" do
+      stub_discord_calls([ history_raw(content: "newer", id: "20"), history_raw(content: "cursor", id: "10") ])
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1", after: "10")
+
+      assert_equal [ "newer" ], history.map(&:text)
+    end
+
+    should "raise when the history call fails" do
+      Net::HTTP.any_instance.stubs(:request).returns(http_response(403, { "message" => "Missing Access" }))
+
+      assert_raises(DiscordRequestError) do
+        @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+      end
+    end
+  end
+
+  context "channel history retrieval" do
+    setup do
+      @since = Time.zone.parse("2026-08-01 00:00:00")
+    end
+
+    should "read the channel messages with the requested limit and before cursor" do
+      stub_discord_calls([])
+
+      @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+
+      assert_equal [ "/api/v10/channels/C1/messages?limit=20&before=900" ], discord_paths
+    end
+
+    should "return the messages in ascending order" do
+      stub_discord_calls([ history_raw(content: "second", id: "20", timestamp: "2026-08-01T10:00:00+00:00"),
+                           history_raw(content: "first", id: "10", timestamp: "2026-08-01T09:00:00+00:00") ])
+
+      history = @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+
+      assert_equal [ "first", "second" ], history.map(&:text)
+    end
+
+    should "drop messages older than the retrieval window" do
+      stub_discord_calls([ history_raw(content: "recent", id: "20", timestamp: "2026-08-01T10:00:00+00:00"),
+                           history_raw(content: "too old", id: "10", timestamp: "2026-07-29T10:00:00+00:00") ])
+
+      history = @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+
+      assert_equal [ "recent" ], history.map(&:text)
+    end
+
+    should "apply the same exclusions as the thread history" do
+      stub_discord_calls([ history_raw(content: "joined", id: "30", type: 7),
+                           history_raw(content: "<@BOT> question", id: "20"),
+                           history_raw(content: "my answer", id: "10", author_id: "BOT") ])
+
+      assert_empty @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+    end
+
+    should "return an empty array when the channel has no recent messages" do
+      stub_discord_calls([])
+
+      assert_empty @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+    end
+
+    should "raise when the channel history call fails" do
+      Net::HTTP.any_instance.stubs(:request).returns(http_response(403, { "message" => "Missing Access" }))
+
+      assert_raises(DiscordRequestError) do
+        @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+      end
+    end
+  end
+
+  context "history filtering" do
+    should "skip system messages" do
+      stub_discord_calls([ history_raw(content: "joined the thread", type: 7) ])
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+    end
+
+    should "skip the gateway's own messages" do
+      stub_discord_calls([ history_raw(content: "my own answer", author_id: "BOT") ])
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+    end
+
+    should "skip questions addressed to the bot in both mention notations" do
+      stub_discord_calls([ history_raw(content: "<@BOT> question", id: "20"),
+                           history_raw(content: "<@!BOT> another question", id: "10") ])
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+    end
+
+    should "skip messages whose content is empty" do
+      stub_discord_calls([ history_raw(content: "   ") ])
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+    end
+
+    should "import other bots as ordinary participants" do
+      raw = history_raw(content: "build failed", username: "CI notifier")
+      raw["author"]["bot"] = true
+      stub_discord_calls([ raw ])
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1")
+
+      assert_equal [ "CI notifier" ], history.map(&:speaker)
+    end
+  end
+
+  context "history speaker names" do
+    should "prefer the guild nickname" do
+      stub_discord_calls([ history_raw(content: "hello", nick: "yamachan",
+                                       global_name: "Yamada Taro", username: "yamada") ])
+
+      assert_equal [ "yamachan" ],
+                   @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1").map(&:speaker)
+    end
+
+    should "fall back to the global name without a nickname" do
+      stub_discord_calls([ history_raw(content: "hello", global_name: "Yamada Taro", username: "yamada") ])
+
+      assert_equal [ "Yamada Taro" ],
+                   @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1").map(&:speaker)
+    end
+
+    should "fall back to the account name" do
+      stub_discord_calls([ history_raw(content: "hello", username: "yamada") ])
+
+      assert_equal [ "yamada" ],
+                   @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:T1").map(&:speaker)
     end
   end
 end

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -158,11 +158,11 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_raises(DiscordRequestError) { @adapter.send(:request, :get, "/users/@me") }
     end
 
-    should "log a debug message and fall back to 1 second when the 429 body cannot be parsed" do
+    should "log a warning and fall back to 1 second when the 429 body cannot be parsed" do
       response = http_response(429, {})
       response.stubs(:body).returns("not json")
       logger = mock("logger")
-      logger.expects(:debug).with(regexp_matches(/retry_after/))
+      logger.expects(:warn).with(regexp_matches(/retry_after/))
       @adapter.stubs(:ai_helper_logger).returns(logger)
 
       assert_equal 1.0, @adapter.send(:retry_after_seconds, response)
@@ -684,6 +684,15 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       history = @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
 
       assert_equal [ "recent" ], history.map(&:text)
+    end
+
+    should "include a message whose timestamp is exactly at the since boundary" do
+      boundary_ts = "2026-08-01T00:00:00.000000+00:00"
+      stub_discord_calls([ history_raw(content: "at boundary", id: "10", timestamp: boundary_ts) ])
+
+      history = @adapter.fetch_channel_history(channel_id: "C1", before: "900", since: @since, limit: 20)
+
+      assert_equal [ "at boundary" ], history.map(&:text)
     end
 
     should "apply the same exclusions as the thread history" do

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -18,6 +18,46 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
     stub(body: body.to_json)
   end
 
+  # Answers the Web API calls with the given bodies in call order and records
+  # the requests so their form parameters can be asserted.
+  def stub_slack_calls(*bodies)
+    @slack_requests = []
+    responses = bodies.map { |body| stub_api_response(body) }
+    Net::HTTP.any_instance.stubs(:request).with { |request| @slack_requests << request; true }
+             .returns(*responses)
+  end
+
+  def slack_form(index)
+    URI.decode_www_form(@slack_requests[index].body.to_s).to_h
+  end
+
+  def slack_paths
+    @slack_requests.map(&:path)
+  end
+
+  def slack_message(text:, user: "U1", ts: "1.000001", subtype: nil, bot_id: nil,
+                    username: nil, bot_profile: nil)
+    message = { "type" => "message", "ts" => ts, "text" => text }
+    message["user"] = user if user
+    message["subtype"] = subtype if subtype
+    message["bot_id"] = bot_id if bot_id
+    message["username"] = username if username
+    message["bot_profile"] = bot_profile if bot_profile
+    message
+  end
+
+  def user_info(display_name: nil, real_name: nil, name: nil)
+    { "ok" => true,
+      "user" => { "profile" => { "display_name" => display_name.to_s },
+                  "real_name" => real_name.to_s, "name" => name.to_s } }
+  end
+
+  def replies_body(messages, next_cursor: nil)
+    body = { "ok" => true, "messages" => messages }
+    body["response_metadata"] = { "next_cursor" => next_cursor.to_s }
+    body
+  end
+
   context "registration and settings" do
     should "declare channel_type slack" do
       assert_equal "slack", RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.channel_type
@@ -248,6 +288,28 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       assert_equal "333.444", message.message_ts
     end
 
+    should "mark a mention inside an existing thread as in_thread" do
+      @ws.stubs(:send)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "app_mention", "user" => "U123", "channel" => "C123",
+          "ts" => "333.444", "thread_ts" => "111.222", "text" => "<@B001> more" }
+      ))
+
+      assert_predicate @dispatcher.messages.first, :in_thread?
+    end
+
+    should "not mark a mention outside a thread as in_thread" do
+      @ws.stubs(:send)
+
+      @adapter.handle_envelope(events_envelope(
+        { "type" => "app_mention", "user" => "U123", "channel" => "C123",
+          "ts" => "111.222", "text" => "<@B001> open issues?" }
+      ))
+
+      assert_not_predicate @dispatcher.messages.first, :in_thread?
+    end
+
     should "convert an im message into a dm IncomingMessage" do
       @ws.stubs(:send)
 
@@ -282,6 +344,265 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       ))
 
       assert_empty @dispatcher.messages
+    end
+  end
+
+  context "history retrieval" do
+    setup do
+      @adapter.instance_variable_set(:@bot_user_id, "B001")
+      @adapter.instance_variable_set(:@bot_id, "BOT_ID")
+    end
+
+    should "declare history support" do
+      assert_predicate @adapter, :supports_history?
+    end
+
+    should "ask conversations.replies for the messages after the cursor" do
+      stub_slack_calls(replies_body([]))
+
+      @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001", after: "100.000500")
+
+      assert_equal [ "/api/conversations.replies" ], slack_paths
+      form = slack_form(0)
+      assert_equal "C1", form["channel"]
+      assert_equal "100.000001", form["ts"]
+      assert_equal "100.000500", form["oldest"]
+      assert_equal "false", form["inclusive"]
+      assert_equal "200", form["limit"]
+    end
+
+    should "omit oldest on the first import of a thread" do
+      stub_slack_calls(replies_body([]))
+
+      @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_not slack_form(0).key?("oldest")
+    end
+
+    should "return the messages in ascending order" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "second", ts: "2"), slack_message(text: "first", ts: "1") ]),
+        user_info(display_name: "yamachan")
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_equal [ "first", "second" ], history.map(&:text)
+    end
+
+    should "follow the next_cursor pagination until it is empty" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "newest", ts: "3", user: nil, bot_id: "OTHER", username: "CI") ],
+                     next_cursor: "page2"),
+        replies_body([ slack_message(text: "older", ts: "1", user: nil, bot_id: "OTHER", username: "CI") ])
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_equal 2, slack_paths.size
+      assert_not slack_form(0).key?("cursor")
+      assert_equal "page2", slack_form(1)["cursor"]
+      assert_equal [ "older", "newest" ], history.map(&:text)
+    end
+
+    should "raise when the history call fails" do
+      stub_slack_calls({ "ok" => false, "error" => "missing_scope" })
+
+      error = assert_raises(RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError) do
+        @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+      end
+      assert_match(/missing_scope/, error.message)
+    end
+  end
+
+  context "channel history retrieval" do
+    setup do
+      @adapter.instance_variable_set(:@bot_user_id, "B001")
+      @adapter.instance_variable_set(:@bot_id, "BOT_ID")
+      @since = Time.zone.parse("2026-08-01 00:00:00")
+    end
+
+    should "ask conversations.history for the recent top-level messages" do
+      stub_slack_calls({ "ok" => true, "messages" => [] })
+
+      @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
+
+      assert_equal [ "/api/conversations.history" ], slack_paths
+      form = slack_form(0)
+      assert_equal "C1", form["channel"]
+      assert_equal "100.000900", form["latest"]
+      assert_equal @since.to_f.to_s, form["oldest"]
+      assert_equal "false", form["inclusive"]
+      assert_equal "20", form["limit"]
+    end
+
+    should "return the messages in ascending order" do
+      stub_slack_calls(
+        { "ok" => true, "messages" => [ slack_message(text: "second", ts: "2", user: nil, bot_id: "CI", username: "CI"),
+                                        slack_message(text: "first", ts: "1", user: nil, bot_id: "CI", username: "CI") ] }
+      )
+
+      history = @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
+
+      assert_equal [ "first", "second" ], history.map(&:text)
+    end
+
+    should "apply the same exclusions as the thread history" do
+      stub_slack_calls(
+        { "ok" => true, "messages" => [ slack_message(text: "joined", subtype: "channel_join"),
+                                        slack_message(text: "<@B001> question", ts: "2"),
+                                        slack_message(text: "my answer", user: "B001", ts: "3") ] }
+      )
+
+      assert_empty @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
+    end
+
+    should "return an empty array when the channel has no recent messages" do
+      stub_slack_calls({ "ok" => true, "messages" => [] })
+
+      assert_empty @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
+    end
+
+    should "raise when the channel history call fails" do
+      stub_slack_calls({ "ok" => false, "error" => "missing_scope" })
+
+      assert_raises(RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError) do
+        @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
+      end
+    end
+  end
+
+  context "history filtering" do
+    setup do
+      @adapter.instance_variable_set(:@bot_user_id, "B001")
+      @adapter.instance_variable_set(:@bot_id, "BOT_ID")
+    end
+
+    should "skip messages whose subtype is not on the allow list" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "joined the channel", subtype: "channel_join") ])
+      )
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+    end
+
+    should "keep the allowed subtypes" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "shared a file", subtype: "file_share", user: nil,
+                                     bot_id: "OTHER", username: "CI") ])
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_equal [ "shared a file" ], history.map(&:text)
+    end
+
+    should "skip the gateway's own messages" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "my own answer", user: "B001"),
+                       slack_message(text: "posted as the app", user: nil, bot_id: "BOT_ID",
+                                     subtype: "bot_message", username: "AI Helper") ])
+      )
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+    end
+
+    should "skip questions addressed to the bot" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "<@B001> what about this?") ])
+      )
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+    end
+
+    should "skip messages whose body is empty" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "   ") ])
+      )
+
+      assert_empty @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+    end
+
+    should "import other bots with their display name" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "build failed", user: nil, bot_id: "CI_BOT",
+                                     subtype: "bot_message", username: "CI notifier") ])
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_equal [ "CI notifier" ], history.map(&:speaker)
+      assert_equal [ "/api/conversations.replies" ], slack_paths, "bot messages must not trigger users.info"
+    end
+
+    should "fall back to the bot profile name when a bot message has no username" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "build failed", user: nil, bot_id: "CI_BOT",
+                                     subtype: "bot_message", bot_profile: { "name" => "CI profile" }) ])
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_equal [ "CI profile" ], history.map(&:speaker)
+    end
+  end
+
+  context "speaker display names" do
+    setup do
+      @adapter.instance_variable_set(:@bot_user_id, "B001")
+      @adapter.instance_variable_set(:@bot_id, "BOT_ID")
+    end
+
+    should "prefer the profile display name" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "hello") ]),
+        user_info(display_name: "yamachan", real_name: "Yamada Taro", name: "yamada")
+      )
+
+      assert_equal [ "yamachan" ],
+                   @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001").map(&:speaker)
+    end
+
+    should "fall back to the real name when the display name is empty" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "hello") ]),
+        user_info(display_name: "", real_name: "Yamada Taro", name: "yamada")
+      )
+
+      assert_equal [ "Yamada Taro" ],
+                   @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001").map(&:speaker)
+    end
+
+    should "fall back to the account name when display and real name are empty" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "hello") ]),
+        user_info(display_name: "", real_name: "", name: "yamada")
+      )
+
+      assert_equal [ "yamada" ],
+                   @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001").map(&:speaker)
+    end
+
+    should "resolve each user only once" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "second", ts: "2"), slack_message(text: "first", ts: "1") ]),
+        user_info(display_name: "yamachan")
+      )
+
+      history = @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001")
+
+      assert_equal [ "yamachan", "yamachan" ], history.map(&:speaker)
+      assert_equal [ "/api/conversations.replies", "/api/users.info" ], slack_paths
+    end
+
+    should "evict the oldest cached display name once the cap is exceeded" do
+      cap = RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::MAX_DISPLAY_NAMES
+      (cap + 1).times { |i| @adapter.send(:cache_display_name, "U#{i}", "name#{i}") }
+
+      cache = @adapter.instance_variable_get(:@display_names)
+      assert_equal cap, cache.size
+      assert_not cache.key?("U0"), "the oldest entry must be evicted"
+      assert cache.key?("U#{cap}"), "the newest entry must be kept"
     end
   end
 

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -413,6 +413,21 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       end
       assert_match(/missing_scope/, error.message)
     end
+
+    should "send oldest alongside cursor on paginated calls after the first import" do
+      stub_slack_calls(
+        replies_body([ slack_message(text: "newest", ts: "3", user: nil, bot_id: "OTHER", username: "CI") ],
+                     next_cursor: "page2"),
+        replies_body([ slack_message(text: "older", ts: "2", user: nil, bot_id: "OTHER", username: "CI") ])
+      )
+
+      @adapter.fetch_thread_history(channel_id: "C1", thread_key: "C1:100.000001", after: "1")
+
+      assert_equal 2, slack_paths.size
+      assert_equal "1", slack_form(0)["oldest"], "oldest must be sent on every page"
+      assert_equal "1", slack_form(1)["oldest"], "oldest must be preserved on the paginated call"
+      assert_equal "page2", slack_form(1)["cursor"]
+    end
   end
 
   context "channel history retrieval" do
@@ -469,6 +484,18 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       assert_raises(RedmineAiHelper::ChatChannel::Adapters::SlackAdapter::SlackApiError) do
         @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
       end
+    end
+
+    should "resolve real user display names via users.info" do
+      stub_slack_calls(
+        { "ok" => true, "messages" => [ slack_message(text: "hello", user: "U1", ts: "1") ] },
+        user_info(display_name: "yamachan")
+      )
+
+      history = @adapter.fetch_channel_history(channel_id: "C1", before: "100.000900", since: @since, limit: 20)
+
+      assert_equal [ "yamachan" ], history.map(&:speaker)
+      assert_equal [ "/api/conversations.history", "/api/users.info" ], slack_paths
     end
   end
 

--- a/test/unit/chat_channel/base_adapter_test.rb
+++ b/test/unit/chat_channel/base_adapter_test.rb
@@ -109,6 +109,59 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
     end
   end
 
+  context "history support" do
+    should "not support history by default" do
+      assert_not_predicate FakeAdapter.new, :supports_history?
+    end
+
+    should "raise NotImplementedError from fetch_thread_history" do
+      error = assert_raises(NotImplementedError) do
+        FakeAdapter.new.fetch_thread_history(channel_id: "FC1", thread_key: "FC1:1.000001")
+      end
+
+      assert_match(/fetch_thread_history/, error.message)
+    end
+
+    should "raise NotImplementedError from fetch_channel_history" do
+      error = assert_raises(NotImplementedError) do
+        FakeAdapter.new.fetch_channel_history(
+          channel_id: "FC1", before: "1.000002", since: 48.hours.ago, limit: 20
+        )
+      end
+
+      assert_match(/fetch_channel_history/, error.message)
+    end
+  end
+
+  # SC-006: an adapter that does not implement history retrieval keeps working
+  # through the unchanged core; the only difference is that no prior context is
+  # available to the answer.
+  context "end-to-end with an adapter that does not support history" do
+    should "answer without fetching or storing any context" do
+      project = Project.find(1)
+      project.enable_module!("ai_helper")
+      user = User.find(2)
+      adapter = FakeAdapter.new
+      create(:ai_helper_chat_adapter_setting, channel_type: "fake_chat", redmine_user_id: user.id)
+      create(:ai_helper_channel_binding, channel_type: "fake_chat", channel_id: "FC2", project: project)
+      adapter.expects(:fetch_thread_history).never
+      adapter.expects(:fetch_channel_history).never
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        AiHelperMessage.new(role: "assistant", content: "answer without context")
+      )
+
+      adapter.dispatch(RedmineAiHelper::ChatChannel::IncomingMessage.new(
+        channel_type: "fake_chat", channel_id: "FC2", thread_key: "FC2:1.000001",
+        message_ts: "1.000001", text: "hello", dm: false
+      ))
+
+      assert_equal "answer without context", adapter.sent_messages.first[:text]
+      conversation = AiHelperConversation.first
+      assert_equal %w[user assistant], conversation.messages.order(:id).pluck(:role)
+      assert_nil conversation.channel_conversation.last_imported_message_key
+    end
+  end
+
   context "IncomingMessage" do
     should "hold the normalized fields" do
       message = RedmineAiHelper::ChatChannel::IncomingMessage.new(
@@ -126,6 +179,23 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
       assert_equal "1700000000.000200", message.message_ts
       assert_equal "hello", message.text
       assert message.dm?
+    end
+
+    should "not be in a thread unless the adapter says so" do
+      message = RedmineAiHelper::ChatChannel::IncomingMessage.new(
+        channel_type: "fake_chat", channel_id: "C123", thread_key: "C123:1.000100", text: "hello"
+      )
+
+      assert_not_predicate message, :in_thread?
+    end
+
+    should "carry the in_thread flag set by the adapter" do
+      message = RedmineAiHelper::ChatChannel::IncomingMessage.new(
+        channel_type: "fake_chat", channel_id: "C123", thread_key: "C123:1.000100",
+        text: "hello", in_thread: true
+      )
+
+      assert_predicate message, :in_thread?
     end
   end
 end

--- a/test/unit/chat_channel/context_importer_test.rb
+++ b/test/unit/chat_channel/context_importer_test.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../test_helper", __FILE__)
+
+class ChatChannelContextImporterTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  ContextImporter = RedmineAiHelper::ChatChannel::ContextImporter
+  HistoryMessage = RedmineAiHelper::ChatChannel::HistoryMessage
+  IncomingMessage = RedmineAiHelper::ChatChannel::IncomingMessage
+
+  # Adapter that supports history retrieval and records how it was called.
+  class HistoryAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    attr_reader :calls
+    attr_accessor :thread_history, :channel_history
+
+    class << self
+      def channel_type
+        "importer_chat"
+      end
+    end
+
+    def initialize
+      super
+      @calls = []
+      @thread_history = []
+      @channel_history = []
+    end
+
+    def start; end
+
+    def stop; end
+
+    def send_message(channel_id:, thread_key:, text:); end
+
+    def supports_history?
+      true
+    end
+
+    def fetch_thread_history(channel_id:, thread_key:, after: nil)
+      @calls << { source: :thread, channel_id: channel_id, thread_key: thread_key, after: after }
+      @thread_history
+    end
+
+    def fetch_channel_history(channel_id:, before:, since:, limit:)
+      @calls << { source: :channel, channel_id: channel_id, before: before, since: since, limit: limit }
+      @channel_history
+    end
+  end
+
+  # Adapter without history support (the default from BaseAdapter).
+  class NoHistoryAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    class << self
+      def channel_type
+        "importer_no_history"
+      end
+    end
+
+    def start; end
+
+    def stop; end
+
+    def send_message(channel_id:, thread_key:, text:); end
+  end
+
+  setup do
+    @adapter = HistoryAdapter.new
+    @channel_conversation = create(:ai_helper_channel_conversation,
+                                   channel_type: "importer_chat", thread_key: "C1:100.000001")
+    @conversation = @channel_conversation.conversation
+  end
+
+  def incoming(in_thread: true, message_ts: "100.000900", channel_id: "C1", thread_key: "C1:100.000001")
+    IncomingMessage.new(
+      channel_type: "importer_chat", channel_id: channel_id, thread_key: thread_key,
+      message_ts: message_ts, text: "@bot what about this?", in_thread: in_thread
+    )
+  end
+
+  def history(*pairs)
+    pairs.map { |speaker, text| HistoryMessage.new(speaker: speaker, text: text) }
+  end
+
+  context "adapters without history support" do
+    should "return 0 without retrieving any history" do
+      importer = ContextImporter.new(NoHistoryAdapter.new)
+
+      assert_equal 0, importer.import(conversation: @conversation, message: incoming)
+      assert_equal 0, @conversation.reload.messages.count
+      assert_nil @channel_conversation.reload.last_imported_message_key
+    end
+  end
+
+  context "storing imported messages" do
+    should "append each retrieved message as a context message with the speaker prefix" do
+      @adapter.thread_history = history([ "Yamada", "it crashes on save" ], [ "Suzuki", "stack trace attached" ])
+
+      imported = ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+
+      assert_equal 2, imported
+      assert_equal [
+        [ "context", "Yamada: it crashes on save" ],
+        [ "context", "Suzuki: stack trace attached" ]
+      ], @conversation.reload.messages.order(:id).pluck(:role, :content)
+    end
+
+    should "advance the import cursor to the message_ts of the current mention" do
+      @adapter.thread_history = history([ "Yamada", "hello" ])
+
+      ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming(message_ts: "100.000900"))
+
+      assert_equal "100.000900", @channel_conversation.reload.last_imported_message_key
+    end
+
+    should "advance the import cursor even when nothing was retrieved" do
+      @adapter.thread_history = []
+
+      imported = ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming(message_ts: "100.000901"))
+
+      assert_equal 0, imported
+      assert_equal "100.000901", @channel_conversation.reload.last_imported_message_key
+    end
+
+    should "store the messages and the cursor in one transaction" do
+      @adapter.thread_history = history([ "Yamada", "hello" ])
+      AiHelperChannelConversation.any_instance.stubs(:update!).raises(ActiveRecord::StatementInvalid, "boom")
+
+      assert_raises(ActiveRecord::StatementInvalid) do
+        ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+      end
+
+      assert_equal 0, @conversation.reload.messages.count
+      assert_nil @channel_conversation.reload.last_imported_message_key
+    end
+  end
+
+  context "thread mode" do
+    should "retrieve the thread history for a mention posted inside a thread" do
+      ContextImporter.new(@adapter).import(
+        conversation: @conversation, message: incoming(in_thread: true, channel_id: "C1", thread_key: "C1:100.000001")
+      )
+
+      assert_equal 1, @adapter.calls.size
+      call = @adapter.calls.first
+      assert_equal :thread, call[:source]
+      assert_equal "C1", call[:channel_id]
+      assert_equal "C1:100.000001", call[:thread_key]
+    end
+
+    should "pass no cursor on the first import of a thread" do
+      ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+
+      assert_nil @adapter.calls.first[:after]
+    end
+
+    should "pass the stored cursor on a later import of the same thread" do
+      @channel_conversation.update!(last_imported_message_key: "100.000500")
+
+      ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+
+      assert_equal "100.000500", @adapter.calls.first[:after]
+    end
+
+    should "advance the cursor with every import so nothing is imported twice" do
+      importer = ContextImporter.new(@adapter)
+      @adapter.thread_history = history([ "Yamada", "first" ])
+      importer.import(conversation: @conversation, message: incoming(message_ts: "100.000901"))
+      @adapter.thread_history = history([ "Suzuki", "second" ])
+      importer.import(conversation: @conversation, message: incoming(message_ts: "100.000902"))
+
+      assert_equal([ nil, "100.000901" ], @adapter.calls.map { |call| call[:after] })
+      assert_equal "100.000902", @channel_conversation.reload.last_imported_message_key
+      assert_equal [ "Yamada: first", "Suzuki: second" ],
+                   @conversation.reload.messages.where(role: "context").order(:id).pluck(:content)
+    end
+
+    should "apply no count or age limit in thread mode" do
+      @adapter.thread_history = history(*Array.new(50) { |i| [ "Yamada", "message #{i}" ] })
+
+      imported = ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+
+      assert_equal 50, imported
+      assert_equal 50, @conversation.reload.messages.where(role: "context").count
+      assert_equal([ :thread ], @adapter.calls.map { |call| call[:source] })
+      assert_not @adapter.calls.first.key?(:limit), "thread mode must not pass a count limit"
+      assert_not @adapter.calls.first.key?(:since), "thread mode must not pass an age limit"
+    end
+
+    should "keep importing into a thread conversation that already has messages" do
+      @conversation.messages << AiHelperMessage.new(role: "user", content: "earlier question")
+      @conversation.save!
+      @adapter.thread_history = history([ "Yamada", "follow-up remark" ])
+
+      imported = ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+
+      assert_equal 1, imported
+    end
+  end
+
+  context "channel mode" do
+    should "retrieve the channel history for a new conversation started outside a thread" do
+      @adapter.channel_history = history([ "Yamada", "we should file a ticket" ])
+
+      imported = ContextImporter.new(@adapter).import(
+        conversation: @conversation, message: incoming(in_thread: false, message_ts: "100.000900")
+      )
+
+      assert_equal 1, imported
+      call = @adapter.calls.first
+      assert_equal :channel, call[:source]
+      assert_equal "C1", call[:channel_id]
+      assert_equal "100.000900", call[:before]
+      assert_equal ContextImporter::CONTEXT_MESSAGE_LIMIT, call[:limit]
+      assert_in_delta ContextImporter::CONTEXT_LOOKBACK_HOURS.hours.ago, call[:since], 5
+    end
+
+    should "store the retrieved channel messages and advance the cursor" do
+      @adapter.channel_history = history([ "Yamada", "we should file a ticket" ])
+
+      ContextImporter.new(@adapter).import(
+        conversation: @conversation, message: incoming(in_thread: false, message_ts: "100.000900")
+      )
+
+      assert_equal [ "Yamada: we should file a ticket" ],
+                   @conversation.reload.messages.where(role: "context").pluck(:content)
+      assert_equal "100.000900", @channel_conversation.reload.last_imported_message_key
+    end
+
+    should "advance the cursor even when the channel has no recent messages" do
+      @adapter.channel_history = []
+
+      imported = ContextImporter.new(@adapter).import(
+        conversation: @conversation, message: incoming(in_thread: false, message_ts: "100.000901")
+      )
+
+      assert_equal 0, imported
+      assert_equal "100.000901", @channel_conversation.reload.last_imported_message_key
+    end
+
+    should "import nothing for a mention outside a thread that continues a conversation" do
+      @conversation.messages << AiHelperMessage.new(role: "user", content: "earlier question")
+      @conversation.save!
+
+      imported = ContextImporter.new(@adapter).import(
+        conversation: @conversation, message: incoming(in_thread: false)
+      )
+
+      assert_equal 0, imported
+      assert_empty @adapter.calls
+      assert_nil @channel_conversation.reload.last_imported_message_key
+    end
+
+    should "use the same path for direct messages" do
+      @adapter.channel_history = history([ "Yamada", "one more thing" ])
+
+      imported = ContextImporter.new(@adapter).import(
+        conversation: @conversation,
+        message: IncomingMessage.new(
+          channel_type: "importer_chat", channel_id: "D1", thread_key: "D1:msg:900",
+          message_ts: "900", text: "what about this?", dm: true
+        )
+      )
+
+      assert_equal 1, imported
+      assert_equal :channel, @adapter.calls.first[:source]
+      assert_equal "D1", @adapter.calls.first[:channel_id]
+    end
+  end
+
+  context "logging" do
+    should "log the number of imported messages, the source and the conversation" do
+      @adapter.thread_history = history([ "Yamada", "hello" ], [ "Suzuki", "hi" ])
+      importer = ContextImporter.new(@adapter)
+      logger = mock("logger")
+      logger.expects(:info).with(
+        regexp_matches(/imported 2 context messages from thread .*conversation #{@conversation.id}/)
+      )
+      importer.stubs(:ai_helper_logger).returns(logger)
+
+      importer.import(conversation: @conversation, message: incoming)
+    end
+  end
+
+  context "retrieval failures" do
+    should "re-raise the adapter's error instead of swallowing it" do
+      @adapter.stubs(:fetch_thread_history).raises(RuntimeError, "slack is down")
+
+      error = assert_raises(RuntimeError) do
+        ContextImporter.new(@adapter).import(conversation: @conversation, message: incoming)
+      end
+
+      assert_equal "slack is down", error.message
+      assert_nil @channel_conversation.reload.last_imported_message_key
+    end
+  end
+end

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -422,6 +422,16 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       assert_nil AiHelperConversation.first.channel_conversation.last_imported_message_key
     end
 
+    should "leave only user and assistant messages in the conversation when the import fails" do
+      @history_adapter.stubs(:fetch_thread_history).raises(RuntimeError, "history scope missing")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming)
+
+      roles = AiHelperConversation.first.messages.order(:id).pluck(:role)
+      assert_equal %w[user assistant], roles, "no orphaned context messages must remain"
+    end
+
     should "not fetch any history when no execution account is configured (FR-013)" do
       @history_setting.update_column(:redmine_user_id, nil)
       @history_adapter.expects(:fetch_thread_history).never

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -432,6 +432,32 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       assert_equal %w[user assistant], roles, "no orphaned context messages must remain"
     end
 
+    should "not store the rolled back context messages when the import transaction fails" do
+      @history_adapter.thread_history = [ history_message("Yamada", "it crashes on save") ]
+      AiHelperChannelConversation.any_instance.stubs(:update!).raises(RuntimeError, "cursor update failed")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming(text: "why does it crash?"))
+
+      roles = AiHelperConversation.first.messages.order(:id).pluck(:role)
+      assert_equal %w[user assistant], roles, "the rolled back context messages must not be saved again"
+    end
+
+    should "not hand the rolled back context messages to the LLM when the import transaction fails" do
+      @history_adapter.thread_history = [ history_message("Yamada", "it crashes on save") ]
+      AiHelperChannelConversation.any_instance.stubs(:update!).raises(RuntimeError, "cursor update failed")
+      handover = nil
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).with do |conversation, _proc, _option|
+        handover = conversation.messages_for_openai
+        true
+      end.returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming(text: "why does it crash?"))
+
+      assert_equal [ { role: "user", content: "why does it crash?" } ], handover,
+                   "the notice says the history is unavailable, so no context may reach the LLM"
+    end
+
     should "not fetch any history when no execution account is configured (FR-013)" do
       @history_setting.update_column(:redmine_user_id, nil)
       @history_adapter.expects(:fetch_thread_history).never

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -31,6 +31,39 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
     end
   end
 
+  # Adapter that supports history retrieval, used for the context import tests.
+  class HistoryRecordingAdapter < RecordingAdapter
+    attr_reader :calls
+    attr_accessor :thread_history, :channel_history
+
+    class << self
+      def channel_type
+        "handler_history_chat"
+      end
+    end
+
+    def initialize
+      super
+      @calls = []
+      @thread_history = []
+      @channel_history = []
+    end
+
+    def supports_history?
+      true
+    end
+
+    def fetch_thread_history(channel_id:, thread_key:, after: nil)
+      @calls << { source: :thread, channel_id: channel_id, thread_key: thread_key, after: after }
+      @thread_history
+    end
+
+    def fetch_channel_history(channel_id:, before:, since:, limit:)
+      @calls << { source: :channel, channel_id: channel_id, before: before, since: since, limit: limit }
+      @channel_history
+    end
+  end
+
   setup do
     @adapter = RecordingAdapter.new
     @handler = @adapter.handler
@@ -47,6 +80,18 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       channel_type: "handler_chat", channel_id: channel_id, thread_key: thread_key,
       text: text, dm: dm
     )
+  end
+
+  def history_incoming(text: "what about this?", channel_id: "CH2", thread_key: "CH2:1.000001",
+                       message_ts: "1.000900", in_thread: true, dm: false)
+    RedmineAiHelper::ChatChannel::IncomingMessage.new(
+      channel_type: "handler_history_chat", channel_id: channel_id, thread_key: thread_key,
+      message_ts: message_ts, text: text, dm: dm, in_thread: in_thread
+    )
+  end
+
+  def history_message(speaker, text)
+    RedmineAiHelper::ChatChannel::HistoryMessage.new(speaker: speaker, text: text)
   end
 
   def error_text(key, user: @service_account)
@@ -302,6 +347,108 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       title = AiHelperConversation.first.title
       assert_equal long_question.truncate(50), title
       assert_operator title.length, :<=, 50
+    end
+  end
+
+  context "context import" do
+    setup do
+      @history_adapter = HistoryRecordingAdapter.new
+      @history_handler = @history_adapter.handler
+      @history_setting = create(:ai_helper_chat_adapter_setting,
+                                channel_type: "handler_history_chat", redmine_user_id: @service_account.id)
+      create(:ai_helper_channel_binding,
+             channel_type: "handler_history_chat", channel_id: "CH2", project: @project)
+    end
+
+    should "import the context before the question is appended to the conversation" do
+      @history_adapter.thread_history = [ history_message("Yamada", "it crashes on save") ]
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming(text: "why does it crash?"))
+
+      conversation = AiHelperConversation.first
+      assert_equal [
+        [ "context", "Yamada: it crashes on save" ],
+        [ "user", "why does it crash?" ],
+        [ "assistant", "the answer" ]
+      ], conversation.messages.order(:id).pluck(:role, :content)
+    end
+
+    should "decide the conversation title before the context is imported" do
+      @history_adapter.thread_history = [ history_message("Yamada", "it crashes on save") ]
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming(text: "why does it crash?"))
+
+      assert_equal "why does it crash?", AiHelperConversation.first.title
+    end
+
+    should "log the failure and prepend the notice to the answer when the import fails" do
+      @history_adapter.stubs(:fetch_thread_history).raises(RuntimeError, "history scope missing")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+      logger = mock("logger")
+      logger.stubs(:info)
+      logger.stubs(:warn)
+      logger.stubs(:debug)
+      logger.expects(:error).with(regexp_matches(/history scope missing/))
+      @history_handler.stubs(:ai_helper_logger).returns(logger)
+
+      @history_handler.handle(history_incoming)
+
+      notice = error_text(:history_unavailable)
+      assert @history_adapter.sent_messages.first[:text].start_with?(notice),
+             "the posted answer must start with the notice"
+      answer = AiHelperConversation.first.messages.order(:id).last
+      assert answer.content.start_with?(notice), "the stored answer must contain the notice as well"
+      assert_match(/the answer/, answer.content)
+    end
+
+    should "still answer when the import fails" do
+      @history_adapter.stubs(:fetch_thread_history).raises(RuntimeError, "history scope missing")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming)
+
+      assert_equal 1, @history_adapter.sent_messages.size
+      assert_match(/the answer/, @history_adapter.sent_messages.first[:text])
+    end
+
+    should "not keep the import cursor when the import failed" do
+      @history_adapter.stubs(:fetch_thread_history).raises(RuntimeError, "history scope missing")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("the answer"))
+
+      @history_handler.handle(history_incoming)
+
+      assert_nil AiHelperConversation.first.channel_conversation.last_imported_message_key
+    end
+
+    should "not fetch any history when no execution account is configured (FR-013)" do
+      @history_setting.update_column(:redmine_user_id, nil)
+      @history_adapter.expects(:fetch_thread_history).never
+      @history_adapter.expects(:fetch_channel_history).never
+
+      @history_handler.handle(history_incoming)
+
+      assert_equal 0, AiHelperConversation.count
+    end
+
+    should "not fetch any history when the project cannot be resolved (FR-013)" do
+      @history_adapter.expects(:fetch_thread_history).never
+      @history_adapter.expects(:fetch_channel_history).never
+
+      @history_handler.handle(history_incoming(channel_id: "UNBOUND", thread_key: "UNBOUND:1.000001"))
+
+      assert_equal error_text(:default_project_not_configured), @history_adapter.sent_messages.first[:text]
+    end
+
+    should "not fetch any history when the ai_helper module is disabled (FR-013)" do
+      @project.disable_module!("ai_helper")
+      @history_adapter.expects(:fetch_thread_history).never
+      @history_adapter.expects(:fetch_channel_history).never
+
+      @history_handler.handle(history_incoming)
+
+      assert_equal error_text(:module_disabled), @history_adapter.sent_messages.first[:text]
     end
   end
 

--- a/test/unit/models/ai_helper_conversation_test.rb
+++ b/test/unit/models/ai_helper_conversation_test.rb
@@ -10,6 +10,85 @@ class AiHelperConversationTest < ActiveSupport::TestCase
     assert_not_nil @ai_helper
   end
 
+  context "messages_for_openai" do
+    setup do
+      @conversation = AiHelperConversation.create!(title: "context conversation", user: User.find(1))
+    end
+
+    should "return the plain messages unchanged when the conversation has no context" do
+      add_message("user", "question")
+      add_message("assistant", "answer")
+
+      assert_equal [
+        { role: "user", content: "question" },
+        { role: "assistant", content: "answer" }
+      ], @conversation.messages_for_openai
+    end
+
+    should "merge consecutive context messages into a single headed user message" do
+      add_message("context", "Yamada: it crashes on save")
+      add_message("context", "Suzuki: stack trace attached")
+      add_message("user", "what is going on?")
+
+      result = @conversation.messages_for_openai
+
+      assert_equal 2, result.size
+      assert_equal "user", result.first[:role]
+      assert_equal [
+        AiHelperConversation::CONTEXT_HEADER,
+        "Yamada: it crashes on save",
+        "Suzuki: stack trace attached"
+      ].join("\n"), result.first[:content]
+      assert_equal({ role: "user", content: "what is going on?" }, result.last)
+    end
+
+    should "keep the conversation order and merge each run of context messages separately" do
+      add_message("context", "Yamada: first")
+      add_message("user", "first question")
+      add_message("assistant", "first answer")
+      add_message("context", "Suzuki: second")
+
+      result = @conversation.messages_for_openai
+
+      assert_equal([ "user", "user", "assistant", "user" ], result.map { |m| m[:role] })
+      assert_match(/Yamada: first/, result[0][:content])
+      assert_equal "first question", result[1][:content]
+      assert_match(/Suzuki: second/, result[3][:content])
+    end
+
+    should "drop the oldest context messages when the character limit is exceeded" do
+      add_message("context", "A: #{"a" * 15_000}")
+      add_message("context", "B: #{"b" * 15_000}")
+      add_message("user", "question")
+
+      result = @conversation.messages_for_openai
+
+      assert_equal 2, result.size
+      assert_no_match(/aaaa/, result.first[:content])
+      assert_match(/bbbb/, result.first[:content])
+    end
+
+    should "not modify the stored records when context messages are dropped" do
+      add_message("context", "A: #{"a" * 15_000}")
+      add_message("context", "B: #{"b" * 15_000}")
+
+      @conversation.messages_for_openai
+
+      assert_equal 2, @conversation.reload.messages.where(role: "context").count
+    end
+
+    should "keep every context message when the total stays within the limit" do
+      add_message("context", "A: short")
+      add_message("context", "B: also short")
+
+      result = @conversation.messages_for_openai
+
+      assert_equal 1, result.size
+      assert_match(/A: short/, result.first[:content])
+      assert_match(/B: also short/, result.first[:content])
+    end
+  end
+
   def test_cleanup_old_conversations
     user = User.find(1)
 
@@ -67,5 +146,13 @@ class AiHelperConversationTest < ActiveSupport::TestCase
     assert_equal initial_count - 1, remaining_conversations.count
     assert_not_nil AiHelperConversation.find_by(id: five_months_old.id)
     assert_nil AiHelperConversation.find_by(id: seven_months_old.id)
+  end
+
+  private
+
+  # Appends and stores one message of the given role in @conversation.
+  def add_message(role, content)
+    @conversation.messages << AiHelperMessage.new(role: role, content: content)
+    @conversation.save!
   end
 end

--- a/test/unit/models/ai_helper_conversation_test.rb
+++ b/test/unit/models/ai_helper_conversation_test.rb
@@ -87,6 +87,33 @@ class AiHelperConversationTest < ActiveSupport::TestCase
       assert_match(/A: short/, result.first[:content])
       assert_match(/B: also short/, result.first[:content])
     end
+
+    should "produce an empty handover when every context message exceeds the limit" do
+      add_message("context", "A: #{"a" * (AiHelperConversation::CONTEXT_CHAR_LIMIT + 100)}")
+
+      result = @conversation.messages_for_openai
+
+      assert_empty result
+    end
+
+    should "merge three or more interleaved context runs in a multi-turn conversation" do
+      add_message("context", "Yamada: first context")
+      add_message("user", "first question")
+      add_message("assistant", "first answer")
+      add_message("context", "Suzuki: second context")
+      add_message("user", "second question")
+      add_message("assistant", "second answer")
+      add_message("context", "Yamada: third context")
+
+      result = @conversation.messages_for_openai
+
+      assert_equal 7, result.size
+      assert_equal([ "user", "user", "assistant", "user", "user", "assistant", "user" ],
+                   result.map { |m| m[:role] })
+      assert_match(/Yamada: first context/, result[0][:content])
+      assert_match(/Suzuki: second context/, result[3][:content])
+      assert_match(/Yamada: third context/, result[6][:content])
+    end
   end
 
   def test_cleanup_old_conversations

--- a/test/unit/models/ai_helper_conversation_test.rb
+++ b/test/unit/models/ai_helper_conversation_test.rb
@@ -15,6 +15,11 @@ class AiHelperConversationTest < ActiveSupport::TestCase
       @conversation = AiHelperConversation.create!(title: "context conversation", user: User.find(1))
     end
 
+    should "order the messages explicitly so the handover never depends on the DB row order" do
+      assert_match(/ORDER BY/i, @conversation.messages.to_sql,
+                   "merging runs of context messages requires a guaranteed conversation order")
+    end
+
     should "return the plain messages unchanged when the conversation has no context" do
       add_message("user", "question")
       add_message("assistant", "answer")


### PR DESCRIPTION
## Changes

- Import unread channel/thread/DM messages as context whenever the bot is mentioned, so it participates as a thread member rather than answering in isolation
- Persist imported third-party messages to conversation history for traceability, while trimming older context passed to the LLM to avoid unbounded growth
- Apply thread messages without count/period limits, and channel/DM messages with a recency + count cap
- Add `AiHelperChannel Conversation` last-imported-message tracking (migration) to support incremental imports
- Add ADR 008 documenting the context-import design and update Discord/Slack gateway setup docs
- Fix CSRF test assertions for Rails 8.x compatibility and RuboCop array spacing