### PR TITLE
Enforce the ai_helper module check in search_issues

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/040-discord-transport-fixes"
+  "feature_directory": "specs/041-search-issues-module-check"
 }

--- a/lib/redmine_ai_helper/tools/issue_search_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_search_tools.rb
@@ -8,8 +8,8 @@ module RedmineAiHelper
       # related-object sorting (e.g. assignee name) is out of scope.
       SUPPORTED_SORT_FIELDS = %w[id created_on updated_on due_date start_date done_ratio].freeze
 
-      define_function :search_issues, description: "Search issues based on the filter conditions and return matching issues. For search items with '_id', specify the ID instead of the name of the search target. If you do not know the ID, you need to call capable_issue_properties in advance to obtain the ID. Default limit is 50 issues." do
-        property :project_id, type: "integer", description: "The project ID of the project to search in.", required: true
+      define_function :search_issues, description: "Search issues based on the filter conditions and return matching issues. For search items with '_id', specify the ID instead of the name of the search target. If you do not know the ID, you need to call capable_issue_properties in advance to obtain the ID. Default limit is 50 issues. Only projects with the AI Helper module enabled can be searched." do
+        property :project_id, type: "integer", description: "The project ID of the project to search in. Only projects with the AI Helper module enabled can be searched.", required: true
         property :limit, type: "integer", description: "Maximum number of issues to return. Default is 50.", required: false
         property :fields, type: "array", description: "Search fields for the issue." do
           item type: "object", description: "Search field for the issue." do
@@ -80,7 +80,7 @@ module RedmineAiHelper
         end
       end
       # Search issues based on filter conditions and return matching issues
-      # @param project_id [Integer] The project ID of the project to search in.
+      # @param project_id [Integer] The project ID of the project to search in. The project must have the ai_helper module enabled and be accessible to the current user.
       # @param limit [Integer] Maximum number of issues to return. Default is 50.
       # @param fields [Array] Search fields for the issue.
       # @param date_fields [Array] Date search fields for the issue.
@@ -91,7 +91,13 @@ module RedmineAiHelper
       # @param custom_fields [Array] Custom field search filters.
       # @param sort [Hash] Sort order with :field (one of SUPPORTED_SORT_FIELDS) and optional :direction (asc/desc, default desc). Defaults to id descending when omitted.
       # @return [Hash] A hash containing issues array and total_count.
+      # @raise [RuntimeError] if project_id is missing, or the project is not accessible with the ai_helper module enabled.
+      # @raise [ActiveRecord::RecordNotFound] if no project matches project_id.
       def search_issues(project_id:, limit: 50, fields: [], date_fields: [], time_fields: [], number_fields: [], text_fields: [], status_field: [], custom_fields: [], sort: nil)
+        # The LLM occasionally omits required parameters; without a project there is
+        # nothing to search, so fail instead of guessing a target.
+        raise "project_id is required" if project_id.nil?
+
         fields = deep_symbolize_array(fields)
         date_fields = deep_symbolize_array(date_fields)
         time_fields = deep_symbolize_array(time_fields)
@@ -103,6 +109,9 @@ module RedmineAiHelper
 
         limit = [ limit.to_i, 1 ].max
         project = Project.find(project_id)
+        # Guard both search paths at once: projects without the ai_helper module (or
+        # without access for the current user) must never expose their issues.
+        raise "ai_helper is not enabled for project: id = #{project_id}" unless accessible_project?(project)
 
         if fields.empty? && date_fields.empty? && time_fields.empty? && number_fields.empty? && text_fields.empty? && status_field.empty? && custom_fields.empty?
           # No conditions: return open visible issues for the project (same as Redmine default)

--- a/test/unit/tools/issue_search_tools_test.rb
+++ b/test/unit/tools/issue_search_tools_test.rb
@@ -1,10 +1,16 @@
 require File.expand_path("../../../test_helper", __FILE__)
 
 class IssueSearchToolsTest < ActiveSupport::TestCase
-  fixtures :projects, :issues, :issue_statuses, :trackers, :enumerations, :users, :issue_categories, :versions, :custom_fields
+  fixtures :projects, :issues, :issue_statuses, :trackers, :enumerations, :users, :issue_categories, :versions, :custom_fields,
+           :enabled_modules, :roles, :members, :member_roles
 
   def setup
     @provider = RedmineAiHelper::Tools::IssueSearchTools.new
+    # search_issues requires the ai_helper module and the view_ai_helper permission
+    # on the searched project. Project 1 with role 1 (jsmith's role) is the baseline
+    # used by every search test below.
+    EnabledModule.create!(project_id: 1, name: "ai_helper")
+    Role.find(1).add_permission!(:view_ai_helper)
   end
 
   context "search_issues" do
@@ -58,7 +64,7 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
       assert_operator result[:total_count], :>=, 55
     end
 
-    should "only return issues visible to current user" do
+    should "refuse to search a project that is not visible to the current user" do
       # Create a private project with a new tracker
       private_tracker = Tracker.create!(name: "PrivateTracker#{Time.now.to_i}#{rand(10000)}", default_status: IssueStatus.first)
       private_project = Project.create!(
@@ -70,6 +76,8 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
       unless private_project.trackers.include?(private_tracker)
         private_project.trackers << private_tracker
       end
+      # Enable the module so that a disabled module cannot be the reason for the failure
+      EnabledModule.create!(project_id: private_project.id, name: "ai_helper")
 
       Issue.create!(
         project: private_project,
@@ -82,13 +90,36 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
 
       # Switch to anonymous user
       User.current = User.anonymous
-      result = @provider.search_issues(project_id: private_project.id)
 
-      assert_equal 0, result[:issues].length
-      assert_equal 0, result[:total_count]
+      assert_raises(RuntimeError) do
+        @provider.search_issues(project_id: private_project.id)
+      end
     ensure
       private_project&.destroy
       private_tracker&.destroy
+    end
+
+    should "exclude issues the current user cannot see inside an accessible project" do
+      # "default" visibility hides private issues from anyone but their author and assignee
+      Role.find(1).update!(issues_visibility: "default")
+      private_issue = Issue.create!(
+        project: @project, tracker: @tracker, subject: "Private Issue In Accessible Project",
+        author: User.find(3), status: IssueStatus.first, priority: IssuePriority.first,
+        is_private: true
+      )
+      visible_issue = Issue.create!(
+        project: @project, tracker: @tracker, subject: "Visible Issue In Accessible Project",
+        author: User.find(3), status: IssueStatus.first, priority: IssuePriority.first
+      )
+
+      result = @provider.search_issues(project_id: @project.id)
+      ids = result[:issues].map { |i| i[:id] }
+
+      assert_includes ids, visible_issue.id
+      assert_not_includes ids, private_issue.id
+    ensure
+      private_issue&.destroy
+      visible_issue&.destroy
     end
 
     should "return formatted issue data with id and name" do
@@ -232,6 +263,77 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
       assert_kind_of Array, issue_data[:custom_fields]
     ensure
       issue&.destroy
+    end
+  end
+
+  context "search_issues access control" do
+    setup do
+      @project = Project.find(1)
+      @tracker = Tracker.find(1)
+      @user = User.find(2)
+      @previous_user = User.current
+      User.current = @user
+    end
+
+    teardown do
+      User.current = @previous_user
+    end
+
+    context "when the ai_helper module is disabled" do
+      setup do
+        EnabledModule.where(project_id: @project.id, name: "ai_helper").destroy_all
+      end
+
+      should "raise an error without search conditions" do
+        assert_raises(RuntimeError) do
+          @provider.search_issues(project_id: @project.id)
+        end
+      end
+
+      should "raise an error with filter conditions as well" do
+        assert_raises(RuntimeError) do
+          @provider.search_issues(project_id: @project.id, fields: [
+            { field_name: "tracker_id", operator: "=", values: [ @tracker.id.to_s ] }
+          ])
+        end
+      end
+
+      should "report the same error message as the other tools" do
+        error = assert_raises(RuntimeError) do
+          @provider.search_issues(project_id: @project.id)
+        end
+
+        assert_equal "ai_helper is not enabled for project: id = #{@project.id}", error.message
+      end
+    end
+
+    should "raise an error when the user lacks the view_ai_helper permission" do
+      Role.find(1).remove_permission!(:view_ai_helper)
+
+      assert_raises(RuntimeError) do
+        @provider.search_issues(project_id: @project.id)
+      end
+    end
+
+    should "raise an error when project_id is not given" do
+      assert_raises(RuntimeError) do
+        @provider.search_issues(project_id: nil)
+      end
+    end
+
+    should "raise a record not found error for a project that does not exist" do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        @provider.search_issues(project_id: 0)
+      end
+    end
+
+    should "state in the tool description that only ai_helper enabled projects are searchable" do
+      schema = RedmineAiHelper::Tools::IssueSearchTools.function_schemas.to_openai_format.find do |f|
+        f[:function][:name].end_with?("__search_issues")
+      end
+
+      assert_match(/AI Helper module enabled/, schema[:function][:description])
+      assert_match(/AI Helper module enabled/, schema[:function][:parameters][:properties][:project_id][:description])
     end
   end
 


### PR DESCRIPTION
## Changes

- Reject `search_issues` when the target project has the AI Helper module disabled, is not visible to the current user, or the user lacks the AI Helper permission — issues from opted-out projects must never reach an LLM
- Reuse the existing `accessible_project?` check that the project and wiki tools already apply, instead of introducing a second rule
- Place the guard before the filter/no-filter branch so both search paths are covered by one check
- Raise an explicit error when `project_id` is missing, since the LLM sometimes omits required parameters
- State in the tool description that only projects with the AI Helper module enabled can be searched, so the model stops trying disabled projects
- Add tests for every rejection path (module disabled, no permission, invisible project, missing `project_id`, unknown project) and for issue level visibility inside an accessible project

Note: a project that is not visible to the user now raises instead of returning an empty result, so the assistant reports "not accessible" rather than "no issues".