### PR TITLE
Fix Japanese translation for assignment suggestion instructions

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -298,7 +298,7 @@ ja:
         issue_draft_instructions: "チケットのコメントを生成する際の指示"
         subtask_instructions: "子チケットを生成する際の指示"
         health_report_instructions: "健全性レポートを生成する際の指示"
-        assignment_suggestion_instructions: "担当者提案インストラクション"
+        assignment_suggestion_instructions: "担当者提案をする際の指示"
       ai_helper_custom_command:
         name: "コマンド名"
         command_type: "コマンドタイプ"


### PR DESCRIPTION
## Changes

- Correct the Japanese translation for `assignment_suggestion_instructions` in `config/locales/ja.yml`