### PR TITLE
Stabilize Slack Socket Mode connection

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/038-gateway-issue-links"
+  "feature_directory": "specs/039-slack-socket-mode-stability"
 }

--- a/docs/adr/012-slack-only-scope-for-websocket-transport-fixes.md
+++ b/docs/adr/012-slack-only-scope-for-websocket-transport-fixes.md
@@ -1,0 +1,110 @@
+# ADR-012: Scope the WebSocket transport fixes to the Slack adapter, leaving the same latent defects in Discord
+
+**Date**: 2026-08-02
+**Status**: Accepted
+
+Relates to [ADR-006](./006-chat-channel-gateway-architecture.md) (gateway
+architecture, per-adapter isolation) and
+[ADR-007](./007-discord-adapter-connection-design.md) (Discord connection
+design).
+
+## Context
+
+The Slack adapter was reconnecting every two minutes, indefinitely. A live
+probe against Socket Mode with real credentials established the cause and
+uncovered two further defects in the same code path.
+
+**The primary defect (Slack-specific).** Slack Socket Mode sends a WebSocket
+ping frame roughly every 10 seconds and expects a pong in return.
+`websocket-client-simple` has no automatic pong reply, and `SlackAdapter#listen`
+matched only `:text` and `:pong` in its message handler, so server pings were
+discarded. Measured behaviour with no pong reply: Slack pinged at 5.6s, 15.8s,
+26.0s and 36.1s, then went silent; the client ping at 30s was answered, the
+ones at 60s, 90s and 120s were not. With pong replies the same connection
+stayed fully healthy for the entire 125-second probe. Discord is unaffected by
+this defect because it uses application-level heartbeats (opcodes 1/11) rather
+than WebSocket ping frames.
+
+**Two secondary defects (structurally shared with Discord).** Both adapters
+drive `websocket-client-simple` the same way, so both carry them:
+
+1. *Unsynchronized writes to one socket.* The receive thread writes (Slack's
+   per-event `acknowledge`, Discord's `send_identify` and heartbeat-on-request)
+   while the health-check thread writes pings/heartbeats. The gem's `send`
+   performs a bare `@socket.write` with no mutex, so two frames can interleave
+   and corrupt the stream.
+2. *EOF is never surfaced as a close.* The gem's read loop does
+   `unless recv_data = @socket.getc; sleep 1; next; end`, so at EOF it spins
+   without ever emitting `:close`. A half-closed connection is only noticed via
+   the health-check timeout.
+
+Neither secondary defect has been observed to fire in production. Slack's
+2-minute reconnect loop is fully explained by the primary defect alone, and
+Discord has been running without incident.
+
+This raises a scope question: fix the two shared defects in both adapters, or
+only in Slack?
+
+## Decision
+
+**The fix is scoped to the Slack adapter only.** Feature
+`039-slack-socket-mode-stability` changes `slack_adapter.rb` and its tests;
+`discord_adapter.rb` is not touched.
+
+The two secondary defects therefore remain latent in the Discord adapter, and
+this ADR is the record of that. Concretely, `DiscordAdapter` still:
+
+- writes to its socket from both the receive thread (`send_identify`,
+  heartbeat-on-request) and the `heartbeat_loop` thread with no mutex; and
+- relies on its heartbeat-ack timeout to notice a half-closed connection,
+  because EOF produces no close event.
+
+Discord's exposure to the first is lower than Slack's was: its receive thread
+writes only on Hello and on an unsolicited opcode-1, whereas Slack's wrote an
+ack for every single event. Its exposure to the second is bounded by the
+heartbeat interval Discord announces (~41s), not by a fixed 120s ceiling.
+
+## Consequences
+
+- The change stays small and reviewable, and the Discord integration — which is
+  working correctly today — carries no regression risk from this fix. This
+  follows the constitution's YAGNI principle: no changes beyond the stated task
+  scope.
+- The two adapters diverge. After this feature, Slack serializes its writes and
+  detects EOF directly; Discord does neither. A maintainer reading both files
+  will see the asymmetry, and this ADR is the explanation.
+- The latent Discord defects can still fire. The realistic trigger for the
+  write race is a burst of gateway traffic coinciding with a heartbeat; the
+  symptom would be a rare, hard-to-reproduce disconnect. If that is ever
+  observed, this ADR is the starting point, and the Slack implementation is the
+  reference to port.
+- Deferring means the eventual Discord fix is a second, separate change rather
+  than one shared change. If a third adapter is added, the third occurrence is
+  the point at which the constitution's DRY rule justifies extracting the
+  shared transport handling into `BaseAdapter` — this ADR should be superseded
+  then.
+- No user-visible behaviour changes for Discord.
+
+## Alternatives Considered
+
+- **Fix both adapters in this feature**: rejected. It doubles the diff and adds
+  manual verification against a live Discord guild for defects that have never
+  been observed to fire there, in order to harden an integration the user
+  reports as stable. The reported problem is Slack-only.
+- **Fix both and extract the shared transport handling into `BaseAdapter`**:
+  rejected for now. With exactly two occurrences this is the premature
+  abstraction the constitution's DRY rule explicitly warns against ("three
+  similar occurrences justify extraction"). It also forces the largest possible
+  blast radius — a base-class change affecting every adapter — for a bug fix.
+- **Replace `websocket-client-simple` with a driver that handles pong replies,
+  write locking and close frames itself** (e.g. `websocket-driver`, already in
+  the bundle): rejected as out of scope for a bug fix. It would rewrite the
+  connection layer of both adapters at once, discarding the reconnect,
+  backoff and fatal-error classification behaviour that ADR-006 and ADR-007
+  established and that is covered by existing tests. Worth revisiting as
+  deliberate work if a third adapter is added.
+- **Leave the secondary defects unfixed in Slack too, and only add the pong
+  reply**: rejected. The pong fix already rewrites the same message handler and
+  health-check loop, so fixing all three together costs little extra, and the
+  new receive-timeout detection replaces the client-ping mechanism outright
+  rather than sitting alongside it.

--- a/docs/adr/013-slack-receive-inactivity-liveness-detection.md
+++ b/docs/adr/013-slack-receive-inactivity-liveness-detection.md
@@ -1,0 +1,85 @@
+# ADR-013: Replace Slack's self-initiated ping/pong-count liveness check with receive-inactivity monitoring
+
+**Date**: 2026-08-02
+**Status**: Accepted
+
+Relates to [ADR-006](./006-chat-channel-gateway-architecture.md) (gateway
+architecture) and [ADR-012](./012-slack-only-scope-for-websocket-transport-fixes.md)
+(scope of the Slack Socket Mode stability fix this ADR is part of).
+
+## Context
+
+Feature `039-slack-socket-mode-stability` fixes the primary defect behind
+Slack's 2-minute reconnect loop: the adapter now answers Slack's WebSocket
+ping frames with a pong (ADR-012; research.md R-001). Once that fix lands, Slack's own
+ping arrives roughly every 10 seconds for as long as the connection is
+healthy — a high-frequency liveness signal the adapter gets for free.
+
+Before this change, `SlackAdapter` ran its own liveness check independently
+of that signal: `ping_loop` sent a WebSocket ping every 30 seconds and counted
+missed pongs, reconnecting after `MAX_MISSED_PONGS` (2) consecutive misses —
+up to 120 seconds to detect a dead connection. This mirrors `MessageHandler`'s
+own instinct to verify liveness by probing, but with the pong fix in place, it
+duplicates a signal that already exists: the receive side goes quiet exactly
+when the connection is actually dead, and it does so before a self-initiated
+probe would even fire.
+
+## Decision
+
+Replace the self-initiated ping/missed-pong-count mechanism with
+**receive-inactivity monitoring**: record the time of the most recently
+received frame, of any type, and reconnect once `RECEIVE_TIMEOUT_SECONDS`
+(30) seconds pass without one. `ping_loop`, `ping_tick` and `handle_pong` are
+removed, along with `PING_INTERVAL_SECONDS` and `MAX_MISSED_PONGS`.
+
+The monitor (`watchdog_loop`) never writes to the connection — it only reads
+`@last_received_at` and waits on the same `@connection_ended` queue that a
+close frame or socket error already pushes to. It waits for the timeout's
+remaining time rather than a fixed poll interval, recomputing that remaining
+time whenever a wait ends without a connection-ended notification, since a
+frame may have arrived (and pushed the deadline forward) while it was
+waiting.
+
+A close frame is now also handled directly (`:close` in `handle_frame`),
+which was previously discarded. This gives Slack the same three-layer
+disconnect detection Discord already has: a clean close frame is immediate,
+a socket-level error is immediate, and only a fully silent link (no close
+frame, no error, just nothing) falls through to the 30-second inactivity
+timeout.
+
+## Consequences
+
+- Detection of a fully silent connection failure drops from up to 120 seconds
+  to 30 seconds, and the close-frame and socket-error paths that were already
+  fast stay fast.
+- The adapter sends no application-level traffic to keep the connection
+  alive; the only socket writes during normal operation are event
+  acknowledgements and pong replies, both receive-triggered. This also
+  shrinks the surface for the write races addressed by the `@send_mutex`
+  serialization introduced in the same feature.
+- `SlackAdapter` and `DiscordAdapter` now use different liveness strategies:
+  Slack observes Slack-initiated pings, Discord still sends its own
+  heartbeats. This is intentional, not an oversight — Discord's protocol has
+  no equivalent free signal (its gateway does not ping the client the way
+  Slack's Socket Mode does), so there is no analogous inactivity signal to
+  observe there instead.
+- `RECEIVE_TIMEOUT_SECONDS` is a constant, not a setting. Per the constitution's
+  YAGNI principle, no configurability is added until a concrete need for a
+  different value appears.
+
+## Alternatives Considered
+
+- **Keep the self-initiated ping alongside the new pong reply**: rejected.
+  Once the adapter answers Slack's ping, the adapter would be measuring the
+  same liveness twice through two independent mechanisms, doubling the
+  constants, state and branches for no gain in detection speed or accuracy
+  (constitution III: KISS/YAGNI).
+- **Lower `RECEIVE_TIMEOUT_SECONDS` closer to Slack's ~10-second ping
+  interval**: rejected. A margin of roughly three ping intervals absorbs
+  ordinary network jitter and GC pauses without producing spurious
+  reconnects; the spec (FR-004) fixes this at 30 seconds.
+- **Poll on a fixed short interval instead of waiting for the computed
+  remaining time**: rejected. A fixed interval either adds detection latency
+  (if longer than needed) or wakes the thread needlessly often (if short),
+  with no benefit over computing the exact remaining time from
+  `@last_received_at`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,3 +64,5 @@ Briefly describe alternatives that were rejected and why.
 | [009](./009-discord-message-content-intent-required.md) | Require the Discord MESSAGE_CONTENT intent in Identify | Accepted |
 | [010](./010-chat-channel-issue-link-rendering.md) | Render issue references as links on the shared gateway send path | Accepted |
 | [011](./011-reset-i18n-locale-between-tests.md) | Reset `I18n.locale` before every test | Accepted |
+| [012](./012-slack-only-scope-for-websocket-transport-fixes.md) | Scope the WebSocket transport fixes to the Slack adapter, leaving the same latent defects in Discord | Accepted |
+| [013](./013-slack-receive-inactivity-liveness-detection.md) | Replace Slack's self-initiated ping/pong-count liveness check with receive-inactivity monitoring | Accepted |

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -23,12 +23,11 @@ module RedmineAiHelper
         SLACK_API_BASE = "https://slack.com/api"
         # Open/read timeout for every Web API call (contract: 10 seconds).
         HTTP_TIMEOUT_SECONDS = 10
-        # Interval between health-check pings on the WebSocket.
-        PING_INTERVAL_SECONDS = 30
         # Upper bound of the exponential reconnect backoff.
         MAX_BACKOFF_SECONDS = 60
-        # Reconnect when this many consecutive pings got no pong.
-        MAX_MISSED_PONGS = 2
+        # Reconnect when no frame of any type has been received for this long
+        # (research.md R-002: receive-inactivity replaces the client-ping count).
+        RECEIVE_TIMEOUT_SECONDS = 30
         # Replies longer than this are split before posting (research.md R-008).
         MAX_MESSAGE_LENGTH = 3900
         # Messages requested per history page (Slack's maximum for a full page).
@@ -67,17 +66,18 @@ module RedmineAiHelper
           @reconnect_requested = false
           @connected = false
           @backoff = 1
-          @missed_pongs = 0
           @display_names = {}
+          @send_mutex = Mutex.new
+          @last_received_at = 0.0
         end
 
         # Connects to Slack and blocks while receiving events. Reconnects on
         # disconnect envelopes (immediately, with a fresh URL), on socket
-        # errors (with exponential backoff), on missed pongs and on clean
-        # closes that never received hello (suspected handshake rejection,
-        # also backed off so a remote-side tight close loop cannot hammer
-        # apps.connections.open). Auth errors (ok:false from the Web API)
-        # terminate without retry.
+        # errors (with exponential backoff), on receive inactivity and on
+        # clean closes that never received hello (suspected handshake
+        # rejection, also backed off so a remote-side tight close loop cannot
+        # hammer apps.connections.open). Auth errors (ok:false from the Web
+        # API) terminate without retry.
         # @return [void]
         def start
           @stopped = false
@@ -242,52 +242,75 @@ module RedmineAiHelper
           @connection_ended = Queue.new
           @reconnect_requested = false
           @connected = false
-          @missed_pongs = 0
+          touch_received
           adapter = self
           @ws = WebSocket::Client::Simple.connect(url) do |ws|
-            ws.on(:message) do |msg|
-              case msg.type
-              when :text
-                adapter.handle_envelope(msg.data)
-              when :pong
-                adapter.send(:handle_pong)
-              end
-            end
+            ws.on(:message) { |msg| adapter.send(:handle_frame, ws, msg) }
             ws.on(:close) { |_event| adapter.send(:connection_ended!) }
             ws.on(:error) { |error| adapter.send(:socket_errored, error) }
           end
-          ping_loop
+          watchdog_loop
         ensure
           close_socket
         end
 
-        # Sends pings on a fixed interval until the connection ends. Missed
-        # pongs beyond the threshold force a reconnect.
-        def ping_loop
+        # Dispatches one received WebSocket frame by type. Runs on the
+        # connection's receive thread. +client+ comes from the block
+        # WebSocket::Client::Simple yields, not @ws: assigning @ws happens only
+        # after #connect returns, so a frame arriving in that short window
+        # would otherwise be unanswerable (research.md R-001).
+        # @param client [WebSocket::Client::Simple::Client] the connection the frame arrived on
+        # @param msg [#type, #data, #code] the received frame
+        # @return [void]
+        def handle_frame(client, msg)
+          touch_received
+          case msg.type
+          when :ping
+            # RFC 6455: a pong must carry the ping's application data verbatim.
+            # No validation, transformation or discarding of the payload.
+            send_frame(client, msg.data, type: :pong)
+          when :text
+            handle_envelope(msg.data)
+          when :close
+            ai_helper_logger.info "slack: close frame received (code #{msg.code || "none"})"
+            connection_ended!
+          end
+        rescue => e
+          # Runs on websocket-client-simple's receive thread: without this
+          # rescue an exception (e.g. a write failure while sending the pong)
+          # would escape into the gem's own handler and never reach
+          # ai_helper_logger, making the failure invisible.
+          ai_helper_logger.error "slack: error while handling frame: #{e.full_message}"
+          connection_ended!
+        end
+
+        # Records the current time as the last time any frame was received,
+        # regardless of type. Used by #watchdog_loop to detect a silently
+        # dead connection (data-model.md, INV-2).
+        # @return [void]
+        def touch_received
+          @last_received_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+
+        # Waits for the connection to end: either Slack signals it (a close
+        # frame, a socket error) or no frame of any type has been received for
+        # RECEIVE_TIMEOUT_SECONDS. Waits only until the timeout deadline
+        # computed from @last_received_at rather than on a fixed interval, and
+        # recomputes the remaining time whenever it wakes up without an end
+        # notification, since a frame may have arrived while it was waiting
+        # (research.md R-003). Never writes to the connection (R-002).
+        # @return [void]
+        def watchdog_loop
           until stopped? || @reconnect_requested
-            break if self.class.timed_queue_pop(@connection_ended, PING_INTERVAL_SECONDS)
-            if ping_tick
-              ai_helper_logger.warn "slack: #{MAX_MISSED_PONGS} pongs missed, reconnecting"
+            remaining = RECEIVE_TIMEOUT_SECONDS - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_received_at)
+            if remaining <= 0
+              elapsed = RECEIVE_TIMEOUT_SECONDS - remaining
+              ai_helper_logger.warn "slack: no frame received for #{elapsed.round(1)}s, reconnecting"
               request_reconnect
               break
             end
-            @ws&.send("ping", type: :ping)
+            break if self.class.timed_queue_pop(@connection_ended, remaining)
           end
-        end
-
-        # Counts a sent ping without a pong reply yet. Returns true when the
-        # missed-pong threshold is exceeded and the connection should be
-        # dropped.
-        # @return [Boolean]
-        def ping_tick
-          @missed_pongs += 1
-          @missed_pongs > MAX_MISSED_PONGS
-        end
-
-        # A pong arrived: the connection is healthy.
-        def handle_pong
-          @missed_pongs = 0
-          ai_helper_logger.debug "slack: pong received"
         end
 
         # Asks the listen loop to end so #start reconnects with a fresh URL.
@@ -307,12 +330,28 @@ module RedmineAiHelper
           @connection_ended&.push(true)
         end
 
+        # Closes the current socket, if any, under @send_mutex so the close
+        # frame is serialized against every other send on the connection
+        # (data-model.md C-3.4).
+        # @return [void]
         def close_socket
           socket = @ws
           @ws = nil
-          socket&.close
+          @send_mutex.synchronize { socket&.close }
         rescue IOError, SystemCallError => e
           ai_helper_logger.debug "slack: error while closing socket: #{e.message}"
+        end
+
+        # Sends one frame through +client+, serialized against every other
+        # send on this connection (ack, pong, close) via @send_mutex. The
+        # mutex belongs to the adapter, not the connection, and is reused
+        # across reconnects (data-model.md INV-4).
+        # @param client [WebSocket::Client::Simple::Client, nil] the connection to send on
+        # @param data [String] the frame payload
+        # @param type [Symbol] the frame type
+        # @return [void]
+        def send_frame(client, data, type: :text)
+          @send_mutex.synchronize { client&.send(data, type: type) }
         end
 
         # Returns the current backoff delay and doubles it (capped).
@@ -331,7 +370,7 @@ module RedmineAiHelper
         # Sends the events_api ack immediately so Slack does not resend the
         # event.
         def acknowledge(envelope_id)
-          @ws&.send({ envelope_id: envelope_id }.to_json)
+          send_frame(@ws, { envelope_id: envelope_id }.to_json)
         end
 
         # Converts a Slack event into an IncomingMessage and dispatches it.

--- a/test/unit/chat_channel/adapters/slack_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/slack_adapter_test.rb
@@ -167,19 +167,6 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
       assert_equal 1, @adapter.send(:next_backoff)
     end
 
-    should "request a reconnect after two missed pongs" do
-      assert_not @adapter.send(:ping_tick)
-      assert_not @adapter.send(:ping_tick)
-      assert @adapter.send(:ping_tick)
-    end
-
-    should "reset missed pongs when a pong arrives" do
-      @adapter.send(:ping_tick)
-      @adapter.send(:handle_pong)
-      assert_not @adapter.send(:ping_tick)
-      assert_not @adapter.send(:ping_tick)
-    end
-
     should "log the connection establishment on hello" do
       @adapter.handle_envelope({ "type" => "hello" }.to_json)
 
@@ -202,6 +189,251 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
 
       assert_equal 2, call_count, "adapter must retry after a hello-less clean close"
       assert_equal [ 1 ], slept, "a backoff sleep must happen before the retry"
+    end
+  end
+
+  context "frame handling" do
+    should "update last_received_at to the current monotonic time before dispatching by type" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(12345.0)
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:unknown, nil, nil))
+
+      assert_equal 12345.0, @adapter.instance_variable_get(:@last_received_at)
+      assert_empty client.sent
+    end
+
+    should "still pass text frames to handle_envelope as before" do
+      @adapter.expects(:handle_envelope).with("payload")
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:text, "payload", nil))
+    end
+
+    should "echo a ping's payload back as a pong to the frame's own client" do
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "Ping from applink-2", nil))
+
+      assert_equal [ FakeClient::Sent.new("Ping from applink-2", :pong) ], client.sent
+    end
+
+    should "answer a ping even while @ws is still nil (pre-handshake window)" do
+      assert_nil @adapter.instance_variable_get(:@ws)
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "Ping from applink-2", nil))
+
+      assert_nil @adapter.instance_variable_get(:@ws)
+      assert_equal [ FakeClient::Sent.new("Ping from applink-2", :pong) ], client.sent
+    end
+
+    should "treat an incoming pong frame as a no-op besides updating last_received_at" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(12345.0)
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:pong, nil, nil))
+
+      assert_equal 12345.0, @adapter.instance_variable_get(:@last_received_at)
+      assert_empty client.sent
+    end
+
+    should "notify connection_ended and log the close code for a close frame" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:info).with(regexp_matches(/1000/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:close, nil, 1000))
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "log 'none' instead of a blank code for a close frame without a status code" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:info).with(regexp_matches(/code none/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:close, nil, nil))
+    end
+
+    should "log and notify connection_ended instead of letting an exception escape to the gem" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      client = FakeClient.new
+      client.stubs(:send).raises(IOError, "not opened for writing")
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/not opened for writing/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_nothing_raised do
+        @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "payload", nil))
+      end
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+  end
+
+  context "watchdog_loop" do
+    should "request a reconnect once the receive timeout has elapsed" do
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(131.0)
+
+      @adapter.send(:watchdog_loop)
+
+      assert @adapter.instance_variable_get(:@reconnect_requested)
+    end
+
+    should "log a warning naming the actual elapsed seconds when reconnecting for inactivity" do
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(131.0)
+      logger = mock("logger")
+      logger.expects(:warn).with(regexp_matches(/no frame received for 31\.0s/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:watchdog_loop)
+    end
+
+    should "exit immediately when the connection has already ended, without waiting for the timeout" do
+      @adapter.instance_variable_set(:@last_received_at, Process.clock_gettime(Process::CLOCK_MONOTONIC))
+      queue = Queue.new
+      queue.push(true)
+      @adapter.instance_variable_set(:@connection_ended, queue)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_not @adapter.instance_variable_get(:@reconnect_requested)
+    end
+
+    should "exit immediately without polling the queue when already stopped" do
+      @adapter.instance_variable_set(:@stopped, true)
+      RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.expects(:timed_queue_pop).never
+
+      @adapter.send(:watchdog_loop)
+    end
+
+    should "exit immediately without polling the queue when a reconnect was already requested" do
+      @adapter.instance_variable_set(:@reconnect_requested, true)
+      RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.expects(:timed_queue_pop).never
+
+      @adapter.send(:watchdog_loop)
+    end
+
+    should "recompute the remaining wait when a frame arrives right at the deadline" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(100.0, 120.0)
+      @adapter.instance_variable_set(:@last_received_at, 90.0)
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      remainings = []
+      RedmineAiHelper::ChatChannel::Adapters::SlackAdapter.stubs(:timed_queue_pop).with do |_queue, remaining|
+        remainings << remaining
+        @adapter.instance_variable_set(:@last_received_at, 115.0) if remainings.size == 1
+        true
+      end.returns(nil, true)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_equal [ 20.0, 25.0 ], remainings
+    end
+  end
+
+  context "send_frame" do
+    should "hold send_mutex while sending through the client" do
+      client = FakeClient.new
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      mutex.expects(:synchronize).yields
+
+      @adapter.send(:send_frame, client, "hello", type: :pong)
+
+      assert_equal [ FakeClient::Sent.new("hello", :pong) ], client.sent
+    end
+
+    should "do nothing and raise no exception when the client is nil" do
+      assert_nothing_raised do
+        @adapter.send(:send_frame, nil, "hello")
+      end
+    end
+
+    should "never let two threads send through the client at the same time" do
+      client = ConcurrencyDetectingClient.new
+
+      threads = 5.times.map { |i| Thread.new { @adapter.send(:send_frame, client, "msg#{i}") } }
+      threads.each(&:join)
+
+      assert_not client.overlap_detected
+      assert_equal 5, client.calls.size
+    end
+  end
+
+  context "close_socket" do
+    should "close the socket while holding send_mutex" do
+      ws = mock("ws")
+      ws.expects(:close)
+      @adapter.instance_variable_set(:@ws, ws)
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      mutex.expects(:synchronize).yields
+
+      @adapter.send(:close_socket)
+
+      assert_nil @adapter.instance_variable_get(:@ws)
+    end
+
+    should "swallow IOError raised while closing" do
+      ws = mock("ws")
+      ws.expects(:close).raises(IOError, "closed stream")
+      @adapter.instance_variable_set(:@ws, ws)
+
+      assert_nothing_raised { @adapter.send(:close_socket) }
+    end
+
+    should "swallow SystemCallError raised while closing" do
+      ws = mock("ws")
+      ws.expects(:close).raises(Errno::ECONNRESET)
+      @adapter.instance_variable_set(:@ws, ws)
+
+      assert_nothing_raised { @adapter.send(:close_socket) }
+    end
+
+    should "do nothing when there is no socket to close" do
+      assert_nil @adapter.instance_variable_get(:@ws)
+
+      assert_nothing_raised { @adapter.send(:close_socket) }
+    end
+  end
+
+  context "send_mutex reuse across reconnects (INV-4)" do
+    should "keep the same send_mutex instance across two listen cycles" do
+      ws = mock("ws")
+      ws.stubs(:close)
+      WebSocket::Client::Simple.stubs(:connect).returns(ws)
+      @adapter.stubs(:watchdog_loop)
+      original_mutex = @adapter.instance_variable_get(:@send_mutex)
+
+      @adapter.send(:listen, "wss://one")
+      assert_same original_mutex, @adapter.instance_variable_get(:@send_mutex)
+
+      @adapter.send(:listen, "wss://two")
+      assert_same original_mutex, @adapter.instance_variable_get(:@send_mutex)
+    end
+  end
+
+  context "socket callbacks" do
+    should "log the error and notify connection_ended on socket_errored" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/websocket error/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:socket_errored, StandardError.new("boom"))
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "notify connection_ended on connection_ended!" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+
+      @adapter.send(:connection_ended!)
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
     end
   end
 
@@ -230,6 +462,48 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
     end
   end
 
+  # A stand-in for the WebSocket::Client::Simple::Client the handler block
+  # receives, so tests never need a real socket. Records every frame sent
+  # through it.
+  class FakeClient
+    Sent = Struct.new(:data, :type)
+
+    attr_reader :sent
+
+    def initialize
+      @sent = []
+    end
+
+    def send(data, type: :text)
+      @sent << Sent.new(data, type)
+    end
+  end
+
+  # Doubles for the frames handle_frame receives (#type / #data / #code).
+  FrameStruct = Struct.new(:type, :data, :code)
+
+  # Detects whether two threads ever ran #send concurrently. Only safe as a
+  # plain (unlocked) instance variable *because* that is exactly the property
+  # under test: if send_frame's own @send_mutex serializes calls correctly,
+  # this method's body never actually runs on two threads at once.
+  class ConcurrencyDetectingClient
+    attr_reader :overlap_detected, :calls
+
+    def initialize
+      @busy = false
+      @overlap_detected = false
+      @calls = []
+    end
+
+    def send(data, type: :text) # rubocop:disable Lint/UnusedMethodArgument
+      @overlap_detected ||= @busy
+      @busy = true
+      sleep 0.01
+      @calls << data
+      @busy = false
+    end
+  end
+
   def events_envelope(event, envelope_id: "env-1")
     {
       "type" => "events_api",
@@ -248,7 +522,7 @@ class ChatChannelSlackAdapterTest < ActiveSupport::TestCase
     end
 
     should "ack immediately with the envelope_id" do
-      @ws.expects(:send).with({ envelope_id: "env-42" }.to_json)
+      @ws.expects(:send).with({ envelope_id: "env-42" }.to_json, type: :text)
 
       @adapter.handle_envelope(events_envelope(
         { "type" => "app_mention", "user" => "U123", "channel" => "C123",


### PR DESCRIPTION
## Changes

- Answer Slack's WebSocket ping with a pong on the connection's own client, even before `@ws` is assigned, fixing the 2-minute reconnect loop caused by missed pings during the handshake window
- Replace the self-initiated ping/missed-pong-count liveness check with receive-inactivity monitoring (`watchdog_loop`), reconnecting after 30s without any received frame
- Handle close frames directly and serialize all sends (ack, pong, close) through a per-adapter mutex reused across reconnects
- Log and surface exceptions raised while handling a frame instead of letting them escape into websocket-client-simple unlogged
- Add ADR-012 (scope) and ADR-013 (liveness detection replacement)
- Add test coverage for the mutex-protected close, the watchdog warning log, mutex reuse across reconnects, pong fallthrough, and the socket error/close callbacks