### PR TITLE
Remove upgrade notes for unreleased gateway features

### DIFF
--- a/docs/adr/009-discord-message-content-intent-required.md
+++ b/docs/adr/009-discord-message-content-intent-required.md
@@ -14,9 +14,11 @@ ADR-008 kept the Identify intents at `GUILD_MESSAGES + DIRECT_MESSAGES = 4608`
 when the context import was added, so that installations which had not enabled
 the Message Content Intent in the Developer Portal would keep working: the
 gateway would still connect, and only the imported context would be missing.
-Turning the toggle on was documented as optional.
+Turning the toggle on was documented as optional. That rationale rested on
+protecting installations that do not exist — the chat channel gateway (028) and
+this feature (034) are both unreleased, present only on `develop`.
 
-Operating the feature showed that this degraded mode is not worth having:
+Exercising the feature showed that the degraded mode is not worth having:
 
 - With the toggle off, Discord returns the surrounding messages with an empty
   body. They are all skipped, the import reports `imported 0 context messages`,
@@ -51,12 +53,10 @@ also enabled the process keeps serving Slack and only Discord goes down.
   failure, instead of silently removing context from every later answer. This
   follows the project guideline that errors must surface immediately rather
   than be absorbed by a fallback.
-- **Breaking for existing installations that never enabled the toggle**: their
-  Discord bot stops answering until an administrator enables it. This is
-  deliberate — those installations were already not getting the context import,
-  and the alternative is leaving them silently degraded. The setup guide
-  documents the toggle as required and the troubleshooting section names close
-  code 4014.
+- Discord answering stops entirely when the toggle is off, rather than
+  degrading. Nothing is broken for users in the field, because the gateway has
+  never been released; the setup guide states the toggle as a required step of
+  the initial setup and the troubleshooting section names close code 4014.
 - The failure is loud in the log but not always in process state: a
   Slack + Discord install keeps running with Slack alone, so operators who
   watch only for a dead process will miss it. The setup guide calls this out.

--- a/docs/slack_gateway_setup.md
+++ b/docs/slack_gateway_setup.md
@@ -34,7 +34,7 @@ The integration uses Slack **Socket Mode**: the gateway process opens an outgoin
 
 > A bot token carries the scopes that were granted when the app was installed.
 > If you add a scope after installing, open **OAuth & Permissions** and choose
-> **Reinstall to Workspace**, otherwise the calls needing it fail with
+> **Reinstall to Workspace**, otherwise the calls that need it fail with
 > `missing_scope`. The bot token stays valid, so the Redmine settings need no
 > change.
 

--- a/docs/slack_gateway_setup.md
+++ b/docs/slack_gateway_setup.md
@@ -32,10 +32,11 @@ The integration uses Slack **Socket Mode**: the gateway process opens an outgoin
    - `message.im`
 5. Install the app into the workspace and note the **Bot User OAuth Token** (starts with `xoxb-`).
 
-> **Upgrading an app installed before this feature existed**: adding scopes does
-> not change an existing installation. Open **OAuth & Permissions**, add the four
-> scopes above and choose **Reinstall to Workspace**, then restart the gateway.
-> The bot token stays valid, so the Redmine settings need no change.
+> A bot token carries the scopes that were granted when the app was installed.
+> If you add a scope after installing, open **OAuth & Permissions** and choose
+> **Reinstall to Workspace**, otherwise the calls needing it fail with
+> `missing_scope`. The bot token stays valid, so the Redmine settings need no
+> change.
 
 ## 2. Configure Redmine
 

--- a/wiki/pages/discord-message-content-intent.md
+++ b/wiki/pages/discord-message-content-intent.md
@@ -51,8 +51,8 @@ import" — while delivering none of the feature's value (S015).
 
 Enabling Message Content Intent in the Developer Portal is a required step of
 the initial setup, done before the gateway is first started (verified apps need
-separate Discord approval). Skip it and Discord answering does not work at all,
-rather than working without context (S015).
+separate Discord approval). If you skip it, Discord answering does not work at
+all, rather than working without context (S015).
 
 Rejected alternatives (S015):
 

--- a/wiki/pages/discord-message-content-intent.md
+++ b/wiki/pages/discord-message-content-intent.md
@@ -34,7 +34,9 @@ The gateway's Identify uses
   then it returns empty bodies and the misconfiguration is invisible.
 
 This reverses the earlier design (ADR-008 decision 7), which kept the intents
-at `4608` so unconfigured installs would keep running without context (S015).
+at `4608` so unconfigured installs would keep running without context — a
+rationale that protected installations that do not exist, since the gateway is
+unreleased and lives only on `develop` (S015).
 
 ## Why the degraded mode was removed
 
@@ -47,11 +49,10 @@ import" — while delivering none of the feature's value (S015).
 
 ## Operational consequence
 
-Admins must enable Message Content Intent in the Developer Portal before
-starting the gateway (verified apps need separate Discord approval). An install
-that never enabled it loses Discord answering entirely until they do — a
-deliberate, documented break, since such an install was never getting the
-context import anyway (S015).
+Enabling Message Content Intent in the Developer Portal is a required step of
+the initial setup, done before the gateway is first started (verified apps need
+separate Discord approval). Skip it and Discord answering does not work at all,
+rather than working without context (S015).
 
 Rejected alternatives (S015):
 


### PR DESCRIPTION
## Changes

- ADR-009: record that the removed degraded mode protected installations that do not exist, since the chat channel gateway (028) and chat history context (034) are unreleased and live only on `develop`
- Slack setup guide: replace the "upgrading an app installed before this feature existed" note with general guidance on reinstalling to the workspace after adding scopes
- Wiki page: present enabling the Discord Message Content Intent as a required initial setup step rather than a deliberate break for existing installs