### PR TITLE
Fix the Discord WebSocket transport defects and share the transport with Slack

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/039-slack-socket-mode-stability"
+  "feature_directory": "specs/040-discord-transport-fixes"
 }

--- a/docs/adr/014-shared-websocket-transport-in-base-adapter.md
+++ b/docs/adr/014-shared-websocket-transport-in-base-adapter.md
@@ -1,0 +1,140 @@
+# ADR-014: Move the shared WebSocket transport handling into `BaseAdapter` and apply it to Discord
+
+**Date**: 2026-08-02
+**Status**: Accepted
+
+Supersedes the scope decision of
+[ADR-012](./012-slack-only-scope-for-websocket-transport-fixes.md) ("the fix is
+scoped to the Slack adapter only"). Extends
+[ADR-013](./013-slack-receive-inactivity-liveness-detection.md)
+(receive-inactivity liveness detection) to the Discord adapter. Neither of
+those ADRs is rewritten; both remain the record of what was decided at the
+time.
+
+## Context
+
+ADR-012 knowingly left two latent defects in `DiscordAdapter` — unsynchronized
+concurrent writes to one socket, and slow detection of a silently dead
+connection — and named the condition under which they should be revisited: "if
+a third adapter is added, the third occurrence is the point at which the
+constitution's DRY rule justifies extracting the shared transport handling into
+`BaseAdapter` — this ADR should be superseded then."
+
+No third adapter was added. Instead the user asked, in feature
+`040-discord-transport-fixes`, for the Discord defects to be fixed now and for
+the shared parts to be extracted into `BaseAdapter` at the same time.
+
+Comparing the two adapters while planning that work surfaced a third defect,
+specific to Discord and not covered by ADR-012: `handle_gateway_message` sent
+Identify through `@ws`, but `@ws` is only assigned after
+`WebSocket::Client::Simple.connect` returns, while the receive thread starts
+inside `connect`. Discord's first frame on a new connection is always Hello, so
+a Hello arriving in that window produced an Identify sent to `nil`, which is
+silently dropped — and a gateway that never receives Identify closes the
+connection. The symptom is an occasional failure to connect right after start
+up. Slack had already been given the fix for this shape of problem in feature
+039 (the frame's own client is used as the send target), so the divergence
+ADR-012 accepted had begun to produce exactly the "fixed on one side only"
+asymmetry it predicted.
+
+## Decision
+
+Three decisions are recorded here.
+
+**1. The scope decision of ADR-012 is reversed.** The two latent defects it
+documented are fixed in `DiscordAdapter`, together with the third defect above.
+Discord's liveness detection is switched to receive-inactivity monitoring on
+the terms ADR-013 established for Slack: the bound is the heartbeat interval
+Discord announces in Hello multiplied by 1.5 (about 61.9 seconds at the current
+41.25-second interval, down from a worst case of about 82 seconds), and the
+`@heartbeat_acked` zombie check is deleted. Discord's protocol-mandated
+heartbeat is still sent, but it is no longer an input to the liveness
+judgement: it runs as the monitor loop's scheduled action, so it does not
+introduce a second writing thread.
+
+**2. The shared behaviour is extracted at the second occurrence, not the
+third.** The constitution's DRY rule asks for three similar occurrences before
+extracting. This extraction happens at two, at the user's explicit direction.
+The extracted surface is: frame dispatch with the automatic pong reply
+(`handle_frame`), receive-time recording (`touch_received`), the monitor loop
+(`watchdog_loop`), serialized sending and closing (`send_frame`,
+`close_socket`, `@send_mutex`), connection-end notification
+(`request_reconnect`, `connection_ended!`, `socket_errored`, `fatal_error!`),
+and the stop flag (`stop`, `stopped?`) and reconnect backoff. Subclasses
+override five hooks: `receive_timeout_seconds`, `next_scheduled_action_in`,
+`perform_scheduled_action`, `handle_text_frame` and `handle_close_frame`.
+
+The reconnect loop in `start` is deliberately **not** extracted: the concept of
+an established connection differs per protocol (Slack's `hello` envelope,
+Discord's READY dispatch), and unifying it would only pass branching parameters
+around.
+
+**3. The shared code lives in `BaseAdapter`, not in a separate connection
+object.** The user chose the parent class. It is also where the existing
+`timed_queue_pop` helper — added for exactly this waiting problem in feature
+039 — already sits.
+
+## Consequences
+
+- The two adapters no longer diverge on transport. Serialized sending,
+  receive-inactivity judgement and disconnect detection exist in exactly one
+  place, so a fix to any of them reaches both adapters at once. This removes
+  the asymmetry ADR-012 accepted as a cost.
+- Discord loses three latent defects: interleaved writes can no longer corrupt
+  a frame, a silently dead connection is detected in about 61.9 seconds instead
+  of about 82, and Identify is no longer lost when Hello wins the race against
+  `@ws` being assigned.
+- The shared frame dispatcher classifies the error it catches through the
+  existing `fatal_config_error?` hook. A credential error raised while a frame
+  is being handled therefore terminates the adapter instead of being retried,
+  in both adapters at once — the exact class of divergence this ADR exists to
+  end.
+- `BaseAdapter` now carries state (`@send_mutex`, `@last_received_at`,
+  `@stopped`, `@backoff`) that adapters without a socket never use. That is the
+  blast radius ADR-012 wanted to avoid. It is bounded by construction — the
+  state is inert unless an adapter calls the transport methods — and the
+  in-memory `FakeAdapter` in `base_adapter_test.rb`, which opens no socket,
+  passes unchanged as the standing check that this stays true.
+- Slack's observable behaviour is unchanged: its method names, log wording and
+  constant values are identical, and of the five hooks it implements only
+  `handle_text_frame`, which every WebSocket adapter must implement because the
+  default raises `NotImplementedError`; the other four keep the shared
+  behaviour. The mechanical proof is that
+  `test/unit/chat_channel/adapters/slack_adapter_test.rb`
+  passes without a single character being edited. The shared log lines are
+  built as `"#{channel_type}: ..."`, which reproduces the Slack strings
+  exactly.
+- The shared monitor loop kept Slack's name, `watchdog_loop`, rather than being
+  renamed. A new name would have forced edits to the frozen Slack test file and
+  destroyed that proof.
+- Discord's close-frame log line changes from
+  `"discord: gateway close frame received (code N)"` to
+  `"discord: close frame received (code N)"` for non-fatal codes, which now go
+  through the shared implementation. Fatal codes (4004/4013/4014) keep their
+  own error line and their no-retry classification.
+- A third adapter now inherits working transport instead of copying it.
+
+## Alternatives Considered
+
+- **Keep ADR-012's scope and fix only Discord, duplicating Slack's
+  implementation**: rejected. It would place the same code in two files and
+  recreate the "one side gets fixed, the other does not" failure this feature
+  exists to end — the very outcome that let the Identify race be fixed in Slack
+  and left standing in Discord.
+- **Wait for a third adapter, as ADR-012 proposed**: rejected. The condition
+  was a heuristic for when extraction stops being speculative. With two
+  concrete implementations already written and their differences fully
+  enumerated, the shape of the abstraction is known rather than guessed, and
+  the defects are real today.
+- **Extract into a separate connection object (composition) rather than the
+  parent class**: rejected. It tests slightly more easily without a real
+  socket, but connection-end notification, the stop flag and the backoff are
+  bound up with each adapter's `start` loop; splitting them out adds two-way
+  traffic between adapter and component for no gain. The user chose the parent
+  class.
+- **Include the transport in a module mixed into both adapters**: rejected.
+  Both already inherit from a common parent, so a mixin would add an
+  indirection layer that buys nothing.
+- **Give Discord a dedicated heartbeat thread and keep the monitor loop
+  read-only**: rejected. It would add a second thread writing to the socket,
+  which is precisely the defect being fixed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,5 +64,6 @@ Briefly describe alternatives that were rejected and why.
 | [009](./009-discord-message-content-intent-required.md) | Require the Discord MESSAGE_CONTENT intent in Identify | Accepted |
 | [010](./010-chat-channel-issue-link-rendering.md) | Render issue references as links on the shared gateway send path | Accepted |
 | [011](./011-reset-i18n-locale-between-tests.md) | Reset `I18n.locale` before every test | Accepted |
-| [012](./012-slack-only-scope-for-websocket-transport-fixes.md) | Scope the WebSocket transport fixes to the Slack adapter, leaving the same latent defects in Discord | Accepted |
+| [012](./012-slack-only-scope-for-websocket-transport-fixes.md) | Scope the WebSocket transport fixes to the Slack adapter, leaving the same latent defects in Discord | Accepted (scope decision superseded by ADR-014) |
 | [013](./013-slack-receive-inactivity-liveness-detection.md) | Replace Slack's self-initiated ping/pong-count liveness check with receive-inactivity monitoring | Accepted |
+| [014](./014-shared-websocket-transport-in-base-adapter.md) | Move the shared WebSocket transport handling into `BaseAdapter` and apply it to Discord | Accepted |

--- a/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/discord_adapter.rb
@@ -54,8 +54,6 @@ module RedmineAiHelper
         GATEWAY_QUERY_STRING = "v=10&encoding=json"
         # Open/read timeout for every REST call (contract: 10 seconds).
         HTTP_TIMEOUT_SECONDS = 10
-        # Upper bound of the exponential reconnect backoff.
-        MAX_BACKOFF_SECONDS = 60
         # Replies longer than this are split before posting (Discord's hard
         # limit is 2,000; 1,900 leaves headroom).
         MAX_MESSAGE_LENGTH = 1900
@@ -72,6 +70,13 @@ module RedmineAiHelper
         # Poll interval while waiting for the Hello opcode that carries the
         # real heartbeat interval.
         HELLO_WAIT_SECONDS = 1
+        # The connection counts as dead once nothing has been received for
+        # this multiple of the announced heartbeat interval. 1.5 tolerates one
+        # completely missed heartbeat round trip without tearing down a
+        # healthy connection, and still detects silence within about 61.9
+        # seconds at Discord's current interval of 41.25 seconds (research.md
+        # R-004).
+        RECEIVE_TIMEOUT_FACTOR = 1.5
         # Channel types that are threads (announcement, public, private).
         THREAD_CHANNEL_TYPES = [ 10, 11, 12 ].freeze
         # Message types this integration reacts to: DEFAULT and REPLY.
@@ -132,22 +137,19 @@ module RedmineAiHelper
 
         def initialize
           super
-          @stopped = false
           @reconnect_requested = false
           @connected = false
-          @backoff = 1
-          @heartbeat_acked = true
           @reply_targets = {}
         end
 
         # Connects to the Discord gateway and blocks while receiving events.
-        # Reconnects on Reconnect/Invalid Session opcodes, on missed heartbeat
-        # acks (zombie connection), on socket errors and on clean closes that
-        # never reached READY (all with exponential backoff). Authentication
+        # Reconnects on Reconnect/Invalid Session opcodes, on receive
+        # inactivity, on socket errors and on clean closes that never reached
+        # READY (the last two with exponential backoff). Authentication
         # failures (REST 401, close 4004/4013/4014) terminate without retry.
         # @return [void]
         def start
-          @stopped = false
+          clear_stop_flag
           @bot_user_id = fetch_bot_user_id
           ai_helper_logger.info "discord: starting gateway connection (bot user #{@bot_user_id})"
           until stopped?
@@ -170,34 +172,33 @@ module RedmineAiHelper
           ai_helper_logger.info "discord: adapter stopped"
         end
 
-        # Closes the connection and lets #start return.
-        # @return [void]
-        def stop
-          @stopped = true
-          @connection_ended&.push(true)
-          close_socket
-        end
-
         # Whether READY has been received on the current socket.
         # @return [Boolean]
         def connected?
           @connected
         end
 
-        # Handles one raw gateway payload (JSON text frame).
+        # Handles one raw gateway payload (JSON text frame). Answers go to
+        # +client+, the connection the payload arrived on, never to @ws: the
+        # first frame of a connection is Hello, and @ws is still nil while it
+        # is being handled (INV-6).
+        # @param client [WebSocket::Client::Simple::Client] the connection the payload arrived on
         # @param raw [String] the raw JSON payload
         # @return [void]
-        def handle_gateway_message(raw)
+        def handle_gateway_message(client, raw)
           payload = JSON.parse(raw)
           @last_sequence = payload["s"] if payload["s"]
           case payload["op"]
           when OP_HELLO
             @heartbeat_interval = payload.dig("d", "heartbeat_interval").to_f / 1000.0
-            send_identify
+            @next_heartbeat_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @heartbeat_interval
+            send_identify(client)
           when OP_HEARTBEAT
-            send_heartbeat
+            send_heartbeat(client)
           when OP_HEARTBEAT_ACK
-            @heartbeat_acked = true
+            # Nothing to do: an ack matters only as a received frame, which
+            # the shared handler already recorded. Its content is unused, and
+            # the branch exists so an ack is not logged as an unknown opcode.
           when OP_RECONNECT, OP_INVALID_SESSION
             ai_helper_logger.info "discord: reconnect requested by gateway (op #{payload["op"]})"
             request_reconnect
@@ -211,17 +212,15 @@ module RedmineAiHelper
         end
 
         # Reacts to a gateway close frame, capturing fatal authentication
-        # close codes so #start can terminate without retry.
+        # close codes so #start can terminate without retry. Every other code
+        # is an ordinary close and is left to the shared implementation.
         # @param code [Integer, nil] the WebSocket close code
         # @return [void]
         def handle_close_frame(code)
-          if FATAL_CLOSE_CODES.include?(code)
-            @fatal_close = DiscordApiError.new("Discord gateway closed with fatal code #{code}")
-            ai_helper_logger.error "discord: gateway closed with fatal code #{code}"
-          else
-            ai_helper_logger.info "discord: gateway close frame received (code #{code})"
-          end
-          @connection_ended&.push(true)
+          return super unless FATAL_CLOSE_CODES.include?(code)
+
+          ai_helper_logger.error "discord: gateway closed with fatal code #{code}"
+          fatal_error!(DiscordApiError.new("Discord gateway closed with fatal code #{code}"))
         end
 
         # Posts a reply to the destination encoded in the thread_key, splitting
@@ -305,12 +304,6 @@ module RedmineAiHelper
 
         private
 
-        # Whether #stop has been called.
-        # @return [Boolean]
-        def stopped?
-          @stopped
-        end
-
         # Fetches the bot's own user id and validates the bot token.
         # @return [String]
         def fetch_bot_user_id
@@ -333,71 +326,87 @@ module RedmineAiHelper
           @reconnect_requested = false
           @connected = false
           @heartbeat_interval = nil
-          @heartbeat_acked = true
+          @next_heartbeat_at = nil
           @last_sequence = nil
           @fatal_close = nil
+          touch_received
           adapter = self
           @ws = WebSocket::Client::Simple.connect("#{url}?#{GATEWAY_QUERY_STRING}") do |ws|
-            ws.on(:message) do |msg|
-              case msg.type
-              when :text  then adapter.send(:handle_gateway_message, msg.data)
-              when :close then adapter.send(:handle_close_frame, msg.code)
-              end
-            end
+            ws.on(:message) { |msg| adapter.send(:handle_frame, ws, msg) }
             ws.on(:close) { |_error| adapter.send(:connection_ended!) }
             ws.on(:error) { |error| adapter.send(:socket_errored, error) }
           end
-          heartbeat_loop
-          raise @fatal_close if @fatal_close
+          watchdog_loop
+          raise_fatal_error!
         ensure
           close_socket
         end
 
-        # Sends heartbeats on the interval announced in Hello. A heartbeat
-        # whose ack never arrived before the next tick is a zombie connection
-        # and forces a reconnect.
-        # @return [void]
-        def heartbeat_loop
-          until stopped? || @reconnect_requested
-            wait = @heartbeat_interval || HELLO_WAIT_SECONDS
-            break if self.class.timed_queue_pop(@connection_ended, wait)
-            next if @heartbeat_interval.nil?
+        # The gateway counts as dead once nothing at all has arrived for one
+        # and a half heartbeat intervals. Before Hello announces the interval
+        # the shared default applies, which is why this is re-read on every
+        # pass of the watchdog rather than computed once.
+        # @return [Numeric] seconds of silence that end the connection
+        def receive_timeout_seconds
+          return super unless @heartbeat_interval
 
-            unless @heartbeat_acked
-              ai_helper_logger.warn "discord: heartbeat not acknowledged; reconnecting (zombie connection)"
-              request_reconnect
-              break
-            end
-            @heartbeat_acked = false
-            send_heartbeat
-          end
+          @heartbeat_interval * RECEIVE_TIMEOUT_FACTOR
+        end
+
+        # Seconds until the next heartbeat is due, or the Hello poll interval
+        # while the heartbeat interval is still unknown.
+        # @return [Numeric]
+        def next_scheduled_action_in
+          return HELLO_WAIT_SECONDS unless @heartbeat_interval
+
+          @next_heartbeat_at - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+
+        # Sends the heartbeat Discord requires when its scheduled time has
+        # come. The next time is counted from now, so waking up early for the
+        # receive deadline never shifts the heartbeat rhythm (INV-7). Nothing
+        # is sent once #stop has run: @ws is read outside the send mutex, so
+        # writing during a shutdown would only produce an IOError on the socket
+        # #stop has just closed.
+        # @return [void]
+        def perform_scheduled_action
+          return if stopped?
+          return unless @heartbeat_interval
+          return if Process.clock_gettime(Process::CLOCK_MONOTONIC) < @next_heartbeat_at
+
+          # The watchdog only starts after connect returned, so @ws is set.
+          send_heartbeat(@ws)
+          @next_heartbeat_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @heartbeat_interval
+        end
+
+        # Parses one gateway text frame.
+        # @param client [WebSocket::Client::Simple::Client] the connection the frame arrived on
+        # @param data [String] the frame payload
+        # @return [void]
+        def handle_text_frame(client, data)
+          handle_gateway_message(client, data)
         end
 
         # Sends the Identify payload. Discord closes the connection with 4014
         # when MESSAGE_CONTENT is requested but not enabled for the app.
+        # @param client [WebSocket::Client::Simple::Client] the connection to identify on
         # @return [void]
-        def send_identify
-          send_json(
+        def send_identify(client)
+          send_frame(client, {
             op: OP_IDENTIFY,
             d: {
               token: settings.bot_token,
               intents: GATEWAY_INTENTS,
               properties: { os: "linux", browser: "redmine_ai_helper", device: "redmine_ai_helper" }
             }
-          )
+          }.to_json)
         end
 
         # Sends a heartbeat carrying the last received sequence number.
+        # @param client [WebSocket::Client::Simple::Client] the connection to send on
         # @return [void]
-        def send_heartbeat
-          send_json(op: OP_HEARTBEAT, d: @last_sequence)
-        end
-
-        # Serializes and sends a gateway payload over the socket.
-        # @param payload [Hash] the gateway payload
-        # @return [void]
-        def send_json(payload)
-          @ws&.send(payload.to_json)
+        def send_heartbeat(client)
+          send_frame(client, { op: OP_HEARTBEAT, d: @last_sequence }.to_json)
         end
 
         # Dispatches a gateway dispatch event (opcode 0).
@@ -619,51 +628,6 @@ module RedmineAiHelper
           else
             [ thread_key.split(":", 2).last, nil ]
           end
-        end
-
-        # Asks the receive loop to end so #start reconnects with a fresh URL.
-        # @return [void]
-        def request_reconnect
-          @reconnect_requested = true
-          @connection_ended&.push(true)
-        end
-
-        # The socket was closed by the remote side.
-        # @return [void]
-        def connection_ended!
-          @connection_ended&.push(true)
-        end
-
-        # A socket error occurred; end the connection so #start can retry.
-        # @param error [Exception] the socket error
-        # @return [void]
-        def socket_errored(error)
-          ai_helper_logger.error "discord: websocket error: #{error.full_message}"
-          @connection_ended&.push(true)
-        end
-
-        # Closes the socket, ignoring the usual close-time IO errors.
-        # @return [void]
-        def close_socket
-          socket = @ws
-          @ws = nil
-          socket&.close
-        rescue IOError, SystemCallError => e
-          ai_helper_logger.debug "discord: error while closing socket: #{e.message}"
-        end
-
-        # Returns the current backoff delay and doubles it (capped).
-        # @return [Integer] seconds to wait
-        def next_backoff
-          current = @backoff
-          @backoff = [ @backoff * 2, MAX_BACKOFF_SECONDS ].min
-          current
-        end
-
-        # Resets the backoff after a successful connection.
-        # @return [void]
-        def reset_backoff
-          @backoff = 1
         end
 
         # Creates a thread from the question message. Returns the thread id

--- a/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/adapters/slack_adapter.rb
@@ -23,11 +23,6 @@ module RedmineAiHelper
         SLACK_API_BASE = "https://slack.com/api"
         # Open/read timeout for every Web API call (contract: 10 seconds).
         HTTP_TIMEOUT_SECONDS = 10
-        # Upper bound of the exponential reconnect backoff.
-        MAX_BACKOFF_SECONDS = 60
-        # Reconnect when no frame of any type has been received for this long
-        # (research.md R-002: receive-inactivity replaces the client-ping count).
-        RECEIVE_TIMEOUT_SECONDS = 30
         # Replies longer than this are split before posting (research.md R-008).
         MAX_MESSAGE_LENGTH = 3900
         # Messages requested per history page (Slack's maximum for a full page).
@@ -62,13 +57,9 @@ module RedmineAiHelper
 
         def initialize
           super
-          @stopped = false
           @reconnect_requested = false
           @connected = false
-          @backoff = 1
           @display_names = {}
-          @send_mutex = Mutex.new
-          @last_received_at = 0.0
         end
 
         # Connects to Slack and blocks while receiving events. Reconnects on
@@ -80,7 +71,7 @@ module RedmineAiHelper
         # API) terminate without retry.
         # @return [void]
         def start
-          @stopped = false
+          clear_stop_flag
           @bot_user_id = fetch_bot_user_id
           ai_helper_logger.info "slack: starting Socket Mode connection (bot user #{@bot_user_id})"
           until stopped?
@@ -101,14 +92,6 @@ module RedmineAiHelper
             end
           end
           ai_helper_logger.info "slack: adapter stopped"
-        end
-
-        # Closes the connection and lets #start return.
-        # @return [void]
-        def stop
-          @stopped = true
-          @connection_ended&.push(true)
-          close_socket
         end
 
         # Whether the hello envelope has been received on the current socket.
@@ -213,11 +196,6 @@ module RedmineAiHelper
 
         private
 
-        # Whether #stop has been called.
-        def stopped?
-          @stopped
-        end
-
         # Fetches the bot's own user id and validates the bot token. The bot id
         # is kept as well: the gateway's own posts appear in the history with a
         # bot_id rather than a user id.
@@ -237,11 +215,13 @@ module RedmineAiHelper
         end
 
         # Connects the WebSocket and blocks until the connection ends, a
-        # reconnect is requested, or the adapter is stopped.
+        # reconnect is requested, or the adapter is stopped. Re-raises a fatal
+        # credential error captured on the receive thread.
         def listen(url)
           @connection_ended = Queue.new
           @reconnect_requested = false
           @connected = false
+          @fatal_close = nil
           touch_received
           adapter = self
           @ws = WebSocket::Client::Simple.connect(url) do |ws|
@@ -250,126 +230,30 @@ module RedmineAiHelper
             ws.on(:error) { |error| adapter.send(:socket_errored, error) }
           end
           watchdog_loop
+          raise_fatal_error!
         ensure
           close_socket
         end
 
-        # Dispatches one received WebSocket frame by type. Runs on the
-        # connection's receive thread. +client+ comes from the block
-        # WebSocket::Client::Simple yields, not @ws: assigning @ws happens only
-        # after #connect returns, so a frame arriving in that short window
-        # would otherwise be unanswerable (research.md R-001).
-        # @param client [WebSocket::Client::Simple::Client] the connection the frame arrived on
-        # @param msg [#type, #data, #code] the received frame
+        # Hands one Socket Mode text frame to the envelope dispatcher. Slack
+        # answers only events_api envelopes, and those arrive long after the
+        # handshake, so this adapter never has to answer inside the window in
+        # which @ws is still nil (C-1.7): its ack goes through @ws as before
+        # (C-7.5), and the frame's own client is not needed here.
+        # @param _client [WebSocket::Client::Simple::Client] the connection the frame arrived on
+        # @param raw [String] the raw JSON payload
         # @return [void]
-        def handle_frame(client, msg)
-          touch_received
-          case msg.type
-          when :ping
-            # RFC 6455: a pong must carry the ping's application data verbatim.
-            # No validation, transformation or discarding of the payload.
-            send_frame(client, msg.data, type: :pong)
-          when :text
-            handle_envelope(msg.data)
-          when :close
-            ai_helper_logger.info "slack: close frame received (code #{msg.code || "none"})"
-            connection_ended!
-          end
-        rescue => e
-          # Runs on websocket-client-simple's receive thread: without this
-          # rescue an exception (e.g. a write failure while sending the pong)
-          # would escape into the gem's own handler and never reach
-          # ai_helper_logger, making the failure invisible.
-          ai_helper_logger.error "slack: error while handling frame: #{e.full_message}"
-          connection_ended!
-        end
-
-        # Records the current time as the last time any frame was received,
-        # regardless of type. Used by #watchdog_loop to detect a silently
-        # dead connection (data-model.md, INV-2).
-        # @return [void]
-        def touch_received
-          @last_received_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        end
-
-        # Waits for the connection to end: either Slack signals it (a close
-        # frame, a socket error) or no frame of any type has been received for
-        # RECEIVE_TIMEOUT_SECONDS. Waits only until the timeout deadline
-        # computed from @last_received_at rather than on a fixed interval, and
-        # recomputes the remaining time whenever it wakes up without an end
-        # notification, since a frame may have arrived while it was waiting
-        # (research.md R-003). Never writes to the connection (R-002).
-        # @return [void]
-        def watchdog_loop
-          until stopped? || @reconnect_requested
-            remaining = RECEIVE_TIMEOUT_SECONDS - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_received_at)
-            if remaining <= 0
-              elapsed = RECEIVE_TIMEOUT_SECONDS - remaining
-              ai_helper_logger.warn "slack: no frame received for #{elapsed.round(1)}s, reconnecting"
-              request_reconnect
-              break
-            end
-            break if self.class.timed_queue_pop(@connection_ended, remaining)
-          end
-        end
-
-        # Asks the listen loop to end so #start reconnects with a fresh URL.
-        def request_reconnect
-          @reconnect_requested = true
-          @connection_ended&.push(true)
-        end
-
-        # The socket was closed by the remote side.
-        def connection_ended!
-          @connection_ended&.push(true)
-        end
-
-        # A socket error occurred; end the connection so #start can retry.
-        def socket_errored(error)
-          ai_helper_logger.error "slack: websocket error: #{error.full_message}"
-          @connection_ended&.push(true)
-        end
-
-        # Closes the current socket, if any, under @send_mutex so the close
-        # frame is serialized against every other send on the connection
-        # (data-model.md C-3.4).
-        # @return [void]
-        def close_socket
-          socket = @ws
-          @ws = nil
-          @send_mutex.synchronize { socket&.close }
-        rescue IOError, SystemCallError => e
-          ai_helper_logger.debug "slack: error while closing socket: #{e.message}"
-        end
-
-        # Sends one frame through +client+, serialized against every other
-        # send on this connection (ack, pong, close) via @send_mutex. The
-        # mutex belongs to the adapter, not the connection, and is reused
-        # across reconnects (data-model.md INV-4).
-        # @param client [WebSocket::Client::Simple::Client, nil] the connection to send on
-        # @param data [String] the frame payload
-        # @param type [Symbol] the frame type
-        # @return [void]
-        def send_frame(client, data, type: :text)
-          @send_mutex.synchronize { client&.send(data, type: type) }
-        end
-
-        # Returns the current backoff delay and doubles it (capped).
-        # @return [Integer] seconds to wait
-        def next_backoff
-          current = @backoff
-          @backoff = [ @backoff * 2, MAX_BACKOFF_SECONDS ].min
-          current
-        end
-
-        # Resets the backoff after a successful connection.
-        def reset_backoff
-          @backoff = 1
+        def handle_text_frame(_client, raw)
+          handle_envelope(raw)
         end
 
         # Sends the events_api ack immediately so Slack does not resend the
-        # event.
+        # event. Nothing is sent once #stop has run: @ws is read outside the
+        # send mutex, so writing during a shutdown would only produce an
+        # IOError on the socket #stop has just closed.
         def acknowledge(envelope_id)
+          return if stopped?
+
           send_frame(@ws, { envelope_id: envelope_id }.to_json)
         end
 

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -14,6 +14,13 @@ module RedmineAiHelper
     class BaseAdapter
       include RedmineAiHelper::Logger
 
+      # Reconnect when no frame of any type has been received for this long.
+      # Adapters that can derive a better bound from the protocol override
+      # #receive_timeout_seconds (contract C-2).
+      DEFAULT_RECEIVE_TIMEOUT_SECONDS = 30
+      # Upper bound of the exponential reconnect backoff.
+      MAX_BACKOFF_SECONDS = 60
+
       class << self
         # Adapter subclasses collected by the inherited hook. channel_type is
         # resolved lazily in .adapters because it is not yet defined when
@@ -76,6 +83,23 @@ module RedmineAiHelper
       # @return [Gateway, nil]
       attr_accessor :dispatcher
 
+      # Initializes the state every adapter carries for its whole lifetime.
+      # The send mutex belongs to the adapter rather than to one connection: it
+      # must survive a reconnect so a close frame on the old socket cannot
+      # overlap a send on the new one (INV-4). The last receive time is reset
+      # per connection by #touch_received, but it lives here so an adapter that
+      # never connects still has a defined value. Adapters that do not open a
+      # socket simply never use either of them (INV-8).
+      # @return [void]
+      def initialize
+        @stopped = false
+        @backoff = 1
+        @send_mutex = Mutex.new
+        # Not "now": never having received a frame must count as stale, so the
+        # monitor loop reconnects instead of waiting out a full timeout (INV-1).
+        @last_received_at = 0.0
+      end
+
       # The tool-independent message handler bound to this adapter.
       # @return [MessageHandler]
       def handler
@@ -125,10 +149,15 @@ module RedmineAiHelper
         raise NotImplementedError, "#{self.class.name} must implement #start"
       end
 
-      # Closes the connection and lets #start return.
+      # Closes the connection and lets #start return: raises the stop flag,
+      # wakes the monitor loop and closes the socket under the send mutex
+      # (C-5.5). Adapters that hold no socket inherit this unchanged - the
+      # close is a no-op when @ws was never assigned (C-3.8 / INV-8).
       # @return [void]
       def stop
-        raise NotImplementedError, "#{self.class.name} must implement #stop"
+        @stopped = true
+        connection_ended!
+        close_socket
       end
 
       # Posts a reply into the given thread.
@@ -206,6 +235,208 @@ module RedmineAiHelper
       # @return [Boolean]
       def fatal_config_error?(_error)
         false
+      end
+
+      protected
+
+      # Dispatches one received WebSocket frame by type. Runs on the
+      # connection's receive thread, so no exception may escape into the
+      # gem's own handler where it would never reach ai_helper_logger.
+      # +client+ is the connection the frame arrived on rather than the
+      # adapter's @ws, which is assigned only after
+      # WebSocket::Client::Simple.connect returns: a frame arriving in that
+      # short window would otherwise be unanswerable (INV-6).
+      # @param client [WebSocket::Client::Simple::Client] the connection the frame arrived on
+      # @param msg [#type, #data, #code] the received frame
+      # @return [void]
+      def handle_frame(client, msg)
+        touch_received
+        case msg.type
+        when :ping
+          # RFC 6455: a pong must carry the ping's application data verbatim.
+          # No validation, transformation or discarding of the payload.
+          send_frame(client, msg.data, type: :pong)
+        when :text
+          handle_text_frame(client, msg.data)
+        when :close
+          handle_close_frame(msg.code)
+        end
+      rescue => e
+        ai_helper_logger.error "#{channel_type}: error while handling frame: #{e.full_message}"
+        # A credential error must not be turned into a reconnect: #start would
+        # see an established connection, skip the backoff and retry into the
+        # same broken credentials forever. It is carried over to the connecting
+        # thread instead, which raises it out of #start (C-1.9 / ADR-006).
+        if fatal_config_error?(e)
+          fatal_error!(e)
+        else
+          connection_ended!
+        end
+      end
+
+      # Handles one text frame in the adapter's own protocol.
+      # @param _client [WebSocket::Client::Simple::Client] the connection the frame arrived on
+      # @param _data [String] the frame payload
+      # @return [void]
+      def handle_text_frame(_client, _data)
+        raise NotImplementedError, "#{self.class.name} must implement #handle_text_frame"
+      end
+
+      # Reacts to a close frame. Adapters that classify close codes override
+      # this and delegate the common part back here with super.
+      # @param code [Integer, nil] the WebSocket close code
+      # @return [void]
+      def handle_close_frame(code)
+        ai_helper_logger.info "#{channel_type}: close frame received (code #{code || "none"})"
+        connection_ended!
+      end
+
+      # Records the current time as the last time any frame was received,
+      # regardless of type (INV-2).
+      # @return [void]
+      def touch_received
+        @last_received_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      # Waits for the connection to end: either the remote side signals it (a
+      # close frame, a socket error) or no frame of any type has been received
+      # within #receive_timeout_seconds. Liveness is judged only by what
+      # arrives, never by counting answers to something this loop sent
+      # (ADR-013, extended to every adapter by ADR-014). Waits until the
+      # earlier of the receive deadline and the next scheduled action, and
+      # recomputes both whenever it wakes up without an end notification, since
+      # a frame may have arrived while it was waiting.
+      # @return [void]
+      def watchdog_loop
+        until stopped? || @reconnect_requested
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          elapsed = now - @last_received_at
+          remaining = receive_timeout_seconds - elapsed
+          if remaining <= 0
+            ai_helper_logger.warn "#{channel_type}: no frame received for #{elapsed.round(1)}s, reconnecting"
+            request_reconnect
+            break
+          end
+          # compact drops the nil #next_scheduled_action_in returns when the
+          # adapter has nothing scheduled, leaving the receive deadline alone.
+          wait = [ remaining, next_scheduled_action_in ].compact.min
+          break if self.class.timed_queue_pop(@connection_ended, wait)
+
+          perform_scheduled_action
+        end
+      end
+
+      # Seconds without any received frame after which the connection counts
+      # as dead. Evaluated on every pass of #watchdog_loop, so an adapter may
+      # return a value that only becomes known mid-connection.
+      # @return [Numeric]
+      def receive_timeout_seconds
+        DEFAULT_RECEIVE_TIMEOUT_SECONDS
+      end
+
+      # Seconds until the adapter's next scheduled action, or nil when it has
+      # none. Bounds how long #watchdog_loop sleeps in one go.
+      # @return [Numeric, nil]
+      def next_scheduled_action_in
+        nil
+      end
+
+      # Runs the adapter's scheduled action, if any. Called by
+      # #watchdog_loop whenever a wait ends without the connection ending.
+      # @return [void]
+      def perform_scheduled_action
+        # Adapters with nothing to send on a schedule leave this empty.
+      end
+
+      # Sends one frame through +client+, serialized against every other send
+      # on this connection via @send_mutex (INV-3).
+      # @param client [WebSocket::Client::Simple::Client, nil] the connection to send on
+      # @param data [String] the frame payload
+      # @param type [Symbol] the frame type
+      # @return [void]
+      def send_frame(client, data, type: :text)
+        @send_mutex.synchronize { client&.send(data, type: type) }
+      end
+
+      # Closes the current socket, if any, under @send_mutex so the close
+      # frame is serialized against every other send on the connection (C-3.4),
+      # and ignoring the usual close-time IO errors.
+      # @return [void]
+      def close_socket
+        socket = @ws
+        @ws = nil
+        @send_mutex.synchronize { socket&.close }
+      rescue IOError, SystemCallError => e
+        ai_helper_logger.debug "#{channel_type}: error while closing socket: #{e.message}"
+      end
+
+      # Asks the listen loop to end so #start reconnects with a fresh URL.
+      # @return [void]
+      def request_reconnect
+        @reconnect_requested = true
+        connection_ended!
+      end
+
+      # Signals that this connection is over, whatever the reason (a close
+      # frame, a socket error, a requested reconnect, #stop): the monitor loop
+      # stops waiting and #listen returns.
+      # @return [void]
+      def connection_ended!
+        @connection_ended&.push(true)
+      end
+
+      # Records an error that must terminate the adapter instead of leading to
+      # a reconnect, and ends the connection. The receive thread cannot raise
+      # into #start - the WebSocket gem would swallow the exception - so the
+      # error is carried across through @fatal_close (C-1.9 / C-6.5.1).
+      # @param error [Exception] the fatal error
+      # @return [void]
+      def fatal_error!(error)
+        @fatal_close = error
+        connection_ended!
+      end
+
+      # Re-raises the error captured by #fatal_error!, if any. Called by
+      # #listen after the monitor loop returns, so the error reaches #start on
+      # the connecting thread and terminates it without a retry (C-6.5.3).
+      # @return [void]
+      def raise_fatal_error!
+        raise @fatal_close if @fatal_close
+      end
+
+      # A socket error occurred; end the connection so #start can retry.
+      # @param error [Exception] the socket error
+      # @return [void]
+      def socket_errored(error)
+        ai_helper_logger.error "#{channel_type}: websocket error: #{error.full_message}"
+        connection_ended!
+      end
+
+      # Whether #stop has been called.
+      # @return [Boolean]
+      def stopped?
+        @stopped
+      end
+
+      # Clears the stop flag so a stopped adapter can be started again. Called
+      # at the top of #start; the flag itself is owned by BaseAdapter (C-5.1).
+      # @return [void]
+      def clear_stop_flag
+        @stopped = false
+      end
+
+      # Returns the current backoff delay and doubles it (capped).
+      # @return [Integer] seconds to wait
+      def next_backoff
+        current = @backoff
+        @backoff = [ @backoff * 2, MAX_BACKOFF_SECONDS ].min
+        current
+      end
+
+      # Resets the backoff after a successful connection.
+      # @return [void]
+      def reset_backoff
+        @backoff = 1
       end
     end
   end

--- a/test/unit/chat_channel/adapters/discord_adapter_test.rb
+++ b/test/unit/chat_channel/adapters/discord_adapter_test.rb
@@ -21,6 +21,62 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
     @adapter.instance_variable_set(:@bot_user_id, "BOT")
   end
 
+  # A stand-in for the WebSocket::Client::Simple::Client the handler block
+  # receives, so tests never need a real socket. Records every frame sent
+  # through it.
+  class FakeClient
+    Sent = Struct.new(:data, :type)
+
+    attr_reader :sent
+
+    def initialize
+      @sent = []
+    end
+
+    def send(data, type: :text)
+      @sent << Sent.new(data, type)
+    end
+  end
+
+  # Detects whether two threads ever ran #send concurrently. Only safe as a
+  # plain (unlocked) instance variable *because* that is exactly the property
+  # under test: if the shared send mutex serializes calls correctly, this
+  # method's body never actually runs on two threads at once.
+  #
+  # Detection is best effort: it can only observe an overlap the scheduler
+  # actually produces. The window is widened deliberately (repeated Thread.pass
+  # plus a sleep, both of which release the GVL) so an unserialized caller has
+  # many chances to enter. The structural guarantee is asserted separately by
+  # the test that expects @send_mutex#synchronize to be held.
+  class ConcurrencyDetectingClient
+    # How long #send stays inside its critical section. Long enough that a
+    # thread waiting on the GVL is scheduled into it if nothing excludes it.
+    BUSY_SECONDS = 0.005
+
+    attr_reader :overlap_detected, :calls
+
+    def initialize
+      @busy = false
+      @overlap_detected = false
+      @calls = []
+    end
+
+    def send(data, type: :text) # rubocop:disable Lint/UnusedMethodArgument
+      @overlap_detected ||= @busy
+      @busy = true
+      @calls << data
+      5.times { Thread.pass }
+      sleep BUSY_SECONDS
+      # A cleared flag means another call ran to completion inside this one,
+      # which catches an overlap the check on entry could still have missed.
+      @overlap_detected ||= !@busy
+      @busy = false
+    end
+  end
+
+  # Doubles for the frames handle_frame receives (#type / #data / #code).
+  FrameStruct = Struct.new(:type, :data, :code)
+
   # Records messages dispatched by the adapter in place of the gateway.
   class RecordingDispatcher
     attr_reader :messages
@@ -191,7 +247,7 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
     end
 
     should "connect the websocket with the required v and encoding query params" do
-      @adapter.stubs(:heartbeat_loop)
+      @adapter.stubs(:watchdog_loop)
       ws = mock("ws")
       ws.stubs(:on)
       ws.stubs(:close)
@@ -220,13 +276,54 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
     should "terminate #start without retry when the gateway closes with a fatal code" do
       @adapter.stubs(:fetch_bot_user_id).returns("B1")
       @adapter.expects(:gateway_url).once.returns("wss://gw")
-      @adapter.stubs(:heartbeat_loop).with { @adapter.send(:handle_close_frame, 4004); true }
+      @adapter.stubs(:watchdog_loop).with { @adapter.send(:handle_close_frame, 4004); true }
       ws = mock("ws")
       ws.stubs(:on)
       ws.stubs(:close)
       WebSocket::Client::Simple.stubs(:connect).returns(ws)
 
       assert_raises(DiscordApiError) { @adapter.start }
+    end
+
+    should "C-1.9: terminate #start without retry when a fatal API error escapes frame handling" do
+      # A token revoked mid-session makes the REST call that resolves the
+      # channel raise. The error must not be turned into an immediate,
+      # unthrottled reconnect: it terminates the adapter (ADR-006).
+      @adapter.stubs(:fetch_bot_user_id).returns("B1")
+      @adapter.expects(:gateway_url).once.returns("wss://gw")
+      @adapter.stubs(:fetch_channel).raises(DiscordApiError, "unauthorized")
+      ws = mock("ws")
+      ws.stubs(:on)
+      ws.stubs(:close)
+      WebSocket::Client::Simple.stubs(:connect).returns(ws)
+      frame = FrameStruct.new(:text, {
+        op: DiscordAdapter::OP_DISPATCH, t: "MESSAGE_CREATE",
+        d: guild_message(content: "<@B1> hello")
+      }.to_json, nil)
+      @adapter.stubs(:watchdog_loop).with { @adapter.send(:handle_frame, ws, frame); true }
+
+      assert_raises(DiscordApiError) { @adapter.start }
+    end
+
+    should "C-1.9: record a DiscordApiError escaping frame handling as the fatal close" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      @adapter.stubs(:handle_gateway_message).raises(DiscordApiError, "unauthorized")
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:text, "{}", nil))
+
+      assert_kind_of DiscordApiError, @adapter.instance_variable_get(:@fatal_close)
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "C-1.9: leave a transient error escaping frame handling non-fatal" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      @adapter.stubs(:handle_gateway_message).raises(DiscordRequestError.new("HTTP 500", status: 500))
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:text, "{}", nil))
+
+      assert_nil @adapter.instance_variable_get(:@fatal_close),
+                 "a transient REST failure must not terminate the adapter"
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
     end
 
     should "store the heartbeat interval and send Identify on Hello" do
@@ -239,7 +336,7 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       end
       @adapter.instance_variable_set(:@ws, ws)
 
-      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_HELLO, d: { heartbeat_interval: 41250 } }.to_json)
+      @adapter.handle_gateway_message(ws, { op: DiscordAdapter::OP_HELLO, d: { heartbeat_interval: 41250 } }.to_json)
 
       assert_in_delta 41.25, @adapter.instance_variable_get(:@heartbeat_interval), 0.001
     end
@@ -247,7 +344,7 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
     should "mark connected and reset the backoff on READY" do
       3.times { @adapter.send(:next_backoff) }
 
-      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_DISPATCH, t: "READY", s: 1, d: { "user" => { "id" => "B1" } } }.to_json)
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_DISPATCH, t: "READY", s: 1, d: { "user" => { "id" => "B1" } } }.to_json)
 
       assert_predicate @adapter, :connected?
       assert_equal 1, @adapter.send(:next_backoff)
@@ -259,15 +356,32 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       @adapter.instance_variable_set(:@ws, ws)
       @adapter.instance_variable_set(:@last_sequence, 7)
 
-      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_HEARTBEAT }.to_json)
+      @adapter.handle_gateway_message(ws, { op: DiscordAdapter::OP_HEARTBEAT }.to_json)
     end
 
-    should "record a heartbeat ack" do
-      @adapter.instance_variable_set(:@heartbeat_acked, false)
+    should "keep the last sequence number of every payload that carries one" do
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_HEARTBEAT_ACK, s: 12 }.to_json)
 
-      @adapter.handle_gateway_message({ op: DiscordAdapter::OP_HEARTBEAT_ACK }.to_json)
+      assert_equal 12, @adapter.instance_variable_get(:@last_sequence)
+    end
 
-      assert @adapter.instance_variable_get(:@heartbeat_acked)
+    should "keep the previous sequence number for a payload that carries none" do
+      @adapter.instance_variable_set(:@last_sequence, 12)
+
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_HEARTBEAT_ACK }.to_json)
+
+      assert_equal 12, @adapter.instance_variable_get(:@last_sequence)
+    end
+
+    should "record a sequence number of zero rather than treating it as absent" do
+      @adapter.instance_variable_set(:@last_sequence, 12)
+
+      # Discord numbers dispatches from 1, so this does not occur in practice;
+      # the test pins down that only a missing "s" is skipped, since 0 is
+      # truthy in Ruby and the check would otherwise be ambiguous.
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_HEARTBEAT_ACK, s: 0 }.to_json)
+
+      assert_equal 0, @adapter.instance_variable_get(:@last_sequence)
     end
 
     should "request a reconnect on Reconnect (op 7) and Invalid Session (op 9)" do
@@ -275,7 +389,7 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
         adapter = DiscordAdapter.new
         adapter.instance_variable_set(:@connection_ended, Queue.new)
 
-        adapter.handle_gateway_message({ op: op }.to_json)
+        adapter.handle_gateway_message(nil, { op: op }.to_json)
 
         assert adapter.instance_variable_get(:@reconnect_requested), "op #{op} must request reconnect"
       end
@@ -295,15 +409,25 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_kind_of DiscordApiError, @adapter.instance_variable_get(:@fatal_close)
     end
 
-    should "request a reconnect when a heartbeat ack is missing at the next send time (zombie connection)" do
+    should "C-6.5.1: log the fatal close code and end the connection" do
       @adapter.instance_variable_set(:@connection_ended, Queue.new)
-      @adapter.instance_variable_set(:@heartbeat_interval, 0.01)
-      @adapter.instance_variable_set(:@heartbeat_acked, false)
-      @adapter.stubs(:send_heartbeat)
+      logger = mock("logger")
+      logger.expects(:error).with("discord: gateway closed with fatal code 4014")
+      @adapter.stubs(:ai_helper_logger).returns(logger)
 
-      @adapter.send(:heartbeat_loop)
+      DiscordAdapter::FATAL_CLOSE_CODES.each do |code|
+        adapter = DiscordAdapter.new
+        adapter.instance_variable_set(:@connection_ended, Queue.new)
 
-      assert @adapter.instance_variable_get(:@reconnect_requested)
+        adapter.handle_close_frame(code)
+
+        assert_kind_of DiscordApiError, adapter.instance_variable_get(:@fatal_close),
+                       "close code #{code} must be fatal"
+      end
+
+      @adapter.handle_close_frame(4014)
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
     end
 
     should "not capture a fatal error on a transient close code" do
@@ -314,6 +438,17 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_nil @adapter.instance_variable_get(:@fatal_close)
     end
 
+    should "C-6.5.2: leave every other close code to the shared implementation" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:info).with("discord: close frame received (code 1006)")
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.handle_close_frame(1006)
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
     should "evict the oldest reply target once the cap is exceeded, keeping recent ones" do
       cap = DiscordAdapter::MAX_REPLY_TARGETS
       (cap + 1).times { |i| @adapter.send(:record_reply_target, "key#{i}", "msg#{i}") }
@@ -322,6 +457,276 @@ class ChatChannelDiscordAdapterTest < ActiveSupport::TestCase
       assert_equal cap, reply_targets.size
       assert_not reply_targets.key?("key0"), "the oldest entry must be evicted"
       assert reply_targets.key?("key#{cap}"), "the newest entry must be kept"
+    end
+  end
+
+  # US2: liveness is judged only by whether frames keep arriving. The bound
+  # comes from the heartbeat interval Discord announces in Hello, so it
+  # follows a changed interval instead of a hard-coded number.
+  context "receive inactivity bound" do
+    should "C-6.1.1 / SC-002: bound the silence at 1.5x the announced heartbeat interval" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+
+      assert_in_delta 61.875, @adapter.send(:receive_timeout_seconds), 0.001
+    end
+
+    should "C-6.1.1: follow the announced interval instead of a fixed number" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 20.0)
+
+      assert_in_delta 30.0, @adapter.send(:receive_timeout_seconds), 0.001
+
+      @adapter.instance_variable_set(:@heartbeat_interval, 60.0)
+
+      assert_in_delta 90.0, @adapter.send(:receive_timeout_seconds), 0.001
+    end
+
+    should "C-6.1.2: fall back to the shared default before Hello announces an interval" do
+      assert_nil @adapter.instance_variable_get(:@heartbeat_interval)
+      assert_equal DiscordAdapter::DEFAULT_RECEIVE_TIMEOUT_SECONDS,
+                   @adapter.send(:receive_timeout_seconds)
+      assert_equal 30, @adapter.send(:receive_timeout_seconds)
+    end
+  end
+
+  # US2: the heartbeat Discord requires is sent as the monitor loop's
+  # scheduled action, so no second thread ever writes to the socket.
+  context "heartbeat scheduling" do
+    should "C-6.2.1: set the next heartbeat time to one interval ahead on Hello" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1000.0)
+      @adapter.stubs(:send_identify)
+
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_HELLO, d: { heartbeat_interval: 41250 } }.to_json)
+
+      assert_in_delta 41.25, @adapter.instance_variable_get(:@heartbeat_interval), 0.001
+      assert_in_delta 1041.25, @adapter.instance_variable_get(:@next_heartbeat_at), 0.001
+    end
+
+    should "C-6.2.2: report the seconds left until the next heartbeat" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+      @adapter.instance_variable_set(:@next_heartbeat_at, 1041.25)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1030.0)
+
+      assert_in_delta 11.25, @adapter.send(:next_scheduled_action_in), 0.001
+    end
+
+    should "C-6.2.2: poll every second while waiting for Hello" do
+      assert_nil @adapter.instance_variable_get(:@heartbeat_interval)
+
+      assert_equal DiscordAdapter::HELLO_WAIT_SECONDS, @adapter.send(:next_scheduled_action_in)
+    end
+
+    should "C-6.2.3 / INV-7: send the heartbeat once the scheduled time is reached and rearm it" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+      @adapter.instance_variable_set(:@next_heartbeat_at, 1000.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1000.5)
+      @adapter.expects(:send_heartbeat).once
+
+      @adapter.send(:perform_scheduled_action)
+
+      assert_in_delta 1041.75, @adapter.instance_variable_get(:@next_heartbeat_at), 0.001
+    end
+
+    should "C-6.2.3 / INV-7: count the next heartbeat from now when the wake-up came late" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+      @adapter.instance_variable_set(:@next_heartbeat_at, 1000.0)
+      # Woken up 7 seconds after the heartbeat was due (a blocking REST call on
+      # the receive thread, a slow scheduler): the rhythm restarts from now
+      # rather than compressing the following intervals to catch up.
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1007.0)
+      @adapter.expects(:send_heartbeat).once
+
+      @adapter.send(:perform_scheduled_action)
+
+      assert_in_delta 1048.25, @adapter.instance_variable_get(:@next_heartbeat_at), 0.001
+    end
+
+    should "C-6.2.3: send no heartbeat once the adapter has been stopped" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+      @adapter.instance_variable_set(:@next_heartbeat_at, 1000.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1000.5)
+      @adapter.instance_variable_set(:@stopped, true)
+      @adapter.expects(:send_heartbeat).never
+
+      @adapter.send(:perform_scheduled_action)
+
+      assert_in_delta 1000.0, @adapter.instance_variable_get(:@next_heartbeat_at), 0.001
+    end
+
+    should "C-6.2.3: not send a heartbeat before the scheduled time, so short waits do not add up" do
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+      @adapter.instance_variable_set(:@next_heartbeat_at, 1041.25)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1020.0)
+      @adapter.expects(:send_heartbeat).never
+
+      @adapter.send(:perform_scheduled_action)
+
+      assert_in_delta 1041.25, @adapter.instance_variable_get(:@next_heartbeat_at), 0.001
+    end
+
+    should "C-6.2.4: send nothing while the heartbeat interval is unknown" do
+      @adapter.expects(:send_heartbeat).never
+
+      @adapter.send(:perform_scheduled_action)
+
+      assert_nil @adapter.instance_variable_get(:@next_heartbeat_at)
+    end
+
+    should "FR-009: keep the heartbeat payload unchanged (op 1 with the last sequence)" do
+      client = FakeClient.new
+      @adapter.instance_variable_set(:@ws, client)
+      @adapter.instance_variable_set(:@last_sequence, 42)
+
+      @adapter.send(:send_heartbeat, client)
+
+      assert_equal([ { "op" => DiscordAdapter::OP_HEARTBEAT, "d" => 42 } ],
+                   client.sent.map { |frame| JSON.parse(frame.data) })
+    end
+  end
+
+  # US2: acks are no longer counted. An ack is just another received frame,
+  # and a connection that stops answering is caught by the inactivity bound.
+  context "heartbeat acknowledgement" do
+    should "C-6.4.1: treat a heartbeat ack as a plain received frame" do
+      @adapter.instance_variable_set(:@ws, FakeClient.new)
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_HEARTBEAT_ACK }.to_json)
+
+      assert_empty @adapter.instance_variable_get(:@ws).sent
+      assert_not @adapter.instance_variable_get(:@reconnect_requested)
+      assert @adapter.instance_variable_get(:@connection_ended).empty?
+    end
+
+    should "C-6.4.2: not track acks at all" do
+      @adapter.handle_gateway_message(nil, { op: DiscordAdapter::OP_HEARTBEAT_ACK }.to_json)
+
+      assert_not @adapter.instance_variables.include?(:@heartbeat_acked)
+    end
+
+    should "C-6.4.3 / FR-008: have no zombie-connection path that reconnects on a missing ack" do
+      assert_not @adapter.respond_to?(:heartbeat_loop, true),
+                 "the ack-counting loop must be replaced by the shared receive-inactivity watchdog"
+    end
+  end
+
+  # US3: a frame is answered on the connection it arrived on. @ws is assigned
+  # only after WebSocket::Client::Simple.connect returns, and Discord's very
+  # first frame is Hello, so anything sent through @ws in that window would be
+  # dropped silently - and a gateway that never receives Identify closes the
+  # connection.
+  context "answering on the arriving connection" do
+    should "C-6.3.1: hand a text frame to the gateway parser together with its client" do
+      client = FakeClient.new
+      @adapter.expects(:handle_gateway_message).with(client, "raw payload")
+
+      @adapter.send(:handle_text_frame, client, "raw payload")
+    end
+
+    should "C-6.3.2 / INV-6: send Identify to the arriving connection while @ws is still nil" do
+      client = FakeClient.new
+      assert_nil @adapter.instance_variable_get(:@ws)
+
+      @adapter.handle_gateway_message(client, { op: DiscordAdapter::OP_HELLO, d: { heartbeat_interval: 41250 } }.to_json)
+
+      assert_nil @adapter.instance_variable_get(:@ws), "the pre-handshake window must not be papered over with @ws"
+      assert_equal([ DiscordAdapter::OP_IDENTIFY ], client.sent.map { |frame| JSON.parse(frame.data)["op"] })
+    end
+
+    should "C-6.2.5: answer a heartbeat request on the arriving connection without moving the schedule" do
+      client = FakeClient.new
+      @adapter.instance_variable_set(:@heartbeat_interval, 41.25)
+      @adapter.instance_variable_set(:@next_heartbeat_at, 1041.25)
+      @adapter.instance_variable_set(:@last_sequence, 9)
+
+      @adapter.handle_gateway_message(client, { op: DiscordAdapter::OP_HEARTBEAT }.to_json)
+
+      assert_equal([ { "op" => DiscordAdapter::OP_HEARTBEAT, "d" => 9 } ],
+                   client.sent.map { |frame| JSON.parse(frame.data) })
+      assert_in_delta 1041.25, @adapter.instance_variable_get(:@next_heartbeat_at), 0.001
+    end
+
+    should "C-6.3.3 / FR-017: keep the Identify payload exactly as it was" do
+      client = FakeClient.new
+
+      @adapter.send(:send_identify, client)
+
+      payload = JSON.parse(client.sent.first.data)
+      assert_equal DiscordAdapter::OP_IDENTIFY, payload["op"]
+      assert_equal BOT_TOKEN, payload["d"]["token"]
+      assert_equal 37376, payload["d"]["intents"]
+      assert_equal({ "os" => "linux", "browser" => "redmine_ai_helper", "device" => "redmine_ai_helper" },
+                   payload["d"]["properties"])
+    end
+
+    should "C-6.3.4: log a payload that cannot be parsed and keep the connection" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/failed to parse gateway payload/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_nothing_raised { @adapter.handle_gateway_message(FakeClient.new, "not json") }
+
+      assert @adapter.instance_variable_get(:@connection_ended).empty?
+    end
+  end
+
+  # US1: every write to the gateway socket - Identify, heartbeats, the answer
+  # to a heartbeat request and the close frame - goes through the single
+  # serialized send path in BaseAdapter, so two of them can never interleave
+  # and corrupt the connection.
+  context "send serialization" do
+    should "C-3.2: send Identify through the shared serialized send_frame" do
+      ws = mock("ws")
+      @adapter.instance_variable_set(:@ws, ws)
+      @adapter.expects(:send_frame).with do |client, data|
+        client == ws && JSON.parse(data)["op"] == DiscordAdapter::OP_IDENTIFY
+      end
+
+      @adapter.send(:send_identify, ws)
+    end
+
+    should "C-3.2: send heartbeats through the shared serialized send_frame" do
+      ws = mock("ws")
+      @adapter.instance_variable_set(:@ws, ws)
+      @adapter.instance_variable_set(:@last_sequence, 7)
+      @adapter.expects(:send_frame).with do |client, data|
+        client == ws && JSON.parse(data) == { "op" => DiscordAdapter::OP_HEARTBEAT, "d" => 7 }
+      end
+
+      @adapter.send(:send_heartbeat, ws)
+    end
+
+    should "C-3.1 / SC-001: never let two sending threads overlap on the socket" do
+      client = ConcurrencyDetectingClient.new
+      @adapter.instance_variable_set(:@ws, client)
+
+      threads = 6.times.map do |i|
+        Thread.new { i.even? ? @adapter.send(:send_identify, client) : @adapter.send(:send_heartbeat, client) }
+      end
+      threads.each(&:join)
+
+      assert_not client.overlap_detected
+      assert_equal 6, client.calls.size
+      # Complements overlap_detected: a truncated payload is what an interleaved
+      # write would leave behind if the overlap itself went unobserved.
+      assert client.calls.all? { |raw| JSON.parse(raw).key?("op") }, "no payload may be cut in half"
+    end
+
+    should "C-3.4 / FR-003: close the socket under the same mutex that serializes sends" do
+      ws = mock("ws")
+      ws.expects(:close)
+      @adapter.instance_variable_set(:@ws, ws)
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      mutex.expects(:synchronize).yields
+
+      @adapter.send(:close_socket)
+
+      assert_nil @adapter.instance_variable_get(:@ws)
+    end
+
+    should "FR-002: have no unserialized send path left" do
+      assert_not @adapter.respond_to?(:send_json, true),
+                 "send_json bypassed the send mutex and must be gone"
     end
   end
 

--- a/test/unit/chat_channel/base_adapter_test.rb
+++ b/test/unit/chat_channel/base_adapter_test.rb
@@ -29,14 +29,110 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
       # No external connection for the in-memory adapter.
     end
 
-    def stop
-      # Nothing to close.
-    end
+    # #stop is not implemented: the shared one in BaseAdapter closes nothing
+    # when the adapter never opened a socket (INV-8).
 
     def send_message(channel_id:, thread_key:, text:)
       @sent_messages << { channel_id: channel_id, thread_key: thread_key, text: text }
     end
   end
+
+  # Adapter that uses the shared WebSocket transport of BaseAdapter. It never
+  # opens a real socket: the tests drive the protected transport methods
+  # directly with a fake client and fake frames, the same way the Slack
+  # adapter's own transport tests do.
+  class FakeSocketAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    # Text frames received through handle_text_frame, as [client, data] pairs.
+    # @return [Array<Array>]
+    attr_reader :text_frames
+
+    # The value of @last_received_at observed at the moment the text frame was
+    # delivered, used to prove the receive time is recorded before dispatch.
+    # @return [Float, nil]
+    attr_reader :received_at_on_text
+
+    class << self
+      def channel_type
+        "fake_socket"
+      end
+    end
+
+    def initialize
+      super
+      @text_frames = []
+    end
+
+    def start
+      # No external connection for the in-memory adapter.
+    end
+
+    def send_message(channel_id:, thread_key:, text:)
+      # Not used by the transport tests.
+    end
+
+    protected
+
+    def handle_text_frame(client, data)
+      @received_at_on_text = @last_received_at
+      @text_frames << [ client, data ]
+    end
+  end
+
+  # A stand-in for the WebSocket::Client::Simple::Client the handler block
+  # receives, so tests never need a real socket. Records every frame sent
+  # through it.
+  class FakeClient
+    Sent = Struct.new(:data, :type)
+
+    attr_reader :sent
+
+    def initialize
+      @sent = []
+    end
+
+    def send(data, type: :text)
+      @sent << Sent.new(data, type)
+    end
+  end
+
+  # Detects whether two threads ever ran #send concurrently. Only safe as a
+  # plain (unlocked) instance variable *because* that is exactly the property
+  # under test: if send_frame's @send_mutex serializes calls correctly, this
+  # method's body never actually runs on two threads at once.
+  #
+  # Detection is best effort: it can only observe an overlap the scheduler
+  # actually produces. The window is widened deliberately (repeated Thread.pass
+  # plus a sleep, both of which release the GVL) so an unserialized caller has
+  # many chances to enter. The structural guarantee is asserted separately by
+  # the test that expects @send_mutex#synchronize to be held.
+  class ConcurrencyDetectingClient
+    # How long #send stays inside its critical section. Long enough that a
+    # thread waiting on the GVL is scheduled into it if nothing excludes it.
+    BUSY_SECONDS = 0.005
+
+    attr_reader :overlap_detected, :calls
+
+    def initialize
+      @busy = false
+      @overlap_detected = false
+      @calls = []
+    end
+
+    def send(data, type: :text) # rubocop:disable Lint/UnusedMethodArgument
+      @overlap_detected ||= @busy
+      @busy = true
+      @calls << data
+      5.times { Thread.pass }
+      sleep BUSY_SECONDS
+      # A cleared flag means another call ran to completion inside this one,
+      # which catches an overlap the check on entry could still have missed.
+      @overlap_detected ||= !@busy
+      @busy = false
+    end
+  end
+
+  # Doubles for the frames handle_frame receives (#type / #data / #code).
+  FrameStruct = Struct.new(:type, :data, :code)
 
   context "automatic registration" do
     should "register subclasses by channel_type" do
@@ -226,6 +322,469 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
       rendered = format.render("#1549", "https://r.example.com/issues/1549")
 
       assert format.pattern.match?(rendered)
+    end
+  end
+
+  # C-1: the shared frame dispatcher. Every adapter that speaks WebSocket
+  # routes its ws.on(:message) block through this method.
+  context "shared transport: handle_frame" do
+    setup do
+      @adapter = FakeSocketAdapter.new
+    end
+
+    should "C-1.1: update last_received_at to the current monotonic time before dispatching by type" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(12345.0)
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:unknown, nil, nil))
+
+      assert_equal 12345.0, @adapter.instance_variable_get(:@last_received_at)
+    end
+
+    should "C-1.1: record the receive time before the subclass sees the frame" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(12345.0)
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:text, "payload", nil))
+
+      assert_equal 12345.0, @adapter.received_at_on_text
+    end
+
+    should "C-1.2: echo a ping's payload back as a pong to the frame's own client" do
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "Ping from applink-2", nil))
+
+      assert_equal [ FakeClient::Sent.new("Ping from applink-2", :pong) ], client.sent
+    end
+
+    should "C-1.3: delegate a text frame to handle_text_frame with the frame's own client" do
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:text, "payload", nil))
+
+      assert_equal [ [ client, "payload" ] ], @adapter.text_frames
+    end
+
+    should "C-1.4: delegate a close frame to handle_close_frame with the close code" do
+      @adapter.expects(:handle_close_frame).with(1001)
+
+      @adapter.send(:handle_frame, FakeClient.new, FrameStruct.new(:close, nil, 1001))
+    end
+
+    should "C-1.5: do nothing but record the receive time for an unknown frame type" do
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:pong, nil, nil))
+
+      assert_empty client.sent
+      assert_empty @adapter.text_frames
+    end
+
+    should "C-1.6: log and notify connection_ended instead of letting an exception escape to the gem" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      client = FakeClient.new
+      client.stubs(:send).raises(IOError, "not opened for writing")
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/fake_socket: error while handling frame.*not opened for writing/m))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_nothing_raised do
+        @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "payload", nil))
+      end
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "C-1.9: carry a fatal credential error over to the connecting thread instead of reconnecting" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      error = StandardError.new("invalid_auth")
+      client = FakeClient.new
+      client.stubs(:send).raises(error)
+      @adapter.stubs(:fatal_config_error?).returns(true)
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/fake_socket: error while handling frame.*invalid_auth/m))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_nothing_raised do
+        @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "payload", nil))
+      end
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+      raised = assert_raises(StandardError) { @adapter.send(:raise_fatal_error!) }
+      assert_same error, raised
+    end
+
+    should "C-1.9: only end the connection when the error is not a fatal one" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      client = FakeClient.new
+      client.stubs(:send).raises(IOError, "not opened for writing")
+      @adapter.stubs(:ai_helper_logger).returns(stub_everything("logger"))
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "payload", nil))
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+      assert_nothing_raised { @adapter.send(:raise_fatal_error!) }
+    end
+
+    should "C-1.7: answer a ping and deliver a text frame while @ws is still nil (pre-handshake window)" do
+      assert_nil @adapter.instance_variable_get(:@ws)
+      client = FakeClient.new
+
+      @adapter.send(:handle_frame, client, FrameStruct.new(:ping, "payload", nil))
+      @adapter.send(:handle_frame, client, FrameStruct.new(:text, "envelope", nil))
+
+      assert_nil @adapter.instance_variable_get(:@ws)
+      assert_equal [ FakeClient::Sent.new("payload", :pong) ], client.sent
+      assert_equal [ [ client, "envelope" ] ], @adapter.text_frames
+    end
+
+    should "C-1.8: log the close code and notify connection_ended by default" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:info).with("fake_socket: close frame received (code 1000)")
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:handle_close_frame, 1000)
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "C-1.8: log 'none' instead of a blank code for a close frame without a status code" do
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+      logger = mock("logger")
+      logger.expects(:info).with("fake_socket: close frame received (code none)")
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:handle_close_frame, nil)
+    end
+
+    should "require a subclass to implement handle_text_frame" do
+      error = assert_raises(NotImplementedError) do
+        FakeAdapter.new.send(:handle_text_frame, nil, "payload")
+      end
+
+      assert_match(/handle_text_frame/, error.message)
+    end
+  end
+
+  # C-2: the shared monitor loop. Liveness is judged only by whether frames
+  # arrive; the loop never probes the connection itself.
+  context "shared transport: watchdog_loop" do
+    setup do
+      @adapter = FakeSocketAdapter.new
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+    end
+
+    should "C-2.2: request a reconnect and leave the loop once the receive timeout has elapsed" do
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(131.0)
+
+      @adapter.send(:watchdog_loop)
+
+      assert @adapter.instance_variable_get(:@reconnect_requested)
+    end
+
+    should "C-2.3: warn with the actual elapsed seconds and without any credential" do
+      create(:ai_helper_chat_adapter_setting, channel_type: "fake_socket", bot_token: "socket-secret")
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(131.0)
+      warnings = []
+      logger = mock("logger")
+      logger.stubs(:warn).with { |message| warnings << message; true }
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_equal [ "fake_socket: no frame received for 31.0s, reconnecting" ], warnings
+      assert_no_match(/socket-secret/, warnings.first)
+    end
+
+    should "C-2.4: exit immediately when the connection has already ended, without waiting for the timeout" do
+      @adapter.instance_variable_set(:@last_received_at, Process.clock_gettime(Process::CLOCK_MONOTONIC))
+      queue = Queue.new
+      queue.push(true)
+      @adapter.instance_variable_set(:@connection_ended, queue)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_not @adapter.instance_variable_get(:@reconnect_requested)
+    end
+
+    should "C-2.5: exit immediately without polling the queue when already stopped" do
+      @adapter.instance_variable_set(:@stopped, true)
+      FakeSocketAdapter.expects(:timed_queue_pop).never
+
+      @adapter.send(:watchdog_loop)
+    end
+
+    should "C-2.5: exit immediately without polling the queue when a reconnect was already requested" do
+      @adapter.instance_variable_set(:@reconnect_requested, true)
+      FakeSocketAdapter.expects(:timed_queue_pop).never
+
+      @adapter.send(:watchdog_loop)
+    end
+
+    should "C-2.6: wait the shorter of the receive deadline and the next scheduled action" do
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(110.0)
+      @adapter.stubs(:next_scheduled_action_in).returns(5.0)
+      waits = []
+      FakeSocketAdapter.stubs(:timed_queue_pop).with { |_queue, wait| waits << wait; true }.returns(true)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_equal [ 5.0 ], waits
+    end
+
+    should "C-2.7: wait only for the receive deadline when no action is scheduled" do
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(110.0)
+      waits = []
+      FakeSocketAdapter.stubs(:timed_queue_pop).with { |_queue, wait| waits << wait; true }.returns(true)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_equal [ 20.0 ], waits
+    end
+
+    should "C-2.8: perform the scheduled action when the wait ends without an end notification" do
+      @adapter.instance_variable_set(:@last_received_at, 100.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(110.0)
+      FakeSocketAdapter.stubs(:timed_queue_pop).returns(nil, true)
+      @adapter.expects(:perform_scheduled_action).once
+
+      @adapter.send(:watchdog_loop)
+    end
+
+    should "C-2.9: evaluate the receive timeout on every pass so a shortened bound takes effect" do
+      @adapter.instance_variable_set(:@last_received_at, 90.0)
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(100.0)
+      @adapter.stubs(:receive_timeout_seconds).returns(30, 5)
+      waits = []
+      FakeSocketAdapter.stubs(:timed_queue_pop).with { |_queue, wait| waits << wait; true }.returns(nil)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_equal [ 20.0 ], waits,
+                   "only the first pass may wait: the second must see the shortened bound as already elapsed"
+      assert @adapter.instance_variable_get(:@reconnect_requested)
+    end
+
+    should "C-2.10: recompute the remaining wait when a frame arrives right at the deadline" do
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(100.0, 120.0)
+      @adapter.instance_variable_set(:@last_received_at, 90.0)
+      waits = []
+      FakeSocketAdapter.stubs(:timed_queue_pop).with do |_queue, wait|
+        waits << wait
+        @adapter.instance_variable_set(:@last_received_at, 115.0) if waits.size == 1
+        true
+      end.returns(nil, true)
+
+      @adapter.send(:watchdog_loop)
+
+      assert_equal [ 20.0, 25.0 ], waits
+    end
+
+    should "use the default receive timeout of 30 seconds" do
+      assert_equal 30, RedmineAiHelper::ChatChannel::BaseAdapter::DEFAULT_RECEIVE_TIMEOUT_SECONDS
+      assert_equal 30, @adapter.send(:receive_timeout_seconds)
+    end
+
+    should "schedule no action and do nothing by default" do
+      assert_nil @adapter.send(:next_scheduled_action_in)
+      assert_nothing_raised { @adapter.send(:perform_scheduled_action) }
+    end
+  end
+
+  # C-3: every write to the socket - payloads, pongs and the close frame -
+  # goes through the adapter's single mutex.
+  context "shared transport: send_frame and close_socket" do
+    setup do
+      @adapter = FakeSocketAdapter.new
+    end
+
+    should "C-3.1: never let two threads send through the client at the same time" do
+      client = ConcurrencyDetectingClient.new
+
+      threads = 5.times.map { |i| Thread.new { @adapter.send(:send_frame, client, "msg#{i}") } }
+      threads.each(&:join)
+
+      assert_not client.overlap_detected
+      assert_equal 5, client.calls.size
+    end
+
+    should "C-3.1: hold send_mutex while sending through the client" do
+      client = FakeClient.new
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      mutex.expects(:synchronize).yields
+
+      @adapter.send(:send_frame, client, "hello", type: :pong)
+
+      assert_equal [ FakeClient::Sent.new("hello", :pong) ], client.sent
+    end
+
+    should "C-3.5: do nothing and raise no exception when the client is nil" do
+      # The mutex must still be taken: a nil check that returns early would
+      # move the guard out of the serialized path for every other caller too.
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      mutex.expects(:synchronize).yields
+
+      assert_nothing_raised do
+        @adapter.send(:send_frame, nil, "hello")
+      end
+    end
+
+    should "C-3.9: send a text frame when no frame type is given" do
+      client = FakeClient.new
+
+      @adapter.send(:send_frame, client, "hello")
+
+      assert_equal [ FakeClient::Sent.new("hello", :text) ], client.sent
+    end
+
+    should "C-3.6: own exactly one mutex that survives every send and close" do
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      assert_kind_of Mutex, mutex
+
+      @adapter.send(:send_frame, FakeClient.new, "hello")
+      @adapter.send(:close_socket)
+
+      assert_same mutex, @adapter.instance_variable_get(:@send_mutex)
+    end
+
+    should "C-3.4: close the socket while holding send_mutex" do
+      ws = mock("ws")
+      ws.expects(:close)
+      @adapter.instance_variable_set(:@ws, ws)
+      mutex = @adapter.instance_variable_get(:@send_mutex)
+      mutex.expects(:synchronize).yields
+
+      @adapter.send(:close_socket)
+
+      assert_nil @adapter.instance_variable_get(:@ws)
+    end
+
+    should "C-3.7: swallow IOError raised while closing" do
+      ws = mock("ws")
+      ws.expects(:close).raises(IOError, "closed stream")
+      @adapter.instance_variable_set(:@ws, ws)
+      logger = mock("logger")
+      logger.expects(:debug).with(regexp_matches(/fake_socket: error while closing socket: closed stream/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_nothing_raised { @adapter.send(:close_socket) }
+    end
+
+    should "C-3.7: swallow SystemCallError raised while closing" do
+      ws = mock("ws")
+      ws.expects(:close).raises(Errno::ECONNRESET)
+      @adapter.instance_variable_set(:@ws, ws)
+      logger = mock("logger")
+      logger.expects(:debug).with(regexp_matches(/fake_socket: error while closing socket: .*Connection reset/))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      assert_nothing_raised { @adapter.send(:close_socket) }
+    end
+
+    should "C-3.8: do nothing when there is no socket to close" do
+      assert_nil @adapter.instance_variable_get(:@ws)
+
+      assert_nothing_raised { @adapter.send(:close_socket) }
+    end
+  end
+
+  # C-4 and C-5: ending a connection, and the retry pacing #start uses.
+  context "shared transport: connection end, stop flag and backoff" do
+    setup do
+      @adapter = FakeSocketAdapter.new
+      @adapter.instance_variable_set(:@connection_ended, Queue.new)
+    end
+
+    should "C-4.1: flag the reconnect and notify connection_ended on request_reconnect" do
+      @adapter.send(:request_reconnect)
+
+      assert @adapter.instance_variable_get(:@reconnect_requested)
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "C-4.2: notify connection_ended on connection_ended!" do
+      @adapter.send(:connection_ended!)
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "C-4.3: log the error and notify connection_ended on socket_errored" do
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/fake_socket: websocket error.*boom/m))
+      @adapter.stubs(:ai_helper_logger).returns(logger)
+
+      @adapter.send(:socket_errored, StandardError.new("boom"))
+
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+    end
+
+    should "C-4.4: raise nothing when there is no connection to notify" do
+      adapter = FakeSocketAdapter.new
+
+      assert_nothing_raised do
+        adapter.send(:request_reconnect)
+        adapter.send(:connection_ended!)
+        adapter.send(:socket_errored, StandardError.new("boom"))
+      end
+    end
+
+    should "C-5.1: report stopped? from the stop flag" do
+      assert_not @adapter.send(:stopped?)
+
+      @adapter.instance_variable_set(:@stopped, true)
+
+      assert @adapter.send(:stopped?)
+    end
+
+    should "C-5.2: back off exponentially from 1 up to 60 seconds" do
+      assert_equal 60, RedmineAiHelper::ChatChannel::BaseAdapter::MAX_BACKOFF_SECONDS
+      assert_equal([ 1, 2, 4, 8, 16, 32, 60, 60 ], (1..8).map { @adapter.send(:next_backoff) })
+    end
+
+    should "C-5.3: reset the backoff after a successful connection" do
+      3.times { @adapter.send(:next_backoff) }
+      @adapter.send(:reset_backoff)
+
+      assert_equal 1, @adapter.send(:next_backoff)
+    end
+
+    should "C-5.4: start out not stopped, with a backoff of 1 and no recorded frame" do
+      adapter = FakeSocketAdapter.new
+
+      assert_not adapter.send(:stopped?)
+      assert_equal 1, adapter.send(:next_backoff)
+      assert_equal 0.0, adapter.instance_variable_get(:@last_received_at)
+    end
+
+    should "C-5.5: raise the stop flag, wake the monitor loop and close the socket on stop" do
+      ws = mock("ws")
+      ws.expects(:close)
+      @adapter.instance_variable_set(:@ws, ws)
+
+      @adapter.stop
+
+      assert @adapter.send(:stopped?)
+      assert @adapter.instance_variable_get(:@connection_ended).pop(true)
+      assert_nil @adapter.instance_variable_get(:@ws)
+    end
+
+    should "C-5.5: stop an adapter that never opened a socket without raising" do
+      adapter = FakeSocketAdapter.new
+
+      assert_nothing_raised { adapter.stop }
+      assert adapter.send(:stopped?)
+    end
+
+    should "C-5.1: clear the stop flag when the adapter is started again" do
+      @adapter.instance_variable_set(:@stopped, true)
+
+      @adapter.send(:clear_stop_flag)
+
+      assert_not @adapter.send(:stopped?)
     end
   end
 end


### PR DESCRIPTION
## Changes

- Move the shared WebSocket transport into `BaseAdapter` (frame dispatch with the automatic pong, receive-time recording, the monitor loop, serialized sending and closing, connection-end notification, the stop flag and the reconnect backoff), leaving five hooks for the protocol-specific parts
- Serialize every write to the Discord socket through the shared send mutex, so identify/heartbeat/close frames can no longer interleave and corrupt the connection
- Detect a silently dead Discord connection through receive inactivity (1.5 x the announced heartbeat interval, about 61.9s) instead of counting heartbeat acks, which cuts worst-case detection from about 82s
- Send Identify to the connection the Hello frame arrived on, so it is no longer dropped while `@ws` is still unassigned right after connecting
- Terminate the adapter when a credential error is raised while a frame is being handled, instead of reconnecting with no backoff into the same broken credentials (applies to both adapters)
- Add ADR-014 recording the extraction and the reversal of ADR-012's Slack-only scope

## Notes

- Slack's observable behaviour is unchanged: `test/unit/chat_channel/adapters/slack_adapter_test.rb` passes without a single character being edited
- Full plugin suite: 2357 runs, 6013 assertions, 0 failures, 0 errors (line coverage 96.29%); RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
