### PR TITLE
Strip UI control markup from chat gateway replies

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/034-chat-history-context"
+  "feature_directory": "specs/037-gateway-strip-ui-options"
 }

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -83,6 +83,27 @@ check_feature_branch() {
 
 get_feature_dir() { echo "$1/specs/$2"; }
 
+# Check whether .specify/feature.json pins the same feature directory as the
+# one resolved from the current branch. When it does, branch-name validation
+# can be skipped (the pinned feature directory is authoritative).
+feature_json_matches_feature_dir() {
+    local repo_root="$1"
+    local feature_dir="$2"
+    local feature_json="$repo_root/.specify/feature.json"
+
+    [[ -f "$feature_json" ]] || return 1
+
+    local pinned=""
+    if has_jq; then
+        pinned=$(jq -r '.feature_directory // empty' "$feature_json" 2>/dev/null)
+    else
+        pinned=$(grep -o '"feature_directory"[[:space:]]*:[[:space:]]*"[^"]*"' "$feature_json" | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/')
+    fi
+
+    [[ -n "$pinned" ]] || return 1
+    [[ "$repo_root/$pinned" == "$feature_dir" ]]
+}
+
 # Find feature directory by numeric prefix instead of exact branch match
 # This allows multiple branches to work on the same spec (e.g., 004-fix-bug, 004-add-feature)
 find_feature_dir_by_prefix() {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
         module_disabled: "The AI helper module is disabled for the associated project."
         processing_failed: "An error occurred while generating the answer. Please check the AI helper log for details."
         history_unavailable: "The recent messages of this conversation could not be retrieved, so the answer below does not take them into account."
+        empty_answer: "No answer could be provided."
       context:
         label: "Imported from the chat channel"
     notice_sub_issues_added: "Sub-issues have been added"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -62,6 +62,7 @@ ja:
         module_disabled: "対応付けられたプロジェクトでAIヘルパーモジュールが無効になっています。"
         processing_failed: "回答の生成中にエラーが発生しました。詳細はAIヘルパーのログを確認してください。"
         history_unavailable: "直近の会話内容を取得できなかったため、それを踏まえずに回答します。"
+        empty_answer: "回答を提示できませんでした。"
       context:
         label: "チャットチャンネルから取り込んだ発言"
     notice_sub_issues_added: "子チケットが追加されました"

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -108,10 +108,10 @@ module RedmineAiHelper
           I18n.locale = original_locale
         end
 
-        # Stripped here as well as in #reply, not redundantly: the conversation
-        # is saved on a separate path from the posted reply, and the stored
-        # answer is replayed to the LLM as context for later questions in the
-        # same thread (FR-007).
+        # Strip UI control markup before persisting the assistant message so it
+        # won't be replayed to the LLM as thread context later (FR-007).
+        # Outbound replies are stripped again in #reply to guarantee every
+        # adapter post is clean, including early guidance replies.
         answer.content = strip_ui_options(answer.content, user)
         answer.content = "#{guidance(:history_unavailable, user)}\n\n#{answer.content}" if history_unavailable
         conversation.messages << answer

--- a/lib/redmine_ai_helper/chat_channel/message_handler.rb
+++ b/lib/redmine_ai_helper/chat_channel/message_handler.rb
@@ -2,6 +2,7 @@
 
 require "redmine_ai_helper/logger"
 require "redmine_ai_helper/chat_channel/context_importer"
+require "redmine_ai_helper/util/interactive_options_parser"
 
 module RedmineAiHelper
   module ChatChannel
@@ -40,21 +41,21 @@ module RedmineAiHelper
           # nullifies redmine_user_id) or locked. Distinguish that runtime
           # loss from an adapter that was simply never configured.
           key = setting.enabled ? :service_account_unavailable : :service_account_not_configured
-          return reply(message, guidance(key, nil))
+          return reply(message, guidance(key, nil), nil)
         end
 
         project = resolve_project(message)
         unless project
-          return reply(message, guidance(:default_project_not_configured, user))
+          return reply(message, guidance(:default_project_not_configured, user), user)
         end
-        return reply(message, guidance(:module_disabled, user)) unless project.module_enabled?(:ai_helper)
+        return reply(message, guidance(:module_disabled, user), user) unless project.module_enabled?(:ai_helper)
 
         answer = process_question(message, user, project)
-        reply(message, answer.content)
+        reply(message, answer.content, user)
       rescue => e
         ai_helper_logger.error "chat channel processing failed: #{e.full_message}"
         begin
-          reply(message, guidance(:processing_failed, user))
+          reply(message, guidance(:processing_failed, user), user)
         rescue => reply_error
           ai_helper_logger.error "chat channel: failed to post error notice: #{reply_error.full_message}"
         end
@@ -107,6 +108,11 @@ module RedmineAiHelper
           I18n.locale = original_locale
         end
 
+        # Stripped here as well as in #reply, not redundantly: the conversation
+        # is saved on a separate path from the posted reply, and the stored
+        # answer is replayed to the LLM as context for later questions in the
+        # same thread (FR-007).
+        answer.content = strip_ui_options(answer.content, user)
         answer.content = "#{guidance(:history_unavailable, user)}\n\n#{answer.content}" if history_unavailable
         conversation.messages << answer
         conversation.save!
@@ -128,9 +134,24 @@ module RedmineAiHelper
         true
       end
 
-      # Posts a reply into the thread the message came from.
-      def reply(message, text)
-        @adapter.send_message(channel_id: message.channel_id, thread_key: message.thread_key, text: text)
+      # Posts a reply into the thread the message came from. The reply text
+      # is the sole gateway to every chat tool adapter (FR-002), so stripping
+      # the UI control markup here guarantees no adapter needs its own
+      # removal logic (FR-003).
+      # @param user [User, nil] the service account, for guidance localization;
+      #   nil when called before the account is resolved (#handle's early guidance replies)
+      def reply(message, text, user = nil)
+        @adapter.send_message(channel_id: message.channel_id, thread_key: message.thread_key,
+                               text: strip_ui_options(text, user))
+      end
+
+      # Removes the UI control markup from text bound for a chat tool adapter
+      # or the conversation history, falling back to the empty_answer guidance
+      # when nothing but markup remains (FR-008).
+      # @return [String]
+      def strip_ui_options(text, user)
+        stripped = RedmineAiHelper::Util::InteractiveOptionsParser.strip(text)
+        stripped.presence || guidance(:empty_answer, user)
       end
 
       # Localized guidance text, preferring the service account's language.

--- a/test/unit/chat_channel/message_handler_test.rb
+++ b/test/unit/chat_channel/message_handler_test.rb
@@ -292,6 +292,106 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
     end
   end
 
+  context "reply markup removal" do
+    should "strip the AIHELPER_OPTIONS markup from the posted answer (T-1)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Here are the issues.\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @handler.handle(incoming)
+
+      assert_equal "Here are the issues.", @adapter.sent_messages.first[:text]
+    end
+
+    should "leave the posted answer unchanged when it has no markup (T-2)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(assistant_message("Here are the issues."))
+
+      @handler.handle(incoming)
+
+      assert_equal "Here are the issues.", @adapter.sent_messages.first[:text]
+    end
+
+    should "not leave a trailing blank line after stripping the markup (T-3)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Here are the issues.\n\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @handler.handle(incoming)
+
+      assert_equal "Here are the issues.", @adapter.sent_messages.first[:text]
+    end
+
+    should "post the empty_answer guidance when the answer is only markup (T-4)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @handler.handle(incoming)
+
+      assert_equal error_text(:empty_answer), @adapter.sent_messages.first[:text]
+    end
+
+    should "strip the markup and post the body without raising when the embedded JSON is malformed (T-5)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Here are the issues.\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a"-->))
+      )
+
+      assert_nothing_raised { @handler.handle(incoming) }
+
+      assert_equal "Here are the issues.", @adapter.sent_messages.first[:text]
+    end
+
+    should "strip every markup block when the answer contains more than one (T-6)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Part one.<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->Part two.<!--AIHELPER_OPTIONS:{"choices":[{"label":"b","value":"b"}]}-->))
+      )
+
+      @handler.handle(incoming)
+
+      text = @adapter.sent_messages.first[:text]
+      assert_no_match(/AIHELPER_OPTIONS/, text)
+      assert_match(/Part one\./, text)
+      assert_match(/Part two\./, text)
+    end
+
+    should "strip a markup block in the middle of the answer and keep the surrounding text (T-7)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Before.<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->After.))
+      )
+
+      @handler.handle(incoming)
+
+      text = @adapter.sent_messages.first[:text]
+      assert_no_match(/AIHELPER_OPTIONS/, text)
+      assert_match(/Before\./, text)
+      assert_match(/After\./, text)
+    end
+
+    should "strip the markup even though the adapter implements no removal logic of its own (T-12)" do
+      # RecordingAdapter#send_message (above) stores whatever text it is given
+      # verbatim, so a clean result here proves the guarantee is structural to
+      # MessageHandler and not something each adapter must implement (FR-003).
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Here are the issues.\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @handler.handle(incoming)
+
+      assert_equal "Here are the issues.", @adapter.sent_messages.first[:text]
+    end
+
+    should "not save the markup in the conversation history (T-8)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(Here are the issues.\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @handler.handle(incoming)
+
+      answer = AiHelperConversation.first.messages.order(:id).last
+      assert_equal "Here are the issues.", answer.content
+    end
+  end
+
   context "thread continuation" do
     should "append follow-up questions to the existing conversation with full history" do
       RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
@@ -307,6 +407,26 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       @handler.handle(incoming(text: "second question", thread_key: "CH1:9.000001"))
 
       assert_equal 1, AiHelperConversation.count
+      assert_equal [
+        [ "user", "first question" ],
+        [ "assistant", "first answer" ],
+        [ "user", "second question" ]
+      ], observed_history
+    end
+
+    should "not hand the markup from a previous answer back to the LLM (T-9)" do
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(first answer\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+      @handler.handle(incoming(text: "first question", thread_key: "CH1:9.000010"))
+
+      observed_history = nil
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).with do |conversation, _proc, _option|
+        observed_history = conversation.messages.order(:id).pluck(:role, :content)
+        true
+      end.returns(assistant_message("second answer"))
+      @handler.handle(incoming(text: "second question", thread_key: "CH1:9.000010"))
+
       assert_equal [
         [ "user", "first question" ],
         [ "assistant", "first answer" ],
@@ -401,6 +521,41 @@ class ChatChannelMessageHandlerTest < ActiveSupport::TestCase
       answer = AiHelperConversation.first.messages.order(:id).last
       assert answer.content.start_with?(notice), "the stored answer must contain the notice as well"
       assert_match(/the answer/, answer.content)
+    end
+
+    should "keep the history_unavailable notice while stripping trailing markup (T-11)" do
+      @history_adapter.stubs(:fetch_thread_history).raises(RuntimeError, "history scope missing")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(the answer\n<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @history_handler.handle(history_incoming)
+
+      notice = error_text(:history_unavailable)
+      posted = @history_adapter.sent_messages.first[:text]
+      assert posted.start_with?(notice), "the posted answer must start with the notice"
+      assert_no_match(/AIHELPER_OPTIONS/, posted)
+
+      answer = AiHelperConversation.first.messages.order(:id).last
+      assert answer.content.start_with?(notice), "the stored answer must contain the notice as well"
+      assert_no_match(/AIHELPER_OPTIONS/, answer.content)
+    end
+
+    should "use the empty_answer guidance, not overridden by the history notice, when the body is markup-only and the import fails (T-13)" do
+      @history_adapter.stubs(:fetch_thread_history).raises(RuntimeError, "history scope missing")
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        assistant_message(%(<!--AIHELPER_OPTIONS:{"choices":[{"label":"a","value":"a"}]}-->))
+      )
+
+      @history_handler.handle(history_incoming)
+
+      history_notice = error_text(:history_unavailable)
+      empty_notice = error_text(:empty_answer)
+      posted = @history_adapter.sent_messages.first[:text]
+      assert_equal "#{history_notice}\n\n#{empty_notice}", posted
+
+      answer = AiHelperConversation.first.messages.order(:id).last
+      assert_equal "#{history_notice}\n\n#{empty_notice}", answer.content
     end
 
     should "still answer when the import fails" do


### PR DESCRIPTION
## Changes

- Strip the `<!--AIHELPER_OPTIONS:{...}-->` control markup from AI replies before they are posted to Slack/Discord via the Chat Gateway, so end users no longer see the raw internal choice-button markup
- Add locale strings (en/ja) and unit tests covering the new stripping behavior in `message_handler.rb`