### PR TITLE
Require the Discord MESSAGE_CONTENT intent

### DIFF
--- a/docs/adr/009-discord-message-content-intent-required.md
+++ b/docs/adr/009-discord-message-content-intent-required.md
@@ -1,0 +1,80 @@
+# ADR-009: Require the Discord MESSAGE_CONTENT intent in Identify
+
+**Date**: 2026-08-01
+**Status**: Accepted
+
+Supersedes decision 7 of [ADR-008](./008-chat-channel-context-import.md)
+("Discord's Identify intents stay at 4608") and the intent part of decision 1
+of [ADR-007](./007-discord-adapter-connection-design.md) ("Minimal intents, no
+privileged MESSAGE_CONTENT").
+
+## Context
+
+ADR-008 kept the Identify intents at `GUILD_MESSAGES + DIRECT_MESSAGES = 4608`
+when the context import was added, so that installations which had not enabled
+the Message Content Intent in the Developer Portal would keep working: the
+gateway would still connect, and only the imported context would be missing.
+Turning the toggle on was documented as optional.
+
+Operating the feature showed that this degraded mode is not worth having:
+
+- With the toggle off, Discord returns the surrounding messages with an empty
+  body. They are all skipped, the import reports `imported 0 context messages`,
+  and no error is raised anywhere — nothing failed.
+- The bot then answers as if the discussion did not exist. That is
+  indistinguishable, from the outside, from an install that is working
+  correctly in a quiet channel, and it is indistinguishable in the log from
+  "there genuinely was nothing to import".
+- Diagnosing it requires knowing that Discord blanks message bodies, which is
+  precisely the knowledge an operator following the setup guide does not have.
+
+The feature's purpose (034) is to make the bot a participant in the thread's
+conversation. Without message content it cannot read the thread at all, so the
+degraded mode delivers none of the feature's value while looking healthy.
+
+## Decision
+
+The Discord adapter identifies with
+`GUILD_MESSAGES (512) + DIRECT_MESSAGES (4096) + MESSAGE_CONTENT (1<<15) = 37376`.
+
+The Message Content Intent is therefore a required setup step, not an optional
+one. When it is not enabled for the application, Discord closes the connection
+with close code **4014**, which `FATAL_CLOSE_CODES` already classifies as a
+fatal configuration error: the adapter stops instead of retrying into the same
+broken configuration (ADR-006). Following ADR-006's per-adapter isolation, the
+gateway process exits only when Discord is the last live adapter; with Slack
+also enabled the process keeps serving Slack and only Discord goes down.
+
+## Consequences
+
+- A missing intent surfaces at connect time as a loud, single, unambiguous
+  failure, instead of silently removing context from every later answer. This
+  follows the project guideline that errors must surface immediately rather
+  than be absorbed by a fallback.
+- **Breaking for existing installations that never enabled the toggle**: their
+  Discord bot stops answering until an administrator enables it. This is
+  deliberate — those installations were already not getting the context import,
+  and the alternative is leaving them silently degraded. The setup guide
+  documents the toggle as required and the troubleshooting section names close
+  code 4014.
+- The failure is loud in the log but not always in process state: a
+  Slack + Discord install keeps running with Slack alone, so operators who
+  watch only for a dead process will miss it. The setup guide calls this out.
+- Verified applications need Discord's approval before the intent can be
+  enabled, which can delay a deployment.
+- Message content also arrives on gateway events now. The adapter does not use
+  it there — mention handling already received full content — so no behaviour
+  other than the connection requirement changes.
+
+## Alternatives Considered
+
+- **Keep 4608 and document the toggle as required** (the state before this
+  ADR): rejected. Documentation cannot prevent the silent-degradation mode; it
+  only helps operators who already suspect the intent is the problem.
+- **Keep 4608 and warn when an import returns only empty bodies**: rejected. It
+  needs a heuristic ("fetched messages but every body was empty") that cannot
+  distinguish a genuinely empty channel with certainty, and it reports the
+  problem at question time rather than at startup.
+- **Request MESSAGE_CONTENT and re-Identify without it on close 4014**:
+  rejected. That is exactly the silent fallback the constitution forbids, and
+  it restores the degraded mode this ADR exists to remove.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,5 +59,6 @@ Briefly describe alternatives that were rejected and why.
 | [004](./004-structured-output-native-and-fallback.md) | Two-tier structured output — native API schema enforcement with a prompt-based fallback pipeline | Proposed |
 | [005](./005-write-tool-classification-for-read-only-mode.md) | Write-tool classification via a `define_function` DSL attribute for read-only mode | Proposed |
 | [006](./006-chat-channel-gateway-architecture.md) | External chat tool gateway with Socket Mode and a serialized worker | Accepted |
-| [007](./007-discord-adapter-connection-design.md) | Discord adapter connection design | Accepted |
-| [008](./008-chat-channel-context-import.md) | Chat channel conversation context import | Accepted |
+| [007](./007-discord-adapter-connection-design.md) | Discord adapter connection design | Accepted (intent choice in decision 1 superseded by ADR-009) |
+| [008](./008-chat-channel-context-import.md) | Chat channel conversation context import | Accepted (decision 7 superseded by ADR-009) |
+| [009](./009-discord-message-content-intent-required.md) | Require the Discord MESSAGE_CONTENT intent in Identify | Accepted |

--- a/docs/discord_gateway_setup.md
+++ b/docs/discord_gateway_setup.md
@@ -7,9 +7,7 @@ and receive answers in the same thread.
 The integration uses the Discord **Gateway API**: the gateway process opens an
 outgoing WebSocket connection to Discord, so **no public URL is required** for
 your Redmine server. The bot needs only a single **bot token** (unlike Slack,
-which uses two tokens). It runs without any privileged intent; enabling the
-**Message Content Intent** is optional and only adds the ability to answer with
-the surrounding discussion in mind (see step 3).
+which uses two tokens).
 
 ## Requirements
 
@@ -28,24 +26,11 @@ the surrounding discussion in mind (see step 3).
    Application**. Give it a name (this becomes the bot's name).
 2. In the **Bot** section, click **Reset Token** (or **Add Bot**) and copy the
    **bot token**. Store it securely — Discord shows it only once.
-3. Under **Privileged Gateway Intents**, turn **Message Content Intent** **ON**
-   if you want the bot to answer with the surrounding discussion in mind.
-   Discord only reveals the body of messages that do not mention the bot when
-   this toggle is enabled, and the toggle governs both the Gateway and the REST
-   API the bot reads the history with.
-   - **Left OFF**: the bot works exactly as before. It still receives mentions
-     and direct messages in full, but the messages around them arrive with an
-     empty body, are skipped, and answers are produced without that context.
-     No notice is shown, because nothing failed.
-   - **Turned ON**: the bot imports the messages posted around a mention (the
-     whole thread, or the last 48 hours / 20 messages of a channel or DM) and
-     answers with them in mind.
-   - If your application is **verified**, enabling the intent requires approval
-     from Discord; request it through the Developer Portal.
-
-   The gateway always identifies with the same intent set (`4608`) whether or
-   not the toggle is on, so enabling it never breaks an existing installation —
-   restart the gateway after flipping it.
+3. Under **Privileged Gateway Intents**, turn **Message Content Intent**
+   **ON**. This is required — Discord refuses the connection without it, and
+   the bot never comes online. If your application is **verified**, enabling it
+   requires approval from Discord; request it through the Developer Portal.
+   Restart the gateway after changing the toggle.
 
 ## 2. Invite the bot to your server
 
@@ -56,7 +41,8 @@ the surrounding discussion in mind (see step 3).
    - **Send Messages in Threads** — answer inside threads
    - **Create Public Threads** — start a thread from a question
    - **Add Reactions** — show the "processing" reaction (⏳)
-   - **Read Message History** — follow reply chains for continued conversations
+   - **Read Message History** — follow reply chains for continued
+     conversations, and read the messages around a mention
 3. Open the generated URL, choose the target server, and authorize. You need
    **Manage Server** permission on that server to complete the invite.
 
@@ -116,3 +102,63 @@ heartbeat acknowledgements (zombie-connection detection). Stop it with
   answer. A new, non-reply message starts a fresh conversation.
 - Answers longer than Discord's 2,000-character limit are split across several
   messages with no content lost.
+
+## Troubleshooting
+
+### The bot never comes online, and the log shows close code 4014
+
+```
+discord: gateway closed with fatal code 4014
+gateway: adapter discord terminated (configuration/credential error): ...
+```
+
+The **Message Content Intent** is OFF. Turn it on (step 1.3) and start the
+gateway again.
+
+If Discord is the only enabled integration, the gateway process exits. If Slack
+is enabled too, **the process keeps running for Slack** and only Discord stops —
+Slack questions are still answered, so watch for the log lines above rather than
+for the process going away.
+
+### The bot answers without taking the discussion into account
+
+If the bot is connected and answering but ignores what was said around the
+mention, check what the import actually collected:
+
+```bash
+grep "imported .* context messages" log/ai_helper.log
+```
+
+`imported 0 context messages` is normal when there was genuinely nothing to
+import — the first mention in a quiet channel, or a follow-up mention with no
+other messages in between. The gateway's own answers and the mentions addressed
+to it are never re-imported, because they are already stored as the
+conversation's questions and answers.
+
+If messages clearly were posted in between, check that the bot can actually see
+them: it only reads channels it has **View Channels** and **Read Message
+History** on, and in channel (non-thread) mode it looks no further back than 48
+hours / 20 messages.
+
+### The answer is prefixed with "The recent messages … could not be retrieved"
+
+The history request failed outright. The reason is logged with a backtrace:
+
+```bash
+grep "could not import the conversation context" log/ai_helper.log
+```
+
+Common causes:
+
+- **Missing "Read Message History" permission** — the REST call is rejected.
+  Re-invite the bot with the permission set from step 2, or add the permission
+  to its role in the server settings.
+- **Plugin migrations not applied** — an error mentioning
+  `last_imported_message_key` means the database is missing the column that
+  tracks how far the import got. Run
+  `bundle exec rake redmine:plugins:migrate RAILS_ENV=production` and restart
+  the gateway. Make sure the migration runs against the same database the
+  gateway uses; a running gateway caches the table layout, so it needs a
+  restart after the migration even if it was already restarted before it.
+
+The bot still answers in both cases — only the surrounding context is missing.

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -14,10 +14,10 @@ module RedmineAiHelper
       # Discord adapter using the Gateway API (v10): an outgoing WebSocket
       # connection to Discord, so no public URL is required. REST calls
       # (/users/@me, /gateway/bot, /channels/...) go through Net::HTTP with the
-      # bot token. Only the GUILD_MESSAGES and DIRECT_MESSAGES intents are used;
-      # the privileged MESSAGE_CONTENT intent is not required because Discord
-      # still delivers the full content of messages that mention the bot and of
-      # direct messages, which is exactly what this integration reacts to. The
+      # bot token. Besides GUILD_MESSAGES and DIRECT_MESSAGES it uses the
+      # privileged MESSAGE_CONTENT intent, which the context import depends on:
+      # Discord delivers the full content of mentions and direct messages
+      # without it, but blanks the body of every surrounding message. The
       # bot token is never written to the log or to any exception message.
       class DiscordAdapter < BaseAdapter
         # Raised on authentication/configuration failures (REST 401, gateway
@@ -59,8 +59,14 @@ module RedmineAiHelper
         # Replies longer than this are split before posting (Discord's hard
         # limit is 2,000; 1,900 leaves headroom).
         MAX_MESSAGE_LENGTH = 1900
-        # GUILD_MESSAGES (1<<9) + DIRECT_MESSAGES (1<<12). No privileged intent.
-        GATEWAY_INTENTS = 4608
+        # GUILD_MESSAGES (1<<9) + DIRECT_MESSAGES (1<<12) + MESSAGE_CONTENT
+        # (1<<15). MESSAGE_CONTENT is privileged and must be enabled in the
+        # Developer Portal: without it Discord blanks the body of every message
+        # that does not mention the bot, which is exactly the history the
+        # context import reads. Identifying with it makes a disabled toggle
+        # fail at connect time (close code 4014, a fatal config error) instead
+        # of silently importing nothing.
+        GATEWAY_INTENTS = 37376
         # Maximum number of times a 429 response is retried before giving up.
         MAX_RATE_LIMIT_RETRIES = 3
         # Poll interval while waiting for the Hello opcode that carries the
@@ -236,10 +242,10 @@ module RedmineAiHelper
         end
 
         # Discord serves both thread and channel messages through the same
-        # REST endpoint. Whether the bodies actually arrive depends on the
-        # Message Content Intent being enabled in the Developer Portal; when it
-        # is not, the bodies are empty and every message is skipped as empty,
-        # so the gateway answers without context instead of failing.
+        # REST endpoint. The bodies arrive populated because the Message
+        # Content Intent is enabled: the adapter identifies with it
+        # (GATEWAY_INTENTS), so a portal toggle that is off fails the
+        # connection outright rather than reaching this method (ADR-009).
         # @return [Boolean]
         def supports_history?
           true
@@ -362,8 +368,8 @@ module RedmineAiHelper
           end
         end
 
-        # Sends the Identify payload with the minimal intents (no privileged
-        # MESSAGE_CONTENT).
+        # Sends the Identify payload. Discord closes the connection with 4014
+        # when MESSAGE_CONTENT is requested but not enabled for the app.
         # @return [void]
         def send_identify
           send_json(

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -591,8 +591,12 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_predicate @adapter, :supports_history?
     end
 
-    should "keep the gateway intents unchanged so existing installations still connect" do
-      assert_equal 4608, DiscordAdapter::GATEWAY_INTENTS
+    should "identify with the privileged MESSAGE_CONTENT intent the import depends on" do
+      assert_equal 4608 | (1 << 15), DiscordAdapter::GATEWAY_INTENTS
+    end
+
+    should "treat a disallowed intent as a fatal configuration error" do
+      assert_includes DiscordAdapter::FATAL_CLOSE_CODES, 4014
     end
 
     should "read the thread messages with the page limit" do

--- a/wiki/INDEX.md
+++ b/wiki/INDEX.md
@@ -24,7 +24,7 @@ page files, not here.
 
 ## reference
 - [Chat History APIs](./pages/chat-history-apis.md) — Slack/Discord message-retrieval APIs, scopes, display-name resolution, exclusion rules.
-- [Discord Message Content Intent](./pages/discord-message-content-intent.md) — why Identify intents stay at 4608 and the close-code-4014 gotcha.
+- [Discord Message Content Intent](./pages/discord-message-content-intent.md) — why Identify requests the privileged intent (37376) and fails fast on close code 4014.
 - [Vector Search](./pages/vector-search.md) — Qdrant setup, index rake tasks, the embedding-provider constraint, and the optional vector model profile.
 - [Multi-modal File Support](./pages/multi-modal-file-support.md) — supported file types, attachment-to-LLM setting, and vector-index integration.
 

--- a/wiki/pages/discord-message-content-intent.md
+++ b/wiki/pages/discord-message-content-intent.md
@@ -1,14 +1,14 @@
 ---
 title: Discord Message Content Intent
 type: reference
-sources: [S001]
+sources: [S001, S015]
 updated: 2026-08-01
 ---
 
 # Discord Message Content Intent
 
-A durable constraint on the Discord adapter's gateway connection, worth
-remembering because getting it wrong breaks *existing* installs (S001).
+A hard requirement of the Discord adapter's gateway connection, worth
+remembering because it is what makes the context import work at all (S015).
 
 ## The rule
 
@@ -18,35 +18,54 @@ toggle applies to **both the Gateway and the REST API**. Exceptions always
 readable regardless of the toggle: the bot's own messages, DMs, and messages
 that mention the bot (S001).
 
-## Why the Identify intents must stay at 4608
+## The Identify intents include MESSAGE_CONTENT
 
-The gateway's Identify uses `GUILD_MESSAGES + DIRECT_MESSAGES = 4608` and this
-**must not change** (S001):
+The gateway's Identify uses
+`GUILD_MESSAGES + DIRECT_MESSAGES + MESSAGE_CONTENT = 37376` (S015):
 
-- Requesting a privileged intent (MESSAGE_CONTENT = `1 << 15`) in Identify when
-  it is **not** enabled in the Portal causes gateway **close code 4014** (fatal
-  config error) — the gateway of every existing install fails to start.
-- REST history retrieval does **not** need the MESSAGE_CONTENT bit in Identify,
-  so history import can be added without touching the intents at all.
+- If the toggle is **not** enabled in the Portal, Discord answers Identify with
+  gateway **close code 4014**. `FATAL_CLOSE_CODES` already treats 4014 as a
+  fatal configuration error, so the adapter logs
+  `discord: gateway closed with fatal code 4014` and stops instead of retrying.
+  Per ADR-006 the *process* exits only if Discord was the last live adapter; a
+  Slack + Discord install keeps serving Slack.
+- Requesting the intent is what turns a missing toggle into a startup failure.
+  REST history retrieval technically works without the bit in Identify, but
+  then it returns empty bodies and the misconfiguration is invisible.
+
+This reverses the earlier design (ADR-008 decision 7), which kept the intents
+at `4608` so unconfigured installs would keep running without context (S015).
+
+## Why the degraded mode was removed
+
+With the toggle off and intents at 4608, nothing failed: Discord returned
+empty message bodies, every imported message was skipped as empty, the log
+recorded `imported 0 context messages`, and the bot answered as if the
+discussion did not exist. That is indistinguishable both from a healthy install
+in a quiet channel and, in the log, from "there genuinely was nothing to
+import" — while delivering none of the feature's value (S015).
 
 ## Operational consequence
 
-Admins must enable Message Content Intent in the Developer Portal themselves
-(and verified apps need separate Discord approval). If they do not, imported
-messages arrive with empty bodies, empty-body messages are skipped, and the bot
-simply runs "without prior context" — question answering itself still works
-(SC-006) (S001).
+Admins must enable Message Content Intent in the Developer Portal before
+starting the gateway (verified apps need separate Discord approval). An install
+that never enabled it loses Discord answering entirely until they do — a
+deliberate, documented break, since such an install was never getting the
+context import anyway (S015).
 
-Rejected alternatives (S001):
+Rejected alternatives (S015):
 
-- Add MESSAGE_CONTENT to Identify → close 4014 in unconfigured environments;
-  breaks existing users.
-- Detect 4014 and re-Identify without MESSAGE_CONTENT → a fallback banned by
-  constitution III, and adds state transitions.
+- Keep 4608 and document the toggle as required → documentation cannot prevent
+  silent degradation.
+- Keep 4608 and warn when every imported body is empty → a heuristic that
+  cannot be certain, reported at question time rather than startup.
+- Request MESSAGE_CONTENT, then re-Identify without it on close 4014 → the
+  silent fallback banned by constitution III.
 
 ## Related
 
 - [Chat Channel Gateway Architecture](./chat-channel-gateway-architecture.md)
 - [Chat History APIs](./chat-history-apis.md) — Discord REST history retrieval.
 
-Recorded in ADR-007 (Discord adapter connection design), `docs/adr/` (S001).
+Recorded in ADR-009, which supersedes decision 7 of ADR-008 and the intent part
+of decision 1 of ADR-007, `docs/adr/` (S015).

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -19,3 +19,4 @@ Sources are immutable inputs — the wiki never edits them.
 | S012 | specs/022-vector-project-selection/spec.md | feature-artifact | 2026-08-01 | 2026-08-01 | vector-search-internals.md, vector-search.md |
 | S013 | https://deepwiki.com/haru/redmine_ai_helper/3.1-ai-chat-sidebar | url | 2026-08-01 | 2026-08-01 | chat-sidebar.md, plugin-overview.md |
 | S014 | https://deepwiki.com/haru/redmine_ai_helper/3.2-issue-ai-features | url | 2026-08-01 | 2026-08-01 | issue-ai-features.md, plugin-overview.md |
+| S015 | docs/adr/009-discord-message-content-intent-required.md | file | 2026-08-01 | 2026-08-01 | discord-message-content-intent.md |


### PR DESCRIPTION
## Changes

- Identify with `GATEWAY_INTENTS = 37376` so the Discord adapter requests the privileged MESSAGE_CONTENT intent
- A disabled Developer Portal toggle now fails the connection (close code 4014) instead of silently importing empty message bodies
- Document the intent as a required setup step and add a troubleshooting section for close code 4014, empty imports and retrieval failures
- Record the reversal in ADR-009 and update the ADR index and the wiki page it contradicted