### PR TITLE
Add inbound chat webhook gateway foundation

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/043-issue-create-routing"
+  "feature_directory": "specs/044-inbound-chat-webhook"
 }

--- a/app/controllers/ai_helper_chat_webhook_controller.rb
+++ b/app/controllers/ai_helper_chat_webhook_controller.rb
@@ -9,6 +9,17 @@
 class AiHelperChatWebhookController < ApplicationController
   include RedmineAiHelper::Logger
 
+  # The keys +parse_events+ is allowed to return (the event shape of
+  # contracts/inbound_adapter.md). +channel_type+, +received_at+ and +status+
+  # are deliberately absent: they belong to the receiving side, and an adapter
+  # that supplied one would rewrite the deduplication scope, the freshness
+  # clock or the queue state of its own row. An event carrying any other key
+  # is rejected in #store_event rather than trimmed, so the adapter defect
+  # shows up in the log instead of being silently dropped.
+  EVENT_CONTRACT_KEYS = %i[
+    event_key text channel_id thread_key message_ts dm in_thread reply_metadata
+  ].freeze
+
   # No session is involved: the request comes from an external service, not
   # a browser with a Redmine session cookie. Authenticity is established by
   # the adapter's own #verify_request (typically a signature check), not by
@@ -29,7 +40,7 @@ class AiHelperChatWebhookController < ApplicationController
     return unless adapter
 
     unless adapter.verify_request(request)
-      ai_helper_logger.warn "ai_helper_chat_webhook: request verification failed for channel_type=#{params[:channel_type]}"
+      ai_helper_logger.warn "ai_helper_chat_webhook: request verification failed for channel_type=#{adapter.channel_type}"
       head :unauthorized
       return
     end
@@ -103,14 +114,36 @@ class AiHelperChatWebhookController < ApplicationController
   # full backtrace and skipped, so it neither becomes a 500 the external
   # service would answer by resending the same broken payload forever, nor
   # takes the other events of the same delivery down with it.
+  #
+  # +channel_type+ and +received_at+ are set here rather than taken from the
+  # event, and an event supplying either of them is rejected by
+  # #check_event_shape!, so an adapter cannot store a row against another
+  # channel or backdate its own freshness deadline.
   # @param channel_type [String] the adapter's identifier
   # @param event [Hash] one event returned by the adapter
   # @return [void]
   def store_event(channel_type, event)
     event_key = event[:event_key] if event.is_a?(Hash)
+    check_event_shape!(event)
     saved = AiHelperInboundEvent.record_event(channel_type: channel_type, received_at: Time.current, **event)
     ai_helper_logger.info "ai_helper_chat_webhook: duplicate event_key=#{event_key} for channel_type=#{channel_type}" unless saved
   rescue => e
     ai_helper_logger.error "ai_helper_chat_webhook: failed to store event #{event_key} for channel_type=#{channel_type}: #{e.full_message}"
+  end
+
+  # Raises unless the event is a Hash whose keys all belong to
+  # EVENT_CONTRACT_KEYS. Rejecting the whole event is intentional: an
+  # out-of-contract key means the adapter and the queue disagree about what
+  # the event is, and quietly trimming the key would store a row that
+  # silently differs from what the adapter believed it produced.
+  # @param event [Object] one event returned by the adapter
+  # @raise [ArgumentError] when the event is not a Hash or carries an
+  #   out-of-contract key
+  # @return [void]
+  def check_event_shape!(event)
+    raise ArgumentError, "event must be a Hash, got #{event.class}" unless event.is_a?(Hash)
+
+    unexpected = event.keys - EVENT_CONTRACT_KEYS
+    raise ArgumentError, "event carries keys outside the contract: #{unexpected.inspect}" if unexpected.any?
   end
 end

--- a/app/controllers/ai_helper_chat_webhook_controller.rb
+++ b/app/controllers/ai_helper_chat_webhook_controller.rb
@@ -53,23 +53,25 @@ class AiHelperChatWebhookController < ApplicationController
   # (contracts/webhook_endpoint.md).
   # @return [RedmineAiHelper::ChatChannel::InboundAdapter, nil]
   def resolve_inbound_adapter
-    channel_type = params[:channel_type]
-    adapter_class = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type]
+    adapter_class = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[params[:channel_type]]
     unless adapter_class
-      ai_helper_logger.warn "ai_helper_chat_webhook: unknown channel_type=#{channel_type}"
+      # Quoted because this is the only branch that logs an unverified value
+      # straight from the URL: quoting keeps a crafted value from passing
+      # itself off as further log content.
+      ai_helper_logger.warn "ai_helper_chat_webhook: unknown channel_type=#{params[:channel_type].inspect}"
       head :not_found
       return nil
     end
 
     unless adapter_class.inbound?
-      ai_helper_logger.warn "ai_helper_chat_webhook: channel_type=#{channel_type} is not an inbound adapter"
+      ai_helper_logger.warn "ai_helper_chat_webhook: channel_type=#{adapter_class.channel_type} is not an inbound adapter"
       head :not_found
       return nil
     end
 
     adapter = adapter_class.new
     unless adapter.enabled?
-      ai_helper_logger.warn "ai_helper_chat_webhook: channel_type=#{channel_type} is not enabled"
+      ai_helper_logger.warn "ai_helper_chat_webhook: channel_type=#{adapter_class.channel_type} is not enabled"
       head :not_found
       return nil
     end
@@ -85,17 +87,30 @@ class AiHelperChatWebhookController < ApplicationController
   # @param adapter [RedmineAiHelper::ChatChannel::InboundAdapter]
   # @return [void]
   def store_events(adapter)
-    channel_type = params[:channel_type]
     events = begin
       adapter.parse_events(request)
     rescue => e
-      ai_helper_logger.error "ai_helper_chat_webhook: failed to parse payload for channel_type=#{channel_type}: #{e.full_message}"
+      ai_helper_logger.error "ai_helper_chat_webhook: failed to parse payload for channel_type=#{adapter.channel_type}: #{e.full_message}"
       []
     end
 
-    events.each do |event|
-      saved = AiHelperInboundEvent.record_event(channel_type: channel_type, received_at: Time.current, **event)
-      ai_helper_logger.info "ai_helper_chat_webhook: duplicate event_key=#{event[:event_key]} for channel_type=#{channel_type}" unless saved
-    end
+    events.each { |event| store_event(adapter.channel_type, event) }
+  end
+
+  # Stores one normalized event as a pending row. An event that does not
+  # meet the contracts/inbound_adapter.md event shape (an unknown key, a
+  # missing required field) is a defect in the adapter: it is logged with its
+  # full backtrace and skipped, so it neither becomes a 500 the external
+  # service would answer by resending the same broken payload forever, nor
+  # takes the other events of the same delivery down with it.
+  # @param channel_type [String] the adapter's identifier
+  # @param event [Hash] one event returned by the adapter
+  # @return [void]
+  def store_event(channel_type, event)
+    event_key = event[:event_key] if event.is_a?(Hash)
+    saved = AiHelperInboundEvent.record_event(channel_type: channel_type, received_at: Time.current, **event)
+    ai_helper_logger.info "ai_helper_chat_webhook: duplicate event_key=#{event_key} for channel_type=#{channel_type}" unless saved
+  rescue => e
+    ai_helper_logger.error "ai_helper_chat_webhook: failed to store event #{event_key} for channel_type=#{channel_type}: #{e.full_message}"
   end
 end

--- a/app/controllers/ai_helper_chat_webhook_controller.rb
+++ b/app/controllers/ai_helper_chat_webhook_controller.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Single receive endpoint shared by every inbound chat adapter
+# (+POST /ai_helper/chat_webhook/:channel_type+, contracts/webhook_endpoint.md).
+# The endpoint only verifies, normalizes and persists events; it never
+# generates an AI answer itself (FR-003, ADR-006 permission separation). The
+# resident gateway process picks up saved rows through
+# +RedmineAiHelper::ChatChannel::InboundAdapter#start+.
+class AiHelperChatWebhookController < ApplicationController
+  include RedmineAiHelper::Logger
+
+  # No session is involved: the request comes from an external service, not
+  # a browser with a Redmine session cookie. Authenticity is established by
+  # the adapter's own #verify_request (typically a signature check), not by
+  # the CSRF token.
+  skip_before_action :verify_authenticity_token
+
+  # Skip Redmine's global login_required filter so Setting.login_required =
+  # ON does not return 403 before the adapter's own verification runs
+  # (same reasoning as AiHelperMcpController, Issue #304).
+  skip_before_action :check_if_login_required, raise: false
+
+  # Receives one webhook delivery, verifies it, and stores zero or more
+  # normalized events as pending rows for the gateway to poll
+  # (contracts/webhook_endpoint.md processing order).
+  # @return [void]
+  def receive
+    adapter = resolve_inbound_adapter
+    return unless adapter
+
+    unless adapter.verify_request(request)
+      ai_helper_logger.warn "ai_helper_chat_webhook: request verification failed for channel_type=#{params[:channel_type]}"
+      head :unauthorized
+      return
+    end
+
+    challenge = adapter.challenge_response(request)
+    if challenge
+      render plain: challenge[:body], status: challenge[:status], content_type: challenge[:content_type]
+      return
+    end
+
+    store_events(adapter)
+    head :ok
+  end
+
+  private
+
+  # Resolves the adapter for the requested channel_type, rendering 404 and
+  # logging when it does not exist, is not an inbound adapter, or is not
+  # enabled. Unknown, non-inbound and disabled adapters share the same 404
+  # response so the endpoint never reveals which adapters are configured
+  # (contracts/webhook_endpoint.md).
+  # @return [RedmineAiHelper::ChatChannel::InboundAdapter, nil]
+  def resolve_inbound_adapter
+    channel_type = params[:channel_type]
+    adapter_class = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type]
+    unless adapter_class
+      ai_helper_logger.warn "ai_helper_chat_webhook: unknown channel_type=#{channel_type}"
+      head :not_found
+      return nil
+    end
+
+    unless adapter_class.inbound?
+      ai_helper_logger.warn "ai_helper_chat_webhook: channel_type=#{channel_type} is not an inbound adapter"
+      head :not_found
+      return nil
+    end
+
+    adapter = adapter_class.new
+    unless adapter.enabled?
+      ai_helper_logger.warn "ai_helper_chat_webhook: channel_type=#{channel_type} is not enabled"
+      head :not_found
+      return nil
+    end
+
+    adapter
+  end
+
+  # Parses the request into events and stores each as a pending row,
+  # skipping duplicates. A payload the adapter cannot interpret is logged
+  # with its full backtrace and treated as received (no events stored)
+  # rather than rejected, so the external service does not retry it forever
+  # (contracts/webhook_endpoint.md step 6).
+  # @param adapter [RedmineAiHelper::ChatChannel::InboundAdapter]
+  # @return [void]
+  def store_events(adapter)
+    channel_type = params[:channel_type]
+    events = begin
+      adapter.parse_events(request)
+    rescue => e
+      ai_helper_logger.error "ai_helper_chat_webhook: failed to parse payload for channel_type=#{channel_type}: #{e.full_message}"
+      []
+    end
+
+    events.each do |event|
+      saved = AiHelperInboundEvent.record_event(channel_type: channel_type, received_at: Time.current, **event)
+      ai_helper_logger.info "ai_helper_chat_webhook: duplicate event_key=#{event[:event_key]} for channel_type=#{channel_type}" unless saved
+    end
+  end
+end

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -98,9 +98,14 @@ module AiHelperSettingsHelper
 
   # The webhook URL to register with the external service for an inbound
   # adapter (FR-011), or nil when the adapter does not receive events by
-  # webhook. Built from Setting.protocol/Setting.host_name rather than a
-  # request-scoped url_for, so it also resolves for adapters that are not
-  # currently reachable within the running request.
+  # webhook. Built from the route helper and Mailer.default_url_options
+  # rather than a request-scoped url_for: the URL has to be the one the
+  # external service will call, which is the deployment's own base URL and
+  # not necessarily the host of the request that renders this page.
+  # Setting.host_name may embed a port and/or a path prefix
+  # (e.g. "r.example.com:3000/redmine"), and default_url_options already
+  # parses that into :host, :port and :script_name the way the rest of
+  # Redmine expects (same reasoning as ChatChannel::IssueLinkFormatter).
   #
   # @param channel_type [String] adapter identifier (e.g. "line")
   # @return [String, nil]
@@ -108,7 +113,9 @@ module AiHelperSettingsHelper
     adapter_class = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type]
     return nil unless adapter_class&.inbound?
 
-    "#{Setting.protocol}://#{Setting.host_name}/ai_helper/chat_webhook/#{channel_type}"
+    Rails.application.routes.url_helpers.ai_helper_chat_webhook_url(
+      channel_type: channel_type, **Mailer.default_url_options
+    )
   end
 
   # Returns options for model profile select fields.

--- a/app/helpers/ai_helper_settings_helper.rb
+++ b/app/helpers/ai_helper_settings_helper.rb
@@ -96,6 +96,21 @@ module AiHelperSettingsHelper
     params_tab
   end
 
+  # The webhook URL to register with the external service for an inbound
+  # adapter (FR-011), or nil when the adapter does not receive events by
+  # webhook. Built from Setting.protocol/Setting.host_name rather than a
+  # request-scoped url_for, so it also resolves for adapters that are not
+  # currently reachable within the running request.
+  #
+  # @param channel_type [String] adapter identifier (e.g. "line")
+  # @return [String, nil]
+  def ai_helper_chat_webhook_url_for(channel_type)
+    adapter_class = RedmineAiHelper::ChatChannel::BaseAdapter.adapters[channel_type]
+    return nil unless adapter_class&.inbound?
+
+    "#{Setting.protocol}://#{Setting.host_name}/ai_helper/chat_webhook/#{channel_type}"
+  end
+
   # Returns options for model profile select fields.
   #
   # @param profiles [ActiveRecord::Relation] collection of model profiles

--- a/app/models/ai_helper_inbound_event.rb
+++ b/app/models/ai_helper_inbound_event.rb
@@ -5,11 +5,15 @@
 # persistent queue between the Redmine web process (receive) and the
 # resident gateway process (poll and process): see data-model.md.
 class AiHelperInboundEvent < ApplicationRecord
-  # Valid values of +status+: see the state diagram in data-model.md.
-  STATUSES = %w[pending processed expired].freeze
+  # Valid values of +status+: see the state diagram in data-model.md. Declared
+  # as an enum so the values live in one place instead of as string literals
+  # spread over the model and the polling adapter. +validate: true+ keeps an
+  # unknown value a validation error rather than an ArgumentError raised at
+  # assignment time.
+  STATUSES = { pending: "pending", processed: "processed", expired: "expired" }.freeze
+  enum :status, STATUSES, validate: true
 
   validates :channel_type, :event_key, :text, :channel_id, :thread_key, :received_at, presence: true
-  validates :status, inclusion: { in: STATUSES }
   validates :event_key, uniqueness: { scope: :channel_type }
 
   class << self
@@ -18,15 +22,25 @@ class AiHelperInboundEvent < ApplicationRecord
     # [channel_type, event_key] is the source of truth for deduplication
     # under concurrent receives (R-004), where two inserts can both pass
     # validation before either commits.
+    #
+    # Only duplication is answered with nil. Any other validation failure
+    # means the adapter produced an event that does not meet the
+    # contracts/inbound_adapter.md event shape, which is a defect in that
+    # adapter: it is raised so the caller can log it as the error it is,
+    # rather than being silently folded into "already received".
     # @param attrs [Hash] channel_type:, event_key:, text:, channel_id:,
     #   thread_key:, received_at: (required), plus the optional message_ts:,
     #   dm:, in_thread:, reply_metadata:
+    # @raise [ActiveRecord::RecordInvalid] when the event is invalid for any
+    #   reason other than duplication
     # @return [AiHelperInboundEvent, nil] the saved event, or nil when the
     #   same channel_type/event_key was already received
     def record_event(**attrs)
       event = new(attrs)
-      event.save
-      event.persisted? ? event : nil
+      return event if event.save
+      return nil if event.errors.of_kind?(:event_key, :taken)
+
+      raise ActiveRecord::RecordInvalid, event
     rescue ActiveRecord::RecordNotUnique
       nil
     end
@@ -36,11 +50,14 @@ class AiHelperInboundEvent < ApplicationRecord
     # @param limit [Integer] Maximum number of rows to return
     # @return [ActiveRecord::Relation<AiHelperInboundEvent>]
     def pending_for(channel_type, limit:)
-      where(channel_type: channel_type, status: "pending").order(:received_at).limit(limit)
+      pending.where(channel_type: channel_type).order(:received_at).limit(limit)
     end
 
     # Deletes rows of the given channel_type received before the given time
-    # (FR-009).
+    # (FR-009). Deliberately independent of +status+: the row is kept only to
+    # deduplicate resends, and a row this old can no longer be answered
+    # whatever state it is in (FRESHNESS_LIMIT_SECONDS is orders of magnitude
+    # shorter than the retention period).
     # @param channel_type [String] Adapter identifier
     # @param before [Time] Cutoff; rows received earlier than this are deleted
     # @return [void]
@@ -57,16 +74,28 @@ class AiHelperInboundEvent < ApplicationRecord
   # @return [Boolean] whether this call performed the claim
   def claim
     # rubocop:disable Rails/SkipsModelValidations
-    updated = self.class.where(id: id, status: "pending").update_all(status: "processed")
+    updated = self.class.pending.where(id: id).update_all(status: STATUSES[:processed])
     # rubocop:enable Rails/SkipsModelValidations
     reload if updated.positive?
     updated.positive?
   end
 
+  # Stores the adapter's reply metadata. contracts/inbound_adapter.md lets
+  # +parse_events+ return +:reply_metadata+ as a Hash while the column holds
+  # JSON, so the conversion belongs here rather than in every caller: without
+  # it a Hash would reach the text column and be stored as its Ruby
+  # inspect form, which +InboundAdapter#reply_metadata_for+ cannot parse. A
+  # String is assumed to be JSON already and is stored as given.
+  # @param value [Hash, String, nil] the metadata to store
+  # @return [void]
+  def reply_metadata=(value)
+    super(value.is_a?(Hash) ? value.to_json : value)
+  end
+
   # Marks the row as expired (FR-008a): received too long ago to answer.
   # @return [void]
   def expire!
-    update!(status: "expired")
+    expired!
   end
 
   # Whether +received_at+ is older than +limit_seconds+.

--- a/app/models/ai_helper_inbound_event.rb
+++ b/app/models/ai_helper_inbound_event.rb
@@ -106,9 +106,13 @@ class AiHelperInboundEvent < ApplicationRecord
   end
 
   # Builds the normalized message the existing chat channel core consumes.
-  # @return [RedmineAiHelper::ChatChannel::IncomingMessage]
+  # Carries this row's id so that the reply posted for this message can be
+  # tied back to it (InboundAdapter#reply_metadata_for); the core treats it
+  # as the plain IncomingMessage it is a subclass of.
+  # @return [RedmineAiHelper::ChatChannel::InboundEventMessage]
   def to_incoming_message
-    RedmineAiHelper::ChatChannel::IncomingMessage.new(
+    RedmineAiHelper::ChatChannel::InboundEventMessage.new(
+      event_id: id,
       channel_type: channel_type, channel_id: channel_id, thread_key: thread_key,
       text: text, message_ts: message_ts, dm: dm, in_thread: in_thread
     )

--- a/app/models/ai_helper_inbound_event.rb
+++ b/app/models/ai_helper_inbound_event.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# One event received from an external chat service through the inbound
+# webhook endpoint, normalized by the adapter at receive time. Acts as a
+# persistent queue between the Redmine web process (receive) and the
+# resident gateway process (poll and process): see data-model.md.
+class AiHelperInboundEvent < ApplicationRecord
+  # Valid values of +status+: see the state diagram in data-model.md.
+  STATUSES = %w[pending processed expired].freeze
+
+  validates :channel_type, :event_key, :text, :channel_id, :thread_key, :received_at, presence: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :event_key, uniqueness: { scope: :channel_type }
+
+  class << self
+    # Persists one event. The app-level uniqueness validation rejects a
+    # duplicate on the normal path; the DB unique index on
+    # [channel_type, event_key] is the source of truth for deduplication
+    # under concurrent receives (R-004), where two inserts can both pass
+    # validation before either commits.
+    # @param attrs [Hash] channel_type:, event_key:, text:, channel_id:,
+    #   thread_key:, received_at: (required), plus the optional message_ts:,
+    #   dm:, in_thread:, reply_metadata:
+    # @return [AiHelperInboundEvent, nil] the saved event, or nil when the
+    #   same channel_type/event_key was already received
+    def record_event(**attrs)
+      event = new(attrs)
+      event.save
+      event.persisted? ? event : nil
+    rescue ActiveRecord::RecordNotUnique
+      nil
+    end
+
+    # Pending rows for the given channel_type, oldest received first.
+    # @param channel_type [String] Adapter identifier
+    # @param limit [Integer] Maximum number of rows to return
+    # @return [ActiveRecord::Relation<AiHelperInboundEvent>]
+    def pending_for(channel_type, limit:)
+      where(channel_type: channel_type, status: "pending").order(:received_at).limit(limit)
+    end
+
+    # Deletes rows of the given channel_type received before the given time
+    # (FR-009).
+    # @param channel_type [String] Adapter identifier
+    # @param before [Time] Cutoff; rows received earlier than this are deleted
+    # @return [void]
+    def purge_old(channel_type, before:)
+      where(channel_type: channel_type, received_at: ...before).delete_all
+    end
+  end
+
+  # Atomically claims this row: only a row still in +pending+ transitions to
+  # +processed+ (R-004). Bypasses validations by design: this is a
+  # conditional UPDATE used purely as a claim primitive (the WHERE clause,
+  # not a callback, is what makes it atomic), not a write of user-provided
+  # attributes. Reloads on success so the in-memory status matches the DB.
+  # @return [Boolean] whether this call performed the claim
+  def claim
+    # rubocop:disable Rails/SkipsModelValidations
+    updated = self.class.where(id: id, status: "pending").update_all(status: "processed")
+    # rubocop:enable Rails/SkipsModelValidations
+    reload if updated.positive?
+    updated.positive?
+  end
+
+  # Marks the row as expired (FR-008a): received too long ago to answer.
+  # @return [void]
+  def expire!
+    update!(status: "expired")
+  end
+
+  # Whether +received_at+ is older than +limit_seconds+.
+  # @param limit_seconds [Numeric] Freshness limit in seconds
+  # @return [Boolean]
+  def expired_by?(limit_seconds)
+    received_at < limit_seconds.seconds.ago
+  end
+
+  # Builds the normalized message the existing chat channel core consumes.
+  # @return [RedmineAiHelper::ChatChannel::IncomingMessage]
+  def to_incoming_message
+    RedmineAiHelper::ChatChannel::IncomingMessage.new(
+      channel_type: channel_type, channel_id: channel_id, thread_key: thread_key,
+      text: text, message_ts: message_ts, dm: dm, in_thread: in_thread
+    )
+  end
+end

--- a/app/views/ai_helper_settings/_channels_tab.html.erb
+++ b/app/views/ai_helper_settings/_channels_tab.html.erb
@@ -51,6 +51,13 @@
                        options_from_collection_for_select(@ai_helper_projects, :id, :name, adapter_setting.default_project_id),
                        include_blank: true, id: nil %>
       </p>
+      <% if (webhook_url = ai_helper_chat_webhook_url_for(channel_type)) %>
+        <p>
+          <label><%= t("ai_helper.chat_channel.settings.webhook_url") %></label>
+          <%= text_field_tag nil, webhook_url, size: 60, readonly: true, id: nil %>
+          <em class="info"><%= t("ai_helper.chat_channel.settings.webhook_url_info") %></em>
+        </p>
+      <% end %>
     </div>
     <% if adapter_setting.configured? %>
       <fieldset class="box" id="adapter-bindings-<%= channel_type %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,8 @@ en:
         redmine_user: "Execution account"
         redmine_user_info: "All questions from the chat tool are processed with this Redmine user's permissions. Restrict this account's roles to limit what the gateway can do."
         default_project: "Default project"
+        webhook_url: "Webhook URL"
+        webhook_url_info: "Register this URL with the external service so it can deliver messages to this integration."
         bindings: "Channel bindings"
         adapter: "Chat tool"
         channel_id: "Channel ID"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,6 +48,8 @@ ja:
         redmine_user: "実行アカウント"
         redmine_user_info: "チャットツールからのすべての質問はこのRedmineユーザーの権限で処理されます。このアカウントのロールを絞ることで、ゲートウェイ経由で可能な操作を制限できます。"
         default_project: "既定プロジェクト"
+        webhook_url: "Webhook URL"
+        webhook_url_info: "このURLを外部サービスに登録すると、この連携にメッセージが配信されます。"
         bindings: "チャンネル対応付け"
         adapter: "チャットツール"
         channel_id: "チャンネルID"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,4 +107,7 @@ RedmineApp::Application.routes.draw do
   # MCP (Model Context Protocol) server endpoint
   match "ai_helper/mcp", to: "ai_helper_mcp#handle_request",
         via: [ :get, :post, :delete ], as: "ai_helper_mcp"
+
+  # Inbound chat webhook endpoint, shared by every inbound adapter
+  post "ai_helper/chat_webhook/:channel_type", to: "ai_helper_chat_webhook#receive", as: "ai_helper_chat_webhook"
 end

--- a/db/migrate/20260808000000_create_ai_helper_inbound_events.rb
+++ b/db/migrate/20260808000000_create_ai_helper_inbound_events.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Persistent queue row for one webhook-delivered chat event, normalized by an
+# inbound adapter at receive time. The web process inserts pending rows here;
+# the resident gateway process polls and claims them (data-model.md).
+class CreateAiHelperInboundEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :ai_helper_inbound_events do |t|
+      t.string :channel_type, null: false
+      t.string :event_key, null: false
+      t.text :text, null: false
+      t.string :channel_id, null: false
+      t.string :thread_key, null: false
+      t.string :message_ts
+      t.boolean :dm, null: false, default: false
+      t.boolean :in_thread, null: false, default: false
+      t.text :reply_metadata
+      t.string :status, null: false, default: "pending", limit: 20
+      t.datetime :received_at, null: false
+      t.timestamps
+    end
+
+    add_index :ai_helper_inbound_events, [ :channel_type, :event_key ],
+              unique: true, name: "index_ai_helper_inbound_events_unique"
+    add_index :ai_helper_inbound_events, [ :channel_type, :status, :received_at ],
+              name: "index_ai_helper_inbound_events_on_poll"
+  end
+end

--- a/docs/adr/017-inbound-chat-webhook-gateway.md
+++ b/docs/adr/017-inbound-chat-webhook-gateway.md
@@ -1,0 +1,36 @@
+# ADR-017: Inbound chat webhook gateway (amends the scope of ADR-006)
+
+**Date**: 2026-08-08
+**Status**: Accepted
+
+## Context
+
+ADR-006 established the chat channel gateway architecture around adapters that open an *outgoing* connection to the chat tool (Slack Socket Mode, Discord's Gateway API), so that a Redmine installation never needs a public URL, TLS termination, or a reverse-proxy webhook endpoint (FR-001 of feature 028). That premise does not hold for every chat platform: services such as LINE and Microsoft Teams only deliver events by pushing an HTTPS POST to a URL the integration registers with them. Building on ADR-006 unchanged would leave no way to support these services at all.
+
+Feature 044 adds the receiving side for that class of integration: a single inbound webhook endpoint, a persistent queue table, and an `InboundAdapter` base class that plugs into the existing gateway/adapter-thread machinery. This ADR records the two decisions that extend the scope of ADR-006 rather than duplicate it — see `specs/044-inbound-chat-webhook/research.md` (R-001 through R-010) for the full alternatives analysis behind each one.
+
+## Decision
+
+1. **"No public URL required" is an outbound-adapter property, not a whole-plugin invariant.** ADR-006's decision 1 (outgoing Socket Mode connection) is not revisited or weakened for Slack/Discord: those adapters are completely unaffected by this feature (SC-006/SC-007, proven by the existing adapter test suite passing unmodified). What changes is the scope of the guarantee: an inbound-type adapter, by the nature of the platform it talks to, *does* require a public HTTPS endpoint. Operators who only enable outbound adapters see no new requirement; operators who enable an inbound adapter must expose `/ai_helper/chat_webhook/:channel_type` behind their existing Redmine reverse proxy, the same way they already expose the rest of Redmine.
+
+2. **The webhook endpoint lives in the Redmine web process, not the gateway process.** The receiving HTTP endpoint (`AiHelperChatWebhookController`) runs inside Redmine itself (Puma/Passenger), reusing Redmine's existing public HTTPS URL, TLS termination and reverse-proxy configuration. It only verifies, normalizes and persists an event to `ai_helper_inbound_events` — it never calls the LLM (ADR-006 decision 5's permission separation is preserved: the multi-threaded web process must never touch `User.current`). The resident gateway process remains the only process that runs LLM requests; its `InboundAdapter#start` polls that table (2-second interval) instead of opening a socket, so `Gateway`, `MessageHandler`, `IncomingMessage` and every existing adapter require zero changes (research.md R-001/R-002/R-003).
+
+## Consequences
+
+**Positive**:
+
+- LINE, Teams and any other webhook-only chat platform can now be integrated by writing one `InboundAdapter` subclass (`verify_request`, `parse_events`, optionally `challenge_response`) with no core changes — proven end to end by a test-only reference adapter (FR-012/SC-007).
+- Outbound-only deployments (the only kind that existed before this feature) are provably unaffected: the full pre-existing test suite, including `gateway_test.rb` and both concrete adapters' tests, passes unmodified.
+- The permission-isolation guarantee from ADR-006 decision 5 is preserved exactly: the web process that is reachable from the internet never runs an LLM request or touches `User.current`.
+
+**Negative**:
+
+- An operator who wants to use an inbound-type integration now needs a public HTTPS URL for their Redmine instance, undoing part of the appeal of ADR-006 decision 1 for that specific integration. This is unavoidable given how those chat platforms work, not a design choice this feature makes.
+- The plugin does not implement request-rate limiting on the webhook endpoint; that is delegated to the reverse-proxy layer (documented in `docs/inbound_chat_adapter_development.md`), matching how the rest of Redmine's public surface is protected.
+
+## Alternatives Considered
+
+See `specs/044-inbound-chat-webhook/research.md` for the complete list; the two most relevant to this ADR's scope:
+
+- **HTTP listener inside the resident gateway process** (rejected, R-001): would give the systemd-supervised gateway process its own public-facing surface, splitting "web serving" and "serial LLM processing" across the same process boundary ADR-006 was written to keep separate.
+- **Silently reusing ADR-006's "no public URL" framing for every adapter type** (rejected): would misdescribe the actual requirement to operators enabling an inbound adapter and risk them leaving the endpoint unreachable. This ADR exists specifically to make the amended scope explicit rather than leave it implicit in the code.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,3 +69,4 @@ Briefly describe alternatives that were rejected and why.
 | [014](./014-shared-websocket-transport-in-base-adapter.md) | Move the shared WebSocket transport handling into `BaseAdapter` and apply it to Discord | Accepted |
 | [015](./015-agent-write-capability-routing.md) | Guard write-capable steps with an internal capability check that is never exposed to the router | Accepted |
 | [016](./016-issue-agent-read-write-rename.md) | Rename IssueAgent/IssueUpdateAgent to IssueReadAgent/IssueWriteAgent | Accepted |
+| [017](./017-inbound-chat-webhook-gateway.md) | Inbound chat webhook gateway (amends the scope of ADR-006) | Accepted |

--- a/docs/inbound_chat_adapter_development.md
+++ b/docs/inbound_chat_adapter_development.md
@@ -74,9 +74,11 @@ Required. Convert the verified request into zero or more normalized event hashes
 | `:message_ts` | String | no | Individual message id, if the platform has one |
 | `:dm` | Boolean | no | Direct message flag (default `false`) |
 | `:in_thread` | Boolean | no | Reply-in-thread flag (default `false`) |
-| `:reply_metadata` | Hash | no | Platform-specific data needed later to reply; JSON-encoded when stored |
+| `:reply_metadata` | Hash | no | Platform-specific data needed later to reply; `AiHelperInboundEvent#reply_metadata=` JSON-encodes it on the way into the column |
 
-Never include the bot's own messages, and never put speaker identity into `:reply_metadata` or `:text` (FR-003 — this plugin does not record who asked a question, only the configured service account that answers it, exactly as for the existing outbound adapters). A request that cannot be parsed (malformed JSON, an unexpected shape) should raise; the controller catches it, logs the full backtrace, and still returns `200` so the platform does not retry forever.
+Return exactly these keys — an event carrying anything else is logged as an error and skipped, since it cannot be stored.
+
+Never include the bot's own messages, and never put speaker identity into `:reply_metadata` or `:text` (FR-003 — this plugin does not record who asked a question, only the configured service account that answers it, exactly as for the existing outbound adapters). A request that cannot be parsed (malformed JSON, an unexpected shape) should raise; the controller catches it, logs the full backtrace, and still returns `200` so the platform does not retry forever. The same holds for a single event that cannot be stored: it is logged with its backtrace and skipped, the other events of that delivery are still stored, and the platform still gets a `200`.
 
 ### 4. Implement `#challenge_response(request)` only if the platform needs it
 
@@ -84,7 +86,9 @@ Optional — the default returns `nil`. Some platforms verify a webhook URL at r
 
 ### 5. Reply metadata, if the platform needs more than channel_id/thread_key to reply
 
-`InboundAdapter#reply_metadata_for(thread_key:)` returns the parsed `reply_metadata` of the most recently claimed event for a thread. Call it from `#send_message` if your platform's reply call needs something beyond `channel_id`/`thread_key` (e.g. a reply token). Most platforms that support pushing a message by channel id alone do not need this.
+`InboundAdapter#reply_metadata_for(thread_key:)` returns the parsed `reply_metadata` of the next claimed event of that thread, in claim order, and consumes it — so calling it once per `#send_message` walks the thread's events in the same order the worker answers them. Call it from `#send_message` if your platform's reply call needs something beyond `channel_id`/`thread_key` (e.g. a reply token). Most platforms that support pushing a message by channel id alone do not need this.
+
+Call it exactly once per reply. A poll cycle claims a whole batch before the single worker answers any of it, so "the most recent event of this thread" is *not* the one being answered; the position is per thread and only advances when you call this method.
 
 ### 6. Settings and the webhook URL
 

--- a/docs/inbound_chat_adapter_development.md
+++ b/docs/inbound_chat_adapter_development.md
@@ -1,0 +1,130 @@
+# Developing an Inbound Chat Adapter
+
+This guide explains how to add support for a chat platform that delivers messages by webhook (LINE, Microsoft Teams, ...), building on the inbound webhook foundation added in feature 044. It complements `docs/slack_gateway_setup.md` / `docs/discord_gateway_setup.md`, which document *operator* setup for the existing outgoing-connection adapters; this document is for *developers* implementing a new adapter class.
+
+See also:
+
+- `specs/044-inbound-chat-webhook/contracts/inbound_adapter.md` — the full method-level contract for `InboundAdapter`
+- `specs/044-inbound-chat-webhook/contracts/webhook_endpoint.md` — the HTTP endpoint contract
+- `docs/adr/017-inbound-chat-webhook-gateway.md` — why the endpoint lives in the Redmine web process while the gateway process still does all the polling and LLM work
+
+## When to use InboundAdapter vs BaseAdapter
+
+Use `RedmineAiHelper::ChatChannel::InboundAdapter` (not `BaseAdapter` directly) when the chat platform pushes events to a URL you register with it, rather than letting you open an outgoing connection. `InboundAdapter` already implements `#start` as a polling loop over the persistent queue table (`ai_helper_inbound_events`) that the webhook controller fills in; you only implement the platform-specific parsing and verification.
+
+## Steps
+
+### 1. Create the adapter file
+
+Add `lib/redmine_ai_helper/chat_channel/adapters/<name>_adapter.rb`, following the same location convention as `slack_adapter.rb`/`discord_adapter.rb`. It is picked up automatically by the `Dir[...adapters/*_adapter.rb]` glob in `init.rb` — no manual registration.
+
+```ruby
+# frozen_string_literal: true
+
+require "redmine_ai_helper/chat_channel/inbound_adapter"
+
+module RedmineAiHelper
+  module ChatChannel
+    module Adapters
+      class LineAdapter < InboundAdapter
+        class << self
+          def channel_type
+            "line"
+          end
+
+          def required_setting_fields
+            [ :bot_token ] # stored in AiHelperChatAdapterSetting#bot_token; use app_token too if needed
+          end
+        end
+
+        def verify_request(request)
+          # Compute the signature over request.raw_post (never the parsed
+          # body) and compare it against the platform's signature header.
+        end
+
+        def parse_events(request)
+          # Return an Array<Hash>; see "The event Hash" below. Return []
+          # when the payload carries nothing to answer (e.g. a delivery
+          # receipt or the bot's own message).
+        end
+
+        def send_message(channel_id:, thread_key:, text:)
+          # Post the reply via the platform's REST API.
+        end
+      end
+    end
+  end
+end
+```
+
+### 2. Implement `#verify_request(request)`
+
+Required — there is no default implementation. Authenticity for a webhook-delivered message can only be established by the adapter itself (typically an HMAC signature over the raw body), since there is no Redmine session involved. Always compute the signature over `request.raw_post` — the exact bytes the platform signed — never over a re-serialized version of the parsed JSON, which is not guaranteed to be byte-identical.
+
+### 3. Implement `#parse_events(request)`
+
+Required. Convert the verified request into zero or more normalized event hashes:
+
+| Key | Type | Required | Notes |
+|-----|------|----------|-------|
+| `:event_key` | String | yes | External event id; deduplication key |
+| `:text` | String | yes | Question body, with mention markup already stripped |
+| `:channel_id` | String | yes | Channel (or DM) identifier |
+| `:thread_key` | String | yes | Thread identifier |
+| `:message_ts` | String | no | Individual message id, if the platform has one |
+| `:dm` | Boolean | no | Direct message flag (default `false`) |
+| `:in_thread` | Boolean | no | Reply-in-thread flag (default `false`) |
+| `:reply_metadata` | Hash | no | Platform-specific data needed later to reply; JSON-encoded when stored |
+
+Never include the bot's own messages, and never put speaker identity into `:reply_metadata` or `:text` (FR-003 — this plugin does not record who asked a question, only the configured service account that answers it, exactly as for the existing outbound adapters). A request that cannot be parsed (malformed JSON, an unexpected shape) should raise; the controller catches it, logs the full backtrace, and still returns `200` so the platform does not retry forever.
+
+### 4. Implement `#challenge_response(request)` only if the platform needs it
+
+Optional — the default returns `nil`. Some platforms verify a webhook URL at registration time with a handshake request (e.g. echoing back a `challenge` value). Return `{ status:, content_type:, body: }` for that request and `nil` for every normal event delivery. A non-nil return skips event storage entirely for that request.
+
+### 5. Reply metadata, if the platform needs more than channel_id/thread_key to reply
+
+`InboundAdapter#reply_metadata_for(thread_key:)` returns the parsed `reply_metadata` of the most recently claimed event for a thread. Call it from `#send_message` if your platform's reply call needs something beyond `channel_id`/`thread_key` (e.g. a reply token). Most platforms that support pushing a message by channel id alone do not need this.
+
+### 6. Settings and the webhook URL
+
+No new settings model is needed: `AiHelperChatAdapterSetting` already has the columns every adapter shares (`enabled`, `app_token`, `bot_token`, execution account, default project). Declare whichever of `app_token`/`bot_token` your adapter needs via `required_setting_fields`, the same as an outbound adapter.
+
+Once your adapter is enabled in *Administration → AI Helper → Chat integrations*, its block automatically shows the webhook URL to register with the external service:
+
+```text
+https://<Setting.host_name>/ai_helper/chat_webhook/<channel_type>
+```
+
+This is generic (`InboundAdapter.inbound?` returns `true` by default; `BaseAdapter.inbound?` returns `false`), so nothing adapter-specific needs to be added to the settings view.
+
+## Constants you can rely on
+
+Defined on `InboundAdapter` and shared by every inbound adapter:
+
+| Constant | Default | Meaning |
+|----------|---------|---------|
+| `POLL_INTERVAL_SECONDS` | 2 | How often the gateway checks for new pending events |
+| `FRESHNESS_LIMIT_SECONDS` | 120 | Events claimed after this many seconds since receipt are discarded, not answered |
+| `RETENTION_DAYS` | 7 | How long a row survives (for deduplication) before deletion |
+| `CLEANUP_INTERVAL_SECONDS` | 3600 | Minimum interval between retention cleanups |
+| `POLL_BATCH_SIZE` | 20 | Rows fetched per poll |
+
+## Reverse-proxy recommendations (rate limiting)
+
+The plugin does not rate-limit the webhook endpoint itself (see ADR-017): that is left to the reverse proxy already in front of Redmine, matching how the rest of Redmine's public surface is protected. A minimal nginx example:
+
+```nginx
+limit_req_zone $binary_remote_addr zone=ai_helper_webhook:10m rate=20r/s;
+
+location /ai_helper/chat_webhook/ {
+    limit_req zone=ai_helper_webhook burst=40 nodelay;
+    proxy_pass http://redmine_upstream;
+}
+```
+
+Tune the rate to the traffic your integration actually expects; the endpoint's own work per request is cheap (verify, normalize, insert one row), so the limit mainly exists to bound abuse, not to protect the endpoint's own performance.
+
+## Testing
+
+Follow the reference inbound adapter pattern used by the plugin's own test suite (`test/unit/chat_channel/inbound_adapter_test.rb`): define a test-only subclass with instance- or class-level toggles for `verify_request`/`parse_events`/`challenge_response`, register it only inside the test file (never under `lib/`), and drive `#start` for one poll cycle by stubbing `InboundAdapter.timed_queue_pop` to call `#stop` as a side effect. This proves your adapter integrates with the shared `Gateway`/`MessageHandler` path without needing a real webhook call or a live chat platform.

--- a/docs/inbound_chat_adapter_development.md
+++ b/docs/inbound_chat_adapter_development.md
@@ -86,9 +86,9 @@ Optional — the default returns `nil`. Some platforms verify a webhook URL at r
 
 ### 5. Reply metadata, if the platform needs more than channel_id/thread_key to reply
 
-`InboundAdapter#reply_metadata_for(thread_key:)` returns the parsed `reply_metadata` of the next claimed event of that thread, in claim order, and consumes it — so calling it once per `#send_message` walks the thread's events in the same order the worker answers them. Call it from `#send_message` if your platform's reply call needs something beyond `channel_id`/`thread_key` (e.g. a reply token). Most platforms that support pushing a message by channel id alone do not need this.
+`InboundAdapter#reply_metadata_for(thread_key:)` returns the parsed `reply_metadata` of the event currently being answered. Call it from `#send_message` if your platform's reply call needs something beyond `channel_id`/`thread_key` (e.g. a reply token). Most platforms that support pushing a message by channel id alone do not need this.
 
-Call it exactly once per reply. A poll cycle claims a whole batch before the single worker answers any of it, so "the most recent event of this thread" is *not* the one being answered; the position is per thread and only advances when you call this method.
+Call it as often as you like: it is resolved from the id of the event the reply belongs to, so every call during one reply returns the same value, and a reply never sees another event's metadata — not the next event of a batch the poll cycle claimed alongside it, and not an event answered days ago whose row is still retained for deduplication. It returns `nil` outside a reply, when the event carries no metadata, or when `thread_key` is not the thread being answered.
 
 ### 6. Settings and the webhook URL
 

--- a/init.rb
+++ b/init.rb
@@ -19,6 +19,7 @@ require "redmine_ai_helper/util/permission_checker"
 require "redmine_ai_helper/user_patch"
 require "redmine_ai_helper/project_patch"
 require "redmine_ai_helper/chat_channel/base_adapter"
+require "redmine_ai_helper/chat_channel/inbound_adapter"
 require "redmine_ai_helper/chat_channel/gateway"
 Dir[File.join(File.dirname(__FILE__), "lib/redmine_ai_helper/chat_channel/adapters", "*_adapter.rb")].sort.each do |file|
   require file

--- a/lib/redmine_ai_helper/chat_channel/base_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/base_adapter.rb
@@ -30,10 +30,20 @@ module RedmineAiHelper
           @registered_subclasses ||= []
         end
 
-        # Registered adapter classes keyed by channel_type.
+        # Registered adapter classes keyed by channel_type. Abstract
+        # intermediate classes (e.g. InboundAdapter) are registered by the
+        # +inherited+ hook exactly like every other subclass, but never
+        # override .channel_type, so they are filtered out here rather than
+        # at registration time: a class becomes a usable adapter simply by
+        # overriding .channel_type, with no separate "am I abstract" flag to
+        # keep in sync.
         # @return [Hash{String => Class}]
         def adapters
-          BaseAdapter.registered_subclasses.index_by(&:channel_type)
+          BaseAdapter.registered_subclasses.each_with_object({}) do |klass, hash|
+            hash[klass.channel_type] = klass
+          rescue NotImplementedError
+            next
+          end
         end
 
         # Automatically registers subclasses (same pattern as BaseAgent).
@@ -55,6 +65,15 @@ module RedmineAiHelper
         # @return [Array<Symbol>]
         def required_setting_fields
           []
+        end
+
+        # Whether this adapter receives events via the shared inbound webhook
+        # endpoint rather than an outgoing connection (R-010). Used by the
+        # settings UI to decide whether to display the webhook URL to
+        # register with the external service.
+        # @return [Boolean]
+        def inbound?
+          false
         end
 
         # Pops from queue, waiting up to timeout seconds for a value.

--- a/lib/redmine_ai_helper/chat_channel/inbound_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/inbound_adapter.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "json"
+require "redmine_ai_helper/logger"
+require "redmine_ai_helper/chat_channel/base_adapter"
+
+module RedmineAiHelper
+  module ChatChannel
+    # Abstract base class for adapters that receive events by webhook rather
+    # than an outgoing connection (LINE, Microsoft Teams, ...). #start polls
+    # the persistent queue table (+ai_helper_inbound_events+) that
+    # +AiHelperChatWebhookController+ fills, instead of opening a socket
+    # (research.md R-002/R-003, contracts/inbound_adapter.md).
+    class InboundAdapter < BaseAdapter
+      # Interval between polls of the pending queue, in seconds (SC-005).
+      POLL_INTERVAL_SECONDS = 2
+      # Events claimed more than this many seconds after being received are
+      # discarded unanswered instead of processed (FR-008a).
+      FRESHNESS_LIMIT_SECONDS = 120
+      # How long a row is kept, for deduplication, before it becomes eligible
+      # for deletion (FR-009).
+      RETENTION_DAYS = 7
+      # Minimum interval between two retention cleanups.
+      CLEANUP_INTERVAL_SECONDS = 3600
+      # Maximum number of pending rows fetched per poll.
+      POLL_BATCH_SIZE = 20
+
+      class << self
+        # Capability declaration read by the settings UI to decide whether to
+        # display the webhook URL to register with the external service
+        # (R-010).
+        # @return [Boolean]
+        def inbound?
+          true
+        end
+      end
+
+      # Verifies the authenticity of a webhook request (FR-002). No default
+      # implementation is provided: unlike an outgoing-connection adapter, an
+      # inbound adapter has no other proof that a request is genuine, so
+      # skipping verification is never an acceptable fallback.
+      # @param _request [ActionDispatch::Request] read +raw_post+ for the
+      #   exact bytes a signature is computed over, never the parsed body
+      # @return [Boolean] whether the request is authentic
+      def verify_request(_request)
+        raise NotImplementedError, "#{self.class.name} must implement #verify_request"
+      end
+
+      # Converts a verified request into zero or more normalized events
+      # (FR-005). Must never yield the bot's own messages or carry speaker
+      # identity (FR-003).
+      # @param _request [ActionDispatch::Request]
+      # @return [Array<Hash>] event hashes; see contracts/inbound_adapter.md
+      def parse_events(_request)
+        raise NotImplementedError, "#{self.class.name} must implement #parse_events"
+      end
+
+      # Answers a service's webhook registration handshake (FR-013). Returns
+      # nil for a normal event delivery; this default covers every service
+      # that has no such handshake.
+      # @param _request [ActionDispatch::Request]
+      # @return [Hash, nil] +{status:, content_type:, body:}+, or nil
+      def challenge_response(_request)
+        nil
+      end
+
+      # Polls the pending queue until #stop is called (BaseAdapter contract).
+      # Runs under a checked-out connection because this thread is not a
+      # Rails request thread.
+      # @return [void]
+      def start
+        clear_stop_flag
+        @connection_ended = Queue.new
+        until stopped?
+          ActiveRecord::Base.connection_pool.with_connection { poll_cycle }
+          self.class.timed_queue_pop(@connection_ended, POLL_INTERVAL_SECONDS)
+        end
+      end
+
+      # Reply metadata saved with the most recently claimed event of the
+      # given thread (R-008). The gateway's worker is single-threaded, so
+      # this always resolves to the event currently being answered.
+      # @param thread_key [String]
+      # @return [Hash, nil]
+      def reply_metadata_for(thread_key:)
+        event = AiHelperInboundEvent.where(channel_type: channel_type, thread_key: thread_key, status: "processed")
+                                     .order(received_at: :desc).first
+        return nil if event&.reply_metadata.blank?
+
+        JSON.parse(event.reply_metadata)
+      end
+
+      private
+
+      # One polling cycle: claim and dispatch due events, then run retention
+      # cleanup if it is due.
+      # @return [void]
+      def poll_cycle
+        AiHelperInboundEvent.pending_for(channel_type, limit: POLL_BATCH_SIZE).each do |event|
+          process_event(event)
+        end
+        purge_expired_rows_if_due
+      end
+
+      # Claims one event and either discards it as stale or dispatches it.
+      # An exception here is logged with a full backtrace and does not stop
+      # the loop: one bad event must not take down every other pending event.
+      # @param event [AiHelperInboundEvent]
+      # @return [void]
+      def process_event(event)
+        return unless event.claim
+
+        if event.expired_by?(FRESHNESS_LIMIT_SECONDS)
+          event.expire!
+          ai_helper_logger.info "#{channel_type}: discarded stale event #{event.event_key} received at #{event.received_at}"
+          return
+        end
+
+        dispatch(event.to_incoming_message)
+      rescue => e
+        ai_helper_logger.error "#{channel_type}: error while processing inbound event #{event.event_key}: #{e.full_message}"
+      end
+
+      # Deletes rows past the retention period, at most once per
+      # CLEANUP_INTERVAL_SECONDS (FR-009 / R-009).
+      # @return [void]
+      def purge_expired_rows_if_due
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        return if @last_purge_at && (now - @last_purge_at) < CLEANUP_INTERVAL_SECONDS
+
+        AiHelperInboundEvent.purge_old(channel_type, before: RETENTION_DAYS.days.ago)
+        @last_purge_at = now
+      end
+    end
+  end
+end

--- a/lib/redmine_ai_helper/chat_channel/inbound_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/inbound_adapter.rb
@@ -3,6 +3,8 @@
 require "json"
 require "redmine_ai_helper/logger"
 require "redmine_ai_helper/chat_channel/base_adapter"
+require "redmine_ai_helper/chat_channel/inbound_event_message"
+require "redmine_ai_helper/chat_channel/message_handler"
 
 module RedmineAiHelper
   module ChatChannel
@@ -77,42 +79,71 @@ module RedmineAiHelper
         end
       end
 
-      # Adds this adapter's per-thread reply position to the state BaseAdapter
-      # sets up. See #reply_metadata_for.
+      # MessageHandler variant that records which stored event the message
+      # being handled was built from, for as long as it is being handled.
+      # #send_message receives only channel_id/thread_key/text, so this is
+      # what lets #reply_metadata_for name the exact event a reply answers.
+      class EventScopedHandler < MessageHandler
+        # @param message [InboundEventMessage] the message to process
+        # @return [void]
+        def handle(message)
+          @adapter.answering(message.event_id) { super }
+        end
+      end
+
+      # Adds the id of the event currently being answered to the state
+      # BaseAdapter sets up. See #reply_metadata_for.
       # @return [void]
       def initialize
         super
-        @answered_up_to = {}
+        @answering_event_id = nil
       end
 
-      # Reply metadata of the next claimed event of the given thread, in claim
-      # order, consuming it so the following call moves on to the one after
-      # it (R-008).
+      # The handler this adapter replies through, wrapped so replies know
+      # which event they answer.
+      # @return [EventScopedHandler]
+      def handler
+        @handler ||= EventScopedHandler.new(self)
+      end
+
+      # Runs the given block with +event_id+ recorded as the event being
+      # answered. One adapter never handles two messages at once - the gateway
+      # serializes every message through a single worker thread, and an
+      # adapter running without a gateway handles them inline on its own
+      # polling thread - so a single instance variable describes the state
+      # exactly. Public because EventScopedHandler calls it; it is not part of
+      # the interface an adapter author implements.
+      # @param event_id [Integer, nil] the event being answered
+      # @return [void]
+      def answering(event_id)
+        previous = @answering_event_id
+        @answering_event_id = event_id
+        yield
+      ensure
+        @answering_event_id = previous
+      end
+
+      # Reply metadata stored with the event currently being answered (R-008),
+      # or nil when that event carries none, when +thread_key+ is not the
+      # thread being answered, or when no reply is in progress.
       #
-      # Claim order rather than "most recently claimed": #poll_cycle claims a
-      # whole batch and hands it to the gateway's queue, so several events of
-      # one thread can already be +processed+ while the single worker is still
-      # answering the first of them. The worker answers them in the order they
-      # were enqueued, which is the order they were claimed, so the oldest
-      # not-yet-answered event is the one being answered now.
-      #
-      # The position is kept as the id of the last answered event, which is
-      # also what orders the query: ids are assigned at receive time, so id
-      # order is receive order, and one integer per thread describes the
-      # position exactly. An event whose reply never happens (the worker
-      # raised before #send_message) leaves the position where it is, so the
-      # next reply in that thread consumes it instead.
-      # @param thread_key [String]
+      # Resolved by event id rather than by position in the thread: #poll_cycle
+      # claims a whole batch at once, so several events of one thread can be
+      # +processed+ while the first of them is still being answered, and the
+      # rows stay in the table for RETENTION_DAYS after that. An id carried on
+      # the message itself identifies the event under every one of those
+      # conditions, including the first reply after a gateway restart, and does
+      # not depend on how many times a single reply calls this method.
+      # @param thread_key [String] the thread being replied to
       # @return [Hash, nil]
       def reply_metadata_for(thread_key:)
-        event = AiHelperInboundEvent.processed
-                                    .where(channel_type: channel_type, thread_key: thread_key)
-                                    .where("id > ?", @answered_up_to[thread_key] || 0)
-                                    .order(:id).first
-        return nil unless event
+        return nil unless @answering_event_id
 
-        @answered_up_to[thread_key] = event.id
-        JSON.parse(event.reply_metadata) if event.reply_metadata.present?
+        event = AiHelperInboundEvent.find_by(id: @answering_event_id, channel_type: channel_type,
+                                             thread_key: thread_key)
+        return nil if event.nil? || event.reply_metadata.blank?
+
+        JSON.parse(event.reply_metadata)
       end
 
       private

--- a/lib/redmine_ai_helper/chat_channel/inbound_adapter.rb
+++ b/lib/redmine_ai_helper/chat_channel/inbound_adapter.rb
@@ -77,17 +77,42 @@ module RedmineAiHelper
         end
       end
 
-      # Reply metadata saved with the most recently claimed event of the
-      # given thread (R-008). The gateway's worker is single-threaded, so
-      # this always resolves to the event currently being answered.
+      # Adds this adapter's per-thread reply position to the state BaseAdapter
+      # sets up. See #reply_metadata_for.
+      # @return [void]
+      def initialize
+        super
+        @answered_up_to = {}
+      end
+
+      # Reply metadata of the next claimed event of the given thread, in claim
+      # order, consuming it so the following call moves on to the one after
+      # it (R-008).
+      #
+      # Claim order rather than "most recently claimed": #poll_cycle claims a
+      # whole batch and hands it to the gateway's queue, so several events of
+      # one thread can already be +processed+ while the single worker is still
+      # answering the first of them. The worker answers them in the order they
+      # were enqueued, which is the order they were claimed, so the oldest
+      # not-yet-answered event is the one being answered now.
+      #
+      # The position is kept as the id of the last answered event, which is
+      # also what orders the query: ids are assigned at receive time, so id
+      # order is receive order, and one integer per thread describes the
+      # position exactly. An event whose reply never happens (the worker
+      # raised before #send_message) leaves the position where it is, so the
+      # next reply in that thread consumes it instead.
       # @param thread_key [String]
       # @return [Hash, nil]
       def reply_metadata_for(thread_key:)
-        event = AiHelperInboundEvent.where(channel_type: channel_type, thread_key: thread_key, status: "processed")
-                                     .order(received_at: :desc).first
-        return nil if event&.reply_metadata.blank?
+        event = AiHelperInboundEvent.processed
+                                    .where(channel_type: channel_type, thread_key: thread_key)
+                                    .where("id > ?", @answered_up_to[thread_key] || 0)
+                                    .order(:id).first
+        return nil unless event
 
-        JSON.parse(event.reply_metadata)
+        @answered_up_to[thread_key] = event.id
+        JSON.parse(event.reply_metadata) if event.reply_metadata.present?
       end
 
       private

--- a/lib/redmine_ai_helper/chat_channel/inbound_event_message.rb
+++ b/lib/redmine_ai_helper/chat_channel/inbound_event_message.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "redmine_ai_helper/chat_channel/incoming_message"
+
+module RedmineAiHelper
+  module ChatChannel
+    # An IncomingMessage built from a stored inbound event, carrying the id of
+    # the +ai_helper_inbound_events+ row it came from.
+    #
+    # The id travels with the message through the gateway queue so that, while
+    # the message is being answered, +InboundAdapter#reply_metadata_for+ can
+    # resolve that exact event rather than infer it from the thread. It lives
+    # in a subclass rather than in IncomingMessage itself because it is
+    # meaningful only to inbound adapters: the tool-independent core, the
+    # outbound adapters and the value object they all share stay unchanged
+    # (contracts/inbound_adapter.md INV-I5).
+    class InboundEventMessage < IncomingMessage
+      # @return [Integer] id of the ai_helper_inbound_events row
+      attr_reader :event_id
+
+      # @param event_id [Integer] id of the ai_helper_inbound_events row
+      # @param attrs [Hash] the IncomingMessage attributes
+      def initialize(event_id:, **attrs)
+        # Assigned before super: IncomingMessage#initialize freezes the object,
+        # so nothing can be written to it afterwards.
+        @event_id = event_id
+        super(**attrs)
+      end
+    end
+  end
+end

--- a/test/functional/ai_helper_chat_webhook_controller_test.rb
+++ b/test/functional/ai_helper_chat_webhook_controller_test.rb
@@ -105,6 +105,16 @@ class AiHelperChatWebhookControllerTest < ActionController::TestCase
       assert_response :unauthorized
       assert_equal 0, AiHelperInboundEvent.count
     end
+
+    should "not answer the connectivity handshake when verification fails (order of steps 4 and 5)" do
+      WebhookReferenceAdapter.verify_result = false
+      WebhookReferenceAdapter.challenge_result = { status: 200, content_type: "text/plain", body: "challenge-echo" }
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :unauthorized
+      assert_not_equal "challenge-echo", @response.body
+    end
   end
 
   context "challenge response (FR-013)" do
@@ -188,6 +198,56 @@ class AiHelperChatWebhookControllerTest < ActionController::TestCase
 
       assert_response :success
       assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "unstorable event" do
+    should "log an error and still return 200 when an event fails validation" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(text: "") ]
+      RedmineAiHelper::CustomLogger.instance.expects(:error).with(regexp_matches(/failed to store event/))
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+
+    should "store the remaining events when one carries a key outside the event contract" do
+      WebhookReferenceAdapter.events_to_parse = [
+        valid_event(event_key: "evt-bad", user_id: "U1"), valid_event(event_key: "evt-good")
+      ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal [ "evt-good" ], AiHelperInboundEvent.pluck(:event_key)
+    end
+  end
+
+  context "reply metadata" do
+    should "store a Hash returned by parse_events as JSON (adapter contract)" do
+      WebhookReferenceAdapter.events_to_parse = [
+        valid_event(event_key: "evt-meta", reply_metadata: { "reply_token" => "tok-1" })
+      ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal({ "reply_token" => "tok-1" }, JSON.parse(AiHelperInboundEvent.last.reply_metadata))
+    end
+  end
+
+  context "login_required" do
+    should "receive the event even when Setting.login_required is on (Issue #304)" do
+      Setting.login_required = "1"
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(event_key: "evt-login") ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 1, AiHelperInboundEvent.count
+    ensure
+      Setting.login_required = "0"
     end
   end
 

--- a/test/functional/ai_helper_chat_webhook_controller_test.rb
+++ b/test/functional/ai_helper_chat_webhook_controller_test.rb
@@ -222,6 +222,46 @@ class AiHelperChatWebhookControllerTest < ActionController::TestCase
       assert_response :success
       assert_equal [ "evt-good" ], AiHelperInboundEvent.pluck(:event_key)
     end
+
+    should "reject an event that carries received_at so the adapter cannot move the freshness clock" do
+      WebhookReferenceAdapter.events_to_parse = [
+        valid_event(event_key: "evt-backdated", received_at: 3.days.ago), valid_event(event_key: "evt-good")
+      ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal [ "evt-good" ], AiHelperInboundEvent.pluck(:event_key)
+    end
+
+    should "reject an event that carries status so the adapter cannot skip the queue" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(event_key: "evt-preprocessed", status: "processed") ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+
+    should "reject an event that carries channel_type so the adapter cannot write outside its own channel" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(event_key: "evt-other", channel_type: "slack") ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "received_at" do
+    should "be stamped by the receiving side at receive time" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(event_key: "evt-stamped") ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_in_delta Time.current, AiHelperInboundEvent.last.received_at, 5.seconds
+    end
   end
 
   context "reply metadata" do

--- a/test/functional/ai_helper_chat_webhook_controller_test.rb
+++ b/test/functional/ai_helper_chat_webhook_controller_test.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", __FILE__)
+
+# Test-only reference inbound adapter with class-level toggles: the
+# controller instantiates a fresh adapter object per request, so the fakes
+# it needs to configure (verification result, parsed events, challenge
+# response) live on the class rather than an instance the test never gets a
+# handle to. Defined only in this test file (spec Assumptions).
+class WebhookReferenceAdapter < RedmineAiHelper::ChatChannel::InboundAdapter
+  class << self
+    def channel_type
+      "webhook_reference"
+    end
+
+    def required_setting_fields
+      [ :bot_token ]
+    end
+
+    attr_accessor :verify_result, :events_to_parse, :challenge_result, :parse_error
+
+    def reset!
+      self.verify_result = true
+      self.events_to_parse = []
+      self.challenge_result = nil
+      self.parse_error = nil
+    end
+  end
+
+  def verify_request(_request)
+    self.class.verify_result
+  end
+
+  def parse_events(_request)
+    raise self.class.parse_error if self.class.parse_error
+
+    self.class.events_to_parse
+  end
+
+  def challenge_response(_request)
+    self.class.challenge_result
+  end
+
+  def send_message(channel_id:, thread_key:, text:); end
+end
+
+class AiHelperChatWebhookControllerTest < ActionController::TestCase
+  fixtures :projects, :users
+
+  def setup
+    @controller = AiHelperChatWebhookController.new
+    @request = ActionController::TestRequest.create(@controller.class)
+    @response = ActionDispatch::TestResponse.create
+
+    WebhookReferenceAdapter.reset!
+    AiHelperInboundEvent.delete_all
+    AiHelperChatAdapterSetting.delete_all
+    AiHelperChatAdapterSetting.create!(
+      channel_type: "webhook_reference", enabled: true, bot_token: "secret-token",
+      redmine_user_id: 2, dm_default_project_id: 1
+    )
+  end
+
+  def valid_event(overrides = {})
+    { event_key: "evt-1", text: "hello", channel_id: "C1", thread_key: "C1:T1" }.merge(overrides)
+  end
+
+  context "unknown channel_type" do
+    should "return 404 and save nothing" do
+      post :receive, params: { channel_type: "does_not_exist" }, body: "{}"
+
+      assert_response :not_found
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "non-inbound adapter" do
+    should "return 404 for a registered adapter that does not declare inbound?" do
+      post :receive, params: { channel_type: "slack" }, body: "{}"
+
+      assert_response :not_found
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "disabled adapter" do
+    should "return 404 when the inbound adapter is not enabled (US2-2)" do
+      AiHelperChatAdapterSetting.for_channel("webhook_reference").update_column(:enabled, false)
+      WebhookReferenceAdapter.events_to_parse = [ valid_event ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :not_found
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "verification" do
+    should "return 401 and save nothing when verify_request fails (FR-002)" do
+      WebhookReferenceAdapter.verify_result = false
+      WebhookReferenceAdapter.events_to_parse = [ valid_event ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :unauthorized
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "challenge response (FR-013)" do
+    should "return the adapter-specified response and save nothing" do
+      WebhookReferenceAdapter.challenge_result = { status: 200, content_type: "text/plain", body: "challenge-echo" }
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal "challenge-echo", @response.body
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "normal event delivery" do
+    should "return 200 and persist a pending row for a valid request" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: '{"event":"payload"}'
+
+      assert_response :success
+      assert_equal 1, AiHelperInboundEvent.count
+      event = AiHelperInboundEvent.last
+      assert_equal "webhook_reference", event.channel_type
+      assert_equal "pending", event.status
+      assert_equal "hello", event.text
+    end
+
+    should "save one row per event when a single request carries multiple events (Q3)" do
+      WebhookReferenceAdapter.events_to_parse = [
+        valid_event(event_key: "evt-a"), valid_event(event_key: "evt-b")
+      ]
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 2, AiHelperInboundEvent.count
+    end
+
+    should "return 200 and save nothing when the request carries zero events" do
+      WebhookReferenceAdapter.events_to_parse = []
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "duplicate events (FR-006)" do
+    should "return 200 on a resend of the same event_key without adding a row" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(event_key: "evt-dup") ]
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+      assert_equal 1, AiHelperInboundEvent.count
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 1, AiHelperInboundEvent.count
+    end
+
+    should "save only the new events when a request mixes an existing and a new event_key" do
+      WebhookReferenceAdapter.events_to_parse = [ valid_event(event_key: "evt-existing") ]
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      WebhookReferenceAdapter.events_to_parse = [
+        valid_event(event_key: "evt-existing"), valid_event(event_key: "evt-fresh")
+      ]
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert_response :success
+      assert_equal 2, AiHelperInboundEvent.count
+    end
+  end
+
+  context "unparseable payload" do
+    should "return 200 and save nothing when parse_events raises (prevents a resend loop)" do
+      WebhookReferenceAdapter.parse_error = StandardError.new("garbled payload")
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "not json"
+
+      assert_response :success
+      assert_equal 0, AiHelperInboundEvent.count
+    end
+  end
+
+  context "logging (FR-007)" do
+    should "log a warning for an unknown channel_type without leaking secrets" do
+      RedmineAiHelper::CustomLogger.instance.expects(:warn).with(regexp_matches(/does_not_exist/))
+
+      post :receive, params: { channel_type: "does_not_exist" }, body: "{}"
+    end
+
+    should "log a warning for a disabled adapter" do
+      AiHelperChatAdapterSetting.for_channel("webhook_reference").update_column(:enabled, false)
+      RedmineAiHelper::CustomLogger.instance.expects(:warn).with(regexp_matches(/webhook_reference/))
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+    end
+
+    should "log a warning for a failed verification without the token or signature" do
+      WebhookReferenceAdapter.verify_result = false
+      logged = []
+      RedmineAiHelper::CustomLogger.instance.stubs(:warn).with { |message| logged << message; true }
+
+      post :receive, params: { channel_type: "webhook_reference" }, body: "{}"
+
+      assert(logged.any? { |m| m.include?("webhook_reference") })
+      assert(logged.none? { |m| m.include?("secret-token") })
+    end
+  end
+end

--- a/test/functional/ai_helper_settings_controller_test.rb
+++ b/test/functional/ai_helper_settings_controller_test.rb
@@ -612,6 +612,32 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
     end
   end
 
+  # Test-only inbound adapter (US2): proves the channels tab shows a webhook
+  # URL for adapters that declare inbound?, and only for those; also used by
+  # AiHelperChatWebhookControllerInboundEnablementTest (US2-2) to prove a
+  # required field left blank keeps the webhook endpoint at 404.
+  class FakeInboundAdapter < RedmineAiHelper::ChatChannel::InboundAdapter
+    class << self
+      def channel_type
+        "fake_inbound"
+      end
+
+      def required_setting_fields
+        [ :bot_token ]
+      end
+    end
+
+    def verify_request(_request)
+      true
+    end
+
+    def parse_events(_request)
+      []
+    end
+
+    def send_message(channel_id:, thread_key:, text:); end
+  end
+
   context "channels tab" do
     setup do
       AiHelperChatAdapterSetting.delete_all
@@ -1022,6 +1048,22 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
         assert_select "#errorExplanation", text: /does not match any user/
       end
     end
+
+    context "webhook URL display (US2)" do
+      should "display the webhook URL for an inbound adapter" do
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_match %r{https?://[^"]*/ai_helper/chat_webhook/fake_inbound}, @response.body
+      end
+
+      should "not display a webhook URL for an outbound adapter" do
+        get :index, params: { tab: "channels" }
+
+        assert_response :success
+        assert_no_match(%r{ai_helper/chat_webhook/ui_chat}, @response.body)
+      end
+    end
   end
 
   # Discord adapter is auto-registered via the init.rb glob, so the existing
@@ -1104,5 +1146,32 @@ class AiHelperSettingsControllerTest < ActionController::TestCase
 
       assert_response :not_found
     end
+  end
+end
+
+# US2-2: an inbound adapter enabled without its required fields must not
+# receive webhook traffic. Exercises AiHelperChatWebhookController rather
+# than AiHelperSettingsController, so it needs its own ActionController::TestCase.
+class AiHelperChatWebhookControllerInboundEnablementTest < ActionController::TestCase
+  tests AiHelperChatWebhookController
+
+  def setup
+    @controller = AiHelperChatWebhookController.new
+    @request = ActionController::TestRequest.create(@controller.class)
+    @response = ActionDispatch::TestResponse.create
+    AiHelperChatAdapterSetting.delete_all
+  end
+
+  should "return 404 when the inbound adapter is enabled but its required field is blank" do
+    # update_column bypasses validation, simulating a row saved before the
+    # adapter declared bot_token as required (same technique as
+    # ChatChannelBaseAdapterTest#enabled?); the validation itself already
+    # prevents reaching this state through the settings form.
+    setting = AiHelperChatAdapterSetting.create!(channel_type: "fake_inbound", enabled: false, redmine_user_id: 2)
+    setting.update_column(:enabled, true)
+
+    post :receive, params: { channel_type: "fake_inbound" }, body: "{}"
+
+    assert_response :not_found
   end
 end

--- a/test/unit/ai_helper_inbound_event_test.rb
+++ b/test/unit/ai_helper_inbound_event_test.rb
@@ -237,5 +237,21 @@ class AiHelperInboundEventTest < ActiveSupport::TestCase
       assert message.dm?
       assert message.in_thread?
     end
+
+    # The id is what lets InboundAdapter#reply_metadata_for resolve the exact
+    # event a reply is answering, so it has to survive the trip through the
+    # gateway queue with the message.
+    should "carry the row id so the reply can be tied back to this event" do
+      event = build_event
+      event.save!
+
+      message = event.to_incoming_message
+
+      assert_kind_of RedmineAiHelper::ChatChannel::InboundEventMessage, message
+      assert_equal event.id, message.event_id
+      # IncomingMessage freezes itself, so event_id must be assigned before
+      # the superclass initializer runs.
+      assert message.frozen?
+    end
   end
 end

--- a/test/unit/ai_helper_inbound_event_test.rb
+++ b/test/unit/ai_helper_inbound_event_test.rb
@@ -80,6 +80,50 @@ class AiHelperInboundEventTest < ActiveSupport::TestCase
       assert_nil result
       assert_equal 1, AiHelperInboundEvent.where(channel_type: "webhook_test", event_key: "evt-3").count
     end
+
+    should "raise when the event is invalid for a reason other than duplication" do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        AiHelperInboundEvent.record_event(
+          channel_type: "webhook_test", event_key: "evt-invalid", text: "",
+          channel_id: "C1", thread_key: "C1:T1", received_at: Time.current
+        )
+      end
+
+      assert_equal 0, AiHelperInboundEvent.where(event_key: "evt-invalid").count
+    end
+
+    should "store a Hash reply_metadata as JSON" do
+      event = AiHelperInboundEvent.record_event(
+        channel_type: "webhook_test", event_key: "evt-meta", text: "hi",
+        channel_id: "C1", thread_key: "C1:T1", received_at: Time.current,
+        reply_metadata: { "reply_token" => "tok" }
+      )
+
+      assert_equal({ "reply_token" => "tok" }, JSON.parse(event.reload.reply_metadata))
+    end
+  end
+
+  context "#reply_metadata=" do
+    should "serialize a Hash to JSON, as the adapter contract promises" do
+      event = build_event(event_key: "evt-hash-meta", reply_metadata: { "reply_token" => "abc" })
+      event.save!
+
+      assert_equal({ "reply_token" => "abc" }, JSON.parse(event.reload.reply_metadata))
+    end
+
+    should "keep a String that is already JSON as given" do
+      event = build_event(event_key: "evt-string-meta", reply_metadata: '{"reply_token":"abc"}')
+      event.save!
+
+      assert_equal '{"reply_token":"abc"}', event.reload.reply_metadata
+    end
+
+    should "keep nil as nil" do
+      event = build_event(event_key: "evt-nil-meta", reply_metadata: nil)
+      event.save!
+
+      assert_nil event.reload.reply_metadata
+    end
   end
 
   context ".pending_for" do

--- a/test/unit/ai_helper_inbound_event_test.rb
+++ b/test/unit/ai_helper_inbound_event_test.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", __FILE__)
+
+class AiHelperInboundEventTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  def build_event(overrides = {})
+    AiHelperInboundEvent.new(
+      {
+        channel_type: "webhook_test",
+        event_key: "evt-1",
+        text: "hello",
+        channel_id: "C1",
+        thread_key: "C1:T1",
+        received_at: Time.current
+      }.merge(overrides)
+    )
+  end
+
+  context "validations" do
+    should "require channel_type, event_key, text, channel_id, thread_key and received_at" do
+      event = AiHelperInboundEvent.new
+
+      assert_not event.valid?
+      %i[channel_type event_key text channel_id thread_key received_at].each do |attr|
+        assert_includes event.errors.attribute_names, attr, "expected #{attr} to be required"
+      end
+    end
+
+    should "only accept pending, processed or expired as status" do
+      event = build_event(status: "bogus")
+
+      assert_not event.valid?
+      assert_includes event.errors.attribute_names, :status
+    end
+
+    should "default status to pending" do
+      event = build_event
+      event.save!
+
+      assert_equal "pending", event.status
+    end
+
+    should "reject a duplicate event_key within the same channel_type" do
+      build_event.save!
+      duplicate = build_event
+
+      assert_not duplicate.valid?
+      assert_includes duplicate.errors.attribute_names, :event_key
+    end
+
+    should "allow the same event_key across different channel_types" do
+      build_event.save!
+      other_channel = build_event(channel_type: "other_webhook_test")
+
+      assert other_channel.valid?
+    end
+  end
+
+  context ".record_event" do
+    should "persist a pending event" do
+      event = AiHelperInboundEvent.record_event(
+        channel_type: "webhook_test", event_key: "evt-2", text: "hi",
+        channel_id: "C1", thread_key: "C1:T1", received_at: Time.current
+      )
+
+      assert event.persisted?
+      assert_equal "pending", event.status
+    end
+
+    should "return nil when the same channel_type/event_key is inserted concurrently (RecordNotUnique)" do
+      build_event(event_key: "evt-3").save!
+
+      result = AiHelperInboundEvent.record_event(
+        channel_type: "webhook_test", event_key: "evt-3", text: "hi",
+        channel_id: "C1", thread_key: "C1:T1", received_at: Time.current
+      )
+
+      assert_nil result
+      assert_equal 1, AiHelperInboundEvent.where(channel_type: "webhook_test", event_key: "evt-3").count
+    end
+  end
+
+  context ".pending_for" do
+    should "return only pending rows for the given channel_type, oldest received_at first" do
+      newer = build_event(event_key: "evt-newer", received_at: 1.minute.ago)
+      newer.save!
+      older = build_event(event_key: "evt-older", received_at: 2.minutes.ago)
+      older.save!
+      build_event(event_key: "evt-other-channel", channel_type: "other_webhook_test").save!
+      processed = build_event(event_key: "evt-processed", status: "processed")
+      processed.save!
+
+      result = AiHelperInboundEvent.pending_for("webhook_test", limit: 20)
+
+      assert_equal [ older.id, newer.id ], result.map(&:id)
+    end
+
+    should "cap the result at the given limit" do
+      3.times { |i| build_event(event_key: "evt-limit-#{i}").save! }
+
+      result = AiHelperInboundEvent.pending_for("webhook_test", limit: 2)
+
+      assert_equal 2, result.size
+    end
+  end
+
+  context ".purge_old" do
+    should "delete rows received before the given time and keep newer rows" do
+      old = build_event(event_key: "evt-old", received_at: 10.days.ago)
+      old.save!
+      recent = build_event(event_key: "evt-recent", received_at: 1.day.ago)
+      recent.save!
+
+      AiHelperInboundEvent.purge_old("webhook_test", before: 7.days.ago)
+
+      assert_not AiHelperInboundEvent.exists?(old.id)
+      assert AiHelperInboundEvent.exists?(recent.id)
+    end
+
+    should "not delete rows of a different channel_type" do
+      other = build_event(event_key: "evt-other", channel_type: "other_webhook_test", received_at: 10.days.ago)
+      other.save!
+
+      AiHelperInboundEvent.purge_old("webhook_test", before: 7.days.ago)
+
+      assert AiHelperInboundEvent.exists?(other.id)
+    end
+  end
+
+  context "#claim" do
+    should "atomically move a pending row to processed and return true" do
+      event = build_event
+      event.save!
+
+      assert event.claim
+      assert_equal "processed", event.reload.status
+    end
+
+    should "return false and leave the row untouched when it is not pending (double claim protection, INV-I3)" do
+      event = build_event
+      event.save!
+      assert event.claim
+
+      second_attempt = AiHelperInboundEvent.find(event.id)
+
+      assert_not second_attempt.claim
+      assert_equal "processed", event.reload.status
+    end
+  end
+
+  context "#expire!" do
+    should "set status to expired" do
+      event = build_event
+      event.save!
+
+      event.expire!
+
+      assert_equal "expired", event.reload.status
+    end
+  end
+
+  context "#expired_by?" do
+    should "be true when received_at is older than the given number of seconds" do
+      event = build_event(received_at: 130.seconds.ago)
+
+      assert event.expired_by?(120)
+    end
+
+    should "be false when received_at is within the given number of seconds" do
+      event = build_event(received_at: 10.seconds.ago)
+
+      assert_not event.expired_by?(120)
+    end
+  end
+
+  context "#to_incoming_message" do
+    should "build an IncomingMessage carrying the normalized fields" do
+      event = build_event(
+        channel_type: "webhook_test", channel_id: "C1", thread_key: "C1:T1",
+        message_ts: "T1-1", text: "hello there", dm: true, in_thread: true
+      )
+
+      message = event.to_incoming_message
+
+      assert_kind_of RedmineAiHelper::ChatChannel::IncomingMessage, message
+      assert_equal "webhook_test", message.channel_type
+      assert_equal "C1", message.channel_id
+      assert_equal "C1:T1", message.thread_key
+      assert_equal "T1-1", message.message_ts
+      assert_equal "hello there", message.text
+      assert message.dm?
+      assert message.in_thread?
+    end
+  end
+end

--- a/test/unit/ai_helper_settings_helper_test.rb
+++ b/test/unit/ai_helper_settings_helper_test.rb
@@ -112,6 +112,42 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
       assert_equal "https://redmine.example.com/ai_helper/chat_webhook/helper_test_inbound", url
     end
 
+    should "keep the path prefix when Redmine is deployed under a sub-URI" do
+      Setting.stubs(:protocol).returns("https")
+      Setting.stubs(:host_name).returns("redmine.example.com/redmine")
+
+      url = ai_helper_chat_webhook_url_for("helper_test_inbound")
+
+      assert_equal "https://redmine.example.com/redmine/ai_helper/chat_webhook/helper_test_inbound", url
+    end
+
+    should "keep the port when Setting.host_name embeds one" do
+      Setting.stubs(:protocol).returns("http")
+      Setting.stubs(:host_name).returns("redmine.example.com:3000")
+
+      url = ai_helper_chat_webhook_url_for("helper_test_inbound")
+
+      assert_equal "http://redmine.example.com:3000/ai_helper/chat_webhook/helper_test_inbound", url
+    end
+
+    should "not repeat the scheme when Setting.host_name embeds one" do
+      Setting.stubs(:protocol).returns("https")
+      Setting.stubs(:host_name).returns("https://redmine.example.com")
+
+      url = ai_helper_chat_webhook_url_for("helper_test_inbound")
+
+      assert_equal "https://redmine.example.com/ai_helper/chat_webhook/helper_test_inbound", url
+    end
+
+    should "not double the separator when Setting.host_name ends with a slash" do
+      Setting.stubs(:protocol).returns("https")
+      Setting.stubs(:host_name).returns("redmine.example.com/redmine/")
+
+      url = ai_helper_chat_webhook_url_for("helper_test_inbound")
+
+      assert_equal "https://redmine.example.com/redmine/ai_helper/chat_webhook/helper_test_inbound", url
+    end
+
     should "return nil for an adapter that does not declare inbound?" do
       assert_nil ai_helper_chat_webhook_url_for("helper_test_outbound")
     end

--- a/test/unit/ai_helper_settings_helper_test.rb
+++ b/test/unit/ai_helper_settings_helper_test.rb
@@ -5,6 +5,24 @@ require_relative "../test_helper"
 class AiHelperSettingsHelperTest < ActionView::TestCase
   include AiHelperSettingsHelper
 
+  # Test-only adapters registered for the webhook URL helper tests, so the
+  # helper test does not depend on any real inbound adapter (spec Assumptions).
+  class HelperTestInboundAdapter < RedmineAiHelper::ChatChannel::InboundAdapter
+    class << self
+      def channel_type
+        "helper_test_inbound"
+      end
+    end
+  end
+
+  class HelperTestOutboundAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+    class << self
+      def channel_type
+        "helper_test_outbound"
+      end
+    end
+  end
+
   context "ai_helper_settings_tabs" do
     should "return 4 tab definitions in order: general, model, vector, channels" do
       f = build_form_builder
@@ -81,6 +99,25 @@ class AiHelperSettingsHelperTest < ActionView::TestCase
     should "return nil when errors array is empty and params_tab is nil" do
       tab = ai_helper_settings_selected_tab([], nil)
       assert_nil tab
+    end
+  end
+
+  context "ai_helper_chat_webhook_url_for" do
+    should "build the URL from Setting.protocol and Setting.host_name for an inbound adapter" do
+      Setting.stubs(:protocol).returns("https")
+      Setting.stubs(:host_name).returns("redmine.example.com")
+
+      url = ai_helper_chat_webhook_url_for("helper_test_inbound")
+
+      assert_equal "https://redmine.example.com/ai_helper/chat_webhook/helper_test_inbound", url
+    end
+
+    should "return nil for an adapter that does not declare inbound?" do
+      assert_nil ai_helper_chat_webhook_url_for("helper_test_outbound")
+    end
+
+    should "return nil for an unregistered channel_type" do
+      assert_nil ai_helper_chat_webhook_url_for("no_such_channel")
     end
   end
 

--- a/test/unit/chat_channel/base_adapter_test.rb
+++ b/test/unit/chat_channel/base_adapter_test.rb
@@ -134,9 +134,24 @@ class ChatChannelBaseAdapterTest < ActiveSupport::TestCase
   # Doubles for the frames handle_frame receives (#type / #data / #code).
   FrameStruct = Struct.new(:type, :data, :code)
 
+  # An abstract intermediate subclass that never overrides .channel_type
+  # (like InboundAdapter), used to prove .adapters tolerates it.
+  class AbstractIntermediateAdapter < RedmineAiHelper::ChatChannel::BaseAdapter
+  end
+
   context "automatic registration" do
     should "register subclasses by channel_type" do
       assert_equal FakeAdapter, RedmineAiHelper::ChatChannel::BaseAdapter.adapters["fake_chat"]
+    end
+
+    should "exclude an abstract intermediate subclass that does not override .channel_type" do
+      assert_not_includes RedmineAiHelper::ChatChannel::BaseAdapter.adapters.values, AbstractIntermediateAdapter
+    end
+  end
+
+  context "inbound? capability declaration" do
+    should "default to false" do
+      assert_not FakeAdapter.inbound?
     end
   end
 

--- a/test/unit/chat_channel/gateway_test.rb
+++ b/test/unit/chat_channel/gateway_test.rb
@@ -193,6 +193,15 @@ class ChatChannelGatewayTest < ActiveSupport::TestCase
       assert_equal 1, adapters.size
       assert_kind_of FakeGatewayAdapter, adapters.first
     end
+
+    # FR-010 / SC-006: adding the (abstract) InboundAdapter base class must
+    # not change how the gateway enumerates and starts existing adapters.
+    should "build from the real registry without error, and never include the abstract InboundAdapter itself" do
+      adapters = @gateway.send(:build_enabled_adapters)
+
+      assert_kind_of Array, adapters
+      assert_not_includes adapters.map(&:class), RedmineAiHelper::ChatChannel::InboundAdapter
+    end
   end
 
   context "dispatch without a gateway" do

--- a/test/unit/chat_channel/inbound_adapter_test.rb
+++ b/test/unit/chat_channel/inbound_adapter_test.rb
@@ -131,7 +131,7 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
       )
       event = create_pending_event
       adapter = ReferenceInboundAdapter.new
-      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+      stub_dispatch_stop(adapter)
 
       Timeout.timeout(5) { adapter.start }
 
@@ -142,7 +142,7 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
 
     should "exit the loop once #stop has been called" do
       adapter = ReferenceInboundAdapter.new
-      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+      stub_dispatch_stop(adapter)
 
       assert_nothing_raised { Timeout.timeout(5) { adapter.start } }
       assert adapter.send(:stopped?)
@@ -155,20 +155,60 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
       logger = mock("logger")
       logger.expects(:error).with(regexp_matches(/handler exploded/))
       adapter.stubs(:ai_helper_logger).returns(logger)
-      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+      stub_dispatch_stop(adapter)
 
       assert_nothing_raised { Timeout.timeout(5) { adapter.start } }
     end
   end
 
   context "#reply_metadata_for" do
-    should "return the parsed reply_metadata of the most recently claimed event for the thread" do
+    should "return the parsed reply_metadata of the claimed event for the thread" do
       event = create_pending_event(reply_metadata: { reply_token: "abc" }.to_json)
       event.claim
 
       metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
 
       assert_equal({ "reply_token" => "abc" }, metadata)
+    end
+
+    # A poll cycle claims a whole batch before the single worker answers any
+    # of it, so several events of one thread can be "processed" at the same
+    # time. The worker answers them in claim order, so each call must hand
+    # back the next one rather than the most recent one.
+    should "hand out metadata in claim order when a thread has several claimed events" do
+      create_pending_event(event_key: "fifo-1", received_at: 20.seconds.ago,
+                           reply_metadata: { "reply_token" => "first" }).claim
+      create_pending_event(event_key: "fifo-2", received_at: 10.seconds.ago,
+                           reply_metadata: { "reply_token" => "second" }).claim
+      adapter = ReferenceInboundAdapter.new
+
+      assert_equal({ "reply_token" => "first" }, adapter.reply_metadata_for(thread_key: "RC1:T1"))
+      assert_equal({ "reply_token" => "second" }, adapter.reply_metadata_for(thread_key: "RC1:T1"))
+      assert_nil adapter.reply_metadata_for(thread_key: "RC1:T1")
+    end
+
+    should "track each thread independently" do
+      create_pending_event(event_key: "thread-a", thread_key: "RC1:TA",
+                           reply_metadata: { "reply_token" => "a" }).claim
+      create_pending_event(event_key: "thread-b", thread_key: "RC1:TB",
+                           reply_metadata: { "reply_token" => "b" }).claim
+      adapter = ReferenceInboundAdapter.new
+
+      assert_equal({ "reply_token" => "a" }, adapter.reply_metadata_for(thread_key: "RC1:TA"))
+      assert_equal({ "reply_token" => "b" }, adapter.reply_metadata_for(thread_key: "RC1:TB"))
+    end
+
+    # An event without metadata must still advance the thread's position:
+    # otherwise it would stay at the head of the queue and every later reply
+    # in that thread would keep getting nil.
+    should "advance past a claimed event that carries no reply_metadata" do
+      create_pending_event(event_key: "no-meta").claim
+      create_pending_event(event_key: "with-meta", received_at: 1.second.from_now,
+                           reply_metadata: { "reply_token" => "later" }).claim
+      adapter = ReferenceInboundAdapter.new
+
+      assert_nil adapter.reply_metadata_for(thread_key: "RC1:T1")
+      assert_equal({ "reply_token" => "later" }, adapter.reply_metadata_for(thread_key: "RC1:T1"))
     end
 
     should "return nil when no claimed event exists for the thread" do
@@ -184,6 +224,34 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
       metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
 
       assert_nil metadata
+    end
+
+    # The contract lets an adapter return :reply_metadata as a Hash; only the
+    # column holds JSON. Passing a pre-encoded String (as the test above does)
+    # would not exercise that conversion.
+    should "return the metadata an adapter supplied as a Hash at parse time" do
+      event = create_pending_event(reply_metadata: { "reply_token" => "hash-token" })
+      event.claim
+
+      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
+
+      assert_equal({ "reply_token" => "hash-token" }, metadata)
+    end
+  end
+
+  context "poll batch size" do
+    should "claim at most POLL_BATCH_SIZE events per cycle" do
+      batch_size = RedmineAiHelper::ChatChannel::InboundAdapter::POLL_BATCH_SIZE
+      (batch_size + 1).times { |i| create_pending_event(event_key: "batch-#{i}") }
+      adapter = ReferenceInboundAdapter.new
+      dispatched = 0
+      adapter.stubs(:dispatch).with { |_message| dispatched += 1; true }
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal batch_size, dispatched
+      assert_equal 1, AiHelperInboundEvent.where(channel_type: "reference_inbound", status: "pending").count
     end
   end
 
@@ -247,7 +315,7 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
       )
       recent_row = create_pending_event(event_key: "ret-recent", status: "expired", received_at: 1.day.ago)
       adapter = ReferenceInboundAdapter.new
-      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+      stub_dispatch_stop(adapter)
 
       Timeout.timeout(5) { adapter.start }
 
@@ -286,7 +354,7 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
       # once polling resumes.
       event = create_pending_event(event_key: "downtime-1", received_at: 90.seconds.ago)
       adapter = ReferenceInboundAdapter.new
-      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+      stub_dispatch_stop(adapter)
 
       Timeout.timeout(5) { adapter.start }
 
@@ -325,8 +393,12 @@ class ChatChannelInboundAdapterEndToEndTest < ActionController::TestCase
     RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
       AiHelperMessage.new(role: "assistant", content: "end to end answer")
     )
+    # reply_metadata is supplied as the Hash the adapter contract defines, so
+    # this covers the Hash -> JSON column -> parsed Hash round trip an adapter
+    # that needs a reply token actually depends on.
     ReferenceInboundAdapter.events_to_parse = [
-      { event_key: "e2e-1", text: "hello from e2e", channel_id: "E2E1", thread_key: "E2E1:T1" }
+      { event_key: "e2e-1", text: "hello from e2e", channel_id: "E2E1", thread_key: "E2E1:T1",
+        reply_metadata: { "reply_token" => "e2e-token" } }
     ]
 
     post :receive, params: { channel_type: "reference_inbound" }, body: "{}"
@@ -342,5 +414,6 @@ class ChatChannelInboundAdapterEndToEndTest < ActionController::TestCase
 
     assert_equal "processed", event.reload.status
     assert_equal [ { channel_id: "E2E1", thread_key: "E2E1:T1", text: "end to end answer" } ], adapter.sent_messages
+    assert_equal({ "reply_token" => "e2e-token" }, adapter.reply_metadata_for(thread_key: "E2E1:T1"))
   end
 end

--- a/test/unit/chat_channel/inbound_adapter_test.rb
+++ b/test/unit/chat_channel/inbound_adapter_test.rb
@@ -21,18 +21,29 @@ class ReferenceInboundAdapter < RedmineAiHelper::ChatChannel::InboundAdapter
     # configuring behavior before POSTing has no handle to that instance.
     attr_accessor :verify_result, :events_to_parse, :challenge_result
 
+    # Error #send_message raises on its first call, to exercise the failure
+    # notice MessageHandler posts through a second #send_message.
+    attr_accessor :send_failure
+
+    # When set, #send_message asks for reply metadata with this thread key
+    # instead of the one it was called with, to exercise the mismatch guard.
+    attr_accessor :probe_thread_key
+
     def reset!
       self.verify_result = true
       self.events_to_parse = []
       self.challenge_result = nil
+      self.send_failure = nil
+      self.probe_thread_key = nil
     end
   end
 
-  attr_reader :sent_messages
+  attr_reader :sent_messages, :sent_metadata
 
   def initialize
     super
     @sent_messages = []
+    @sent_metadata = []
   end
 
   def verify_request(_request)
@@ -47,8 +58,13 @@ class ReferenceInboundAdapter < RedmineAiHelper::ChatChannel::InboundAdapter
     self.class.challenge_result
   end
 
+  # Reads the reply metadata the way a real adapter does: from inside
+  # #send_message, which is the only point at which a platform needing a
+  # reply token has to know it.
   def send_message(channel_id:, thread_key:, text:)
     @sent_messages << { channel_id: channel_id, thread_key: thread_key, text: text }
+    @sent_metadata << reply_metadata_for(thread_key: self.class.probe_thread_key || thread_key)
+    raise self.class.send_failure if self.class.send_failure && @sent_messages.one?
   end
 end
 
@@ -71,6 +87,19 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
   # condition check.
   def stub_dispatch_stop(adapter)
     ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+  end
+
+  # Configures everything MessageHandler needs for a dispatched event to
+  # reach #send_message, which is where reply metadata is read.
+  def setup_reply_path(answer: "reference answer")
+    project = Project.find(1)
+    project.enable_module!("ai_helper")
+    user = User.find(2)
+    create(:ai_helper_chat_adapter_setting, channel_type: "reference_inbound", redmine_user_id: user.id)
+    create(:ai_helper_channel_binding, channel_type: "reference_inbound", channel_id: "RC1", project: project)
+    RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+      AiHelperMessage.new(role: "assistant", content: answer)
+    )
   end
 
   context "capability declaration" do
@@ -162,80 +191,114 @@ class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
   end
 
   context "#reply_metadata_for" do
-    should "return the parsed reply_metadata of the claimed event for the thread" do
-      event = create_pending_event(reply_metadata: { reply_token: "abc" }.to_json)
-      event.claim
-
-      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
-
-      assert_equal({ "reply_token" => "abc" }, metadata)
-    end
-
-    # A poll cycle claims a whole batch before the single worker answers any
-    # of it, so several events of one thread can be "processed" at the same
-    # time. The worker answers them in claim order, so each call must hand
-    # back the next one rather than the most recent one.
-    should "hand out metadata in claim order when a thread has several claimed events" do
-      create_pending_event(event_key: "fifo-1", received_at: 20.seconds.ago,
-                           reply_metadata: { "reply_token" => "first" }).claim
-      create_pending_event(event_key: "fifo-2", received_at: 10.seconds.ago,
-                           reply_metadata: { "reply_token" => "second" }).claim
+    should "return the parsed reply_metadata of the event being answered" do
+      setup_reply_path
+      create_pending_event(reply_metadata: { reply_token: "abc" }.to_json)
       adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
 
-      assert_equal({ "reply_token" => "first" }, adapter.reply_metadata_for(thread_key: "RC1:T1"))
-      assert_equal({ "reply_token" => "second" }, adapter.reply_metadata_for(thread_key: "RC1:T1"))
-      assert_nil adapter.reply_metadata_for(thread_key: "RC1:T1")
-    end
+      Timeout.timeout(5) { adapter.start }
 
-    should "track each thread independently" do
-      create_pending_event(event_key: "thread-a", thread_key: "RC1:TA",
-                           reply_metadata: { "reply_token" => "a" }).claim
-      create_pending_event(event_key: "thread-b", thread_key: "RC1:TB",
-                           reply_metadata: { "reply_token" => "b" }).claim
-      adapter = ReferenceInboundAdapter.new
-
-      assert_equal({ "reply_token" => "a" }, adapter.reply_metadata_for(thread_key: "RC1:TA"))
-      assert_equal({ "reply_token" => "b" }, adapter.reply_metadata_for(thread_key: "RC1:TB"))
-    end
-
-    # An event without metadata must still advance the thread's position:
-    # otherwise it would stay at the head of the queue and every later reply
-    # in that thread would keep getting nil.
-    should "advance past a claimed event that carries no reply_metadata" do
-      create_pending_event(event_key: "no-meta").claim
-      create_pending_event(event_key: "with-meta", received_at: 1.second.from_now,
-                           reply_metadata: { "reply_token" => "later" }).claim
-      adapter = ReferenceInboundAdapter.new
-
-      assert_nil adapter.reply_metadata_for(thread_key: "RC1:T1")
-      assert_equal({ "reply_token" => "later" }, adapter.reply_metadata_for(thread_key: "RC1:T1"))
-    end
-
-    should "return nil when no claimed event exists for the thread" do
-      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:none")
-
-      assert_nil metadata
-    end
-
-    should "return nil when the claimed event has no reply_metadata" do
-      event = create_pending_event
-      event.claim
-
-      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
-
-      assert_nil metadata
+      assert_equal [ { "reply_token" => "abc" } ], adapter.sent_metadata
     end
 
     # The contract lets an adapter return :reply_metadata as a Hash; only the
     # column holds JSON. Passing a pre-encoded String (as the test above does)
     # would not exercise that conversion.
     should "return the metadata an adapter supplied as a Hash at parse time" do
-      event = create_pending_event(reply_metadata: { "reply_token" => "hash-token" })
-      event.claim
+      setup_reply_path
+      create_pending_event(reply_metadata: { "reply_token" => "hash-token" })
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
 
-      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
+      Timeout.timeout(5) { adapter.start }
 
-      assert_equal({ "reply_token" => "hash-token" }, metadata)
+      assert_equal [ { "reply_token" => "hash-token" } ], adapter.sent_metadata
+    end
+
+    # One poll cycle claims a whole batch before any of it is answered, so
+    # several events of one thread are "processed" at the same time. Each
+    # reply must still see the metadata of the event it is answering.
+    should "give each event of a thread the metadata of that event" do
+      setup_reply_path
+      create_pending_event(event_key: "fifo-1", received_at: 20.seconds.ago,
+                           reply_metadata: { "reply_token" => "first" })
+      create_pending_event(event_key: "fifo-2", received_at: 10.seconds.ago,
+                           reply_metadata: { "reply_token" => "second" })
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal [ { "reply_token" => "first" }, { "reply_token" => "second" } ], adapter.sent_metadata
+    end
+
+    # Regression: the reply position used to be a per-thread cursor held only
+    # in the gateway process's memory. A restart reset it, so the first reply
+    # in a thread picked up the oldest row still retained for deduplication -
+    # an event answered up to RETENTION_DAYS ago - instead of the event being
+    # answered now.
+    should "not pick up an already answered event of the same thread after a gateway restart" do
+      setup_reply_path
+      answered_before_restart = create_pending_event(
+        event_key: "answered-two-days-ago", status: "processed", received_at: 2.days.ago,
+        reply_metadata: { "reply_token" => "long-since-expired" }
+      )
+      create_pending_event(event_key: "asked-now", reply_metadata: { "reply_token" => "current" })
+      # A newly started gateway process knows nothing about the older event.
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal [ { "reply_token" => "current" } ], adapter.sent_metadata
+      assert_equal "processed", answered_before_restart.reload.status
+    end
+
+    # Regression: MessageHandler posts a failure notice through a second
+    # #send_message when the first one raises. That used to consume a second
+    # event's metadata for a single event's reply.
+    should "return the same metadata for every reply to one event" do
+      setup_reply_path
+      ReferenceInboundAdapter.send_failure = RuntimeError.new("the chat service is down")
+      create_pending_event(reply_metadata: { "reply_token" => "only-token" })
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal 2, adapter.sent_messages.size, "the failure notice is a second send"
+      assert_equal [ { "reply_token" => "only-token" }, { "reply_token" => "only-token" } ],
+                   adapter.sent_metadata
+    end
+
+    should "return nil when the event being answered carries no reply_metadata" do
+      setup_reply_path
+      create_pending_event
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal [ nil ], adapter.sent_metadata
+    end
+
+    should "return nil for a thread other than the one being answered" do
+      setup_reply_path
+      ReferenceInboundAdapter.probe_thread_key = "RC1:SOME_OTHER_THREAD"
+      create_pending_event(reply_metadata: { "reply_token" => "abc" })
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal [ nil ], adapter.sent_metadata
+    end
+
+    should "return nil when no reply is in progress" do
+      create_pending_event(reply_metadata: { "reply_token" => "abc" }).claim
+
+      assert_nil ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
     end
   end
 
@@ -414,6 +477,6 @@ class ChatChannelInboundAdapterEndToEndTest < ActionController::TestCase
 
     assert_equal "processed", event.reload.status
     assert_equal [ { channel_id: "E2E1", thread_key: "E2E1:T1", text: "end to end answer" } ], adapter.sent_messages
-    assert_equal({ "reply_token" => "e2e-token" }, adapter.reply_metadata_for(thread_key: "E2E1:T1"))
+    assert_equal [ { "reply_token" => "e2e-token" } ], adapter.sent_metadata
   end
 end

--- a/test/unit/chat_channel/inbound_adapter_test.rb
+++ b/test/unit/chat_channel/inbound_adapter_test.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../test_helper", __FILE__)
+
+# Test-only reference inbound adapter (spec Assumptions): exercises the
+# InboundAdapter contract without depending on any real chat service.
+# Defined only in this test file so it never appears in the production
+# settings screen or adapter registry outside of tests.
+class ReferenceInboundAdapter < RedmineAiHelper::ChatChannel::InboundAdapter
+  class << self
+    def channel_type
+      "reference_inbound"
+    end
+
+    def required_setting_fields
+      [ :bot_token ]
+    end
+
+    # Class-level, not instance-level, because the webhook controller
+    # instantiates its own throwaway adapter object per request: a test
+    # configuring behavior before POSTing has no handle to that instance.
+    attr_accessor :verify_result, :events_to_parse, :challenge_result
+
+    def reset!
+      self.verify_result = true
+      self.events_to_parse = []
+      self.challenge_result = nil
+    end
+  end
+
+  attr_reader :sent_messages
+
+  def initialize
+    super
+    @sent_messages = []
+  end
+
+  def verify_request(_request)
+    self.class.verify_result
+  end
+
+  def parse_events(_request)
+    self.class.events_to_parse || []
+  end
+
+  def challenge_response(_request)
+    self.class.challenge_result
+  end
+
+  def send_message(channel_id:, thread_key:, text:)
+    @sent_messages << { channel_id: channel_id, thread_key: thread_key, text: text }
+  end
+end
+
+class ChatChannelInboundAdapterTest < ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
+
+  setup { ReferenceInboundAdapter.reset! }
+
+  def create_pending_event(overrides = {})
+    AiHelperInboundEvent.create!(
+      {
+        channel_type: "reference_inbound", event_key: SecureRandom.hex(4), text: "hello",
+        channel_id: "RC1", thread_key: "RC1:T1", received_at: Time.current
+      }.merge(overrides)
+    )
+  end
+
+  # Stubs the wait step so #start's loop runs exactly one poll cycle: the
+  # stub's side effect calls #stop, which the loop observes on its next
+  # condition check.
+  def stub_dispatch_stop(adapter)
+    ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+  end
+
+  context "capability declaration" do
+    should "declare inbound? as true" do
+      assert RedmineAiHelper::ChatChannel::InboundAdapter.inbound?
+    end
+  end
+
+  context "abstract methods" do
+    should "raise NotImplementedError from #verify_request when not overridden" do
+      adapter = Class.new(RedmineAiHelper::ChatChannel::InboundAdapter) do
+        class << self
+          def channel_type
+            "unimplemented_inbound"
+          end
+        end
+      end.new
+
+      error = assert_raises(NotImplementedError) { adapter.verify_request(nil) }
+      assert_match(/verify_request/, error.message)
+    end
+
+    should "raise NotImplementedError from #parse_events when not overridden" do
+      adapter = Class.new(RedmineAiHelper::ChatChannel::InboundAdapter) do
+        class << self
+          def channel_type
+            "unimplemented_inbound2"
+          end
+        end
+      end.new
+
+      error = assert_raises(NotImplementedError) { adapter.parse_events(nil) }
+      assert_match(/parse_events/, error.message)
+    end
+
+    should "default #challenge_response to nil" do
+      adapter = Class.new(RedmineAiHelper::ChatChannel::InboundAdapter) do
+        class << self
+          def channel_type
+            "unimplemented_inbound3"
+          end
+        end
+      end.new
+
+      assert_nil adapter.challenge_response(nil)
+    end
+  end
+
+  context "#start" do
+    should "claim and dispatch a pending event in one polling cycle, then stop" do
+      project = Project.find(1)
+      project.enable_module!("ai_helper")
+      user = User.find(2)
+      create(:ai_helper_chat_adapter_setting, channel_type: "reference_inbound", redmine_user_id: user.id)
+      create(:ai_helper_channel_binding, channel_type: "reference_inbound", channel_id: "RC1", project: project)
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        AiHelperMessage.new(role: "assistant", content: "reference answer")
+      )
+      event = create_pending_event
+      adapter = ReferenceInboundAdapter.new
+      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal "processed", event.reload.status
+      assert_equal [ { channel_id: "RC1", thread_key: "RC1:T1", text: "reference answer" } ],
+                   adapter.sent_messages
+    end
+
+    should "exit the loop once #stop has been called" do
+      adapter = ReferenceInboundAdapter.new
+      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+
+      assert_nothing_raised { Timeout.timeout(5) { adapter.start } }
+      assert adapter.send(:stopped?)
+    end
+
+    should "keep polling and log the error instead of stopping when one event raises" do
+      create_pending_event(event_key: "boom")
+      adapter = ReferenceInboundAdapter.new
+      adapter.stubs(:dispatch).raises(StandardError, "handler exploded")
+      logger = mock("logger")
+      logger.expects(:error).with(regexp_matches(/handler exploded/))
+      adapter.stubs(:ai_helper_logger).returns(logger)
+      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+
+      assert_nothing_raised { Timeout.timeout(5) { adapter.start } }
+    end
+  end
+
+  context "#reply_metadata_for" do
+    should "return the parsed reply_metadata of the most recently claimed event for the thread" do
+      event = create_pending_event(reply_metadata: { reply_token: "abc" }.to_json)
+      event.claim
+
+      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
+
+      assert_equal({ "reply_token" => "abc" }, metadata)
+    end
+
+    should "return nil when no claimed event exists for the thread" do
+      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:none")
+
+      assert_nil metadata
+    end
+
+    should "return nil when the claimed event has no reply_metadata" do
+      event = create_pending_event
+      event.claim
+
+      metadata = ReferenceInboundAdapter.new.reply_metadata_for(thread_key: "RC1:T1")
+
+      assert_nil metadata
+    end
+  end
+
+  context "freshness limit (FR-008a)" do
+    should "expire and discard an event received before the freshness limit, without dispatching it" do
+      old_event = create_pending_event(
+        event_key: "stale-1",
+        received_at: (RedmineAiHelper::ChatChannel::InboundAdapter::FRESHNESS_LIMIT_SECONDS + 10).seconds.ago
+      )
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal "expired", old_event.reload.status
+      assert_empty adapter.sent_messages
+    end
+
+    should "log the discard of an expired event" do
+      create_pending_event(
+        event_key: "stale-2",
+        received_at: (RedmineAiHelper::ChatChannel::InboundAdapter::FRESHNESS_LIMIT_SECONDS + 10).seconds.ago
+      )
+      adapter = ReferenceInboundAdapter.new
+      logger = mock("logger")
+      logger.expects(:info).with(regexp_matches(/stale-2/))
+      adapter.stubs(:ai_helper_logger).returns(logger)
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+    end
+
+    should "process an event received within the freshness limit" do
+      project = Project.find(1)
+      project.enable_module!("ai_helper")
+      user = User.find(2)
+      create(:ai_helper_chat_adapter_setting, channel_type: "reference_inbound", redmine_user_id: user.id)
+      create(:ai_helper_channel_binding, channel_type: "reference_inbound", channel_id: "RC1", project: project)
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        AiHelperMessage.new(role: "assistant", content: "still fresh")
+      )
+      fresh_event = create_pending_event(
+        event_key: "fresh-1",
+        received_at: (RedmineAiHelper::ChatChannel::InboundAdapter::FRESHNESS_LIMIT_SECONDS - 10).seconds.ago
+      )
+      adapter = ReferenceInboundAdapter.new
+      stub_dispatch_stop(adapter)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal "processed", fresh_event.reload.status
+      assert_equal [ { channel_id: "RC1", thread_key: "RC1:T1", text: "still fresh" } ], adapter.sent_messages
+    end
+  end
+
+  context "retention cleanup (FR-009)" do
+    should "delete rows past the retention period on the first cycle and keep newer rows" do
+      old_row = create_pending_event(
+        event_key: "ret-old", status: "expired",
+        received_at: (RedmineAiHelper::ChatChannel::InboundAdapter::RETENTION_DAYS.days + 1.day).ago
+      )
+      recent_row = create_pending_event(event_key: "ret-recent", status: "expired", received_at: 1.day.ago)
+      adapter = ReferenceInboundAdapter.new
+      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_not AiHelperInboundEvent.exists?(old_row.id)
+      assert AiHelperInboundEvent.exists?(recent_row.id)
+    end
+
+    should "not purge again before CLEANUP_INTERVAL_SECONDS has elapsed since the last purge" do
+      # Drives the private cleanup step directly, rather than through #start,
+      # so the narrow Process.clock_gettime stub below does not also have to
+      # account for every other call Rails makes to it during a full cycle.
+      adapter = ReferenceInboundAdapter.new
+      interval = RedmineAiHelper::ChatChannel::InboundAdapter::CLEANUP_INTERVAL_SECONDS
+      AiHelperInboundEvent.expects(:purge_old).with("reference_inbound", anything).once
+
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1000.0)
+      adapter.send(:purge_expired_rows_if_due)
+
+      Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(1000.0 + interval - 1)
+      adapter.send(:purge_expired_rows_if_due)
+    end
+  end
+
+  context "gateway-stop recovery (FR-008)" do
+    should "process an event that was saved while polling was stopped, once polling resumes within the freshness limit" do
+      project = Project.find(1)
+      project.enable_module!("ai_helper")
+      user = User.find(2)
+      create(:ai_helper_chat_adapter_setting, channel_type: "reference_inbound", redmine_user_id: user.id)
+      create(:ai_helper_channel_binding, channel_type: "reference_inbound", channel_id: "RC1", project: project)
+      RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+        AiHelperMessage.new(role: "assistant", content: "caught up after downtime")
+      )
+      # Simulates an event received while the gateway process was down: it
+      # sat pending for a while, but is still inside the freshness window
+      # once polling resumes.
+      event = create_pending_event(event_key: "downtime-1", received_at: 90.seconds.ago)
+      adapter = ReferenceInboundAdapter.new
+      ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+
+      Timeout.timeout(5) { adapter.start }
+
+      assert_equal "processed", event.reload.status
+      assert_equal [ { channel_id: "RC1", thread_key: "RC1:T1", text: "caught up after downtime" } ],
+                   adapter.sent_messages
+    end
+  end
+end
+
+# FR-012 / SC-007: proves the inbound foundation works end to end - receive,
+# persist, poll, dispatch, reply - through the reference adapter alone, with
+# zero changes to Gateway, MessageHandler, IncomingMessage or an existing
+# (Slack/Discord) adapter.
+class ChatChannelInboundAdapterEndToEndTest < ActionController::TestCase
+  include FactoryBot::Syntax::Methods
+  tests AiHelperChatWebhookController
+
+  def setup
+    @controller = AiHelperChatWebhookController.new
+    @request = ActionController::TestRequest.create(@controller.class)
+    @response = ActionDispatch::TestResponse.create
+
+    ReferenceInboundAdapter.reset!
+    AiHelperInboundEvent.delete_all
+    AiHelperChatAdapterSetting.delete_all
+  end
+
+  should "carry a webhook POST through storage, polling and dispatch to send_message" do
+    project = Project.find(1)
+    project.enable_module!("ai_helper")
+    user = User.find(2)
+    create(:ai_helper_chat_adapter_setting, channel_type: "reference_inbound", enabled: true,
+                                             bot_token: "secret", redmine_user_id: user.id, default_project_id: project.id)
+    create(:ai_helper_channel_binding, channel_type: "reference_inbound", channel_id: "E2E1", project: project)
+    RedmineAiHelper::Llm.any_instance.stubs(:chat).returns(
+      AiHelperMessage.new(role: "assistant", content: "end to end answer")
+    )
+    ReferenceInboundAdapter.events_to_parse = [
+      { event_key: "e2e-1", text: "hello from e2e", channel_id: "E2E1", thread_key: "E2E1:T1" }
+    ]
+
+    post :receive, params: { channel_type: "reference_inbound" }, body: "{}"
+
+    assert_response :success
+    event = AiHelperInboundEvent.find_by(channel_type: "reference_inbound", event_key: "e2e-1")
+    assert_not_nil event
+    assert_equal "pending", event.status
+
+    adapter = ReferenceInboundAdapter.new
+    ReferenceInboundAdapter.stubs(:timed_queue_pop).with { |_queue, _timeout| adapter.stop; true }.returns(nil)
+    Timeout.timeout(5) { adapter.start }
+
+    assert_equal "processed", event.reload.status
+    assert_equal [ { channel_id: "E2E1", thread_key: "E2E1:T1", text: "end to end answer" } ], adapter.sent_messages
+  end
+end

--- a/wiki/INDEX.md
+++ b/wiki/INDEX.md
@@ -10,9 +10,13 @@ page files, not here.
 
 ## decision
 - [Agent Write-Capability Routing](./pages/agent-write-capability-routing.md) — why `can_write?`/`requires_write` guard write steps at dispatch time instead of being exposed to the router, and how skipped steps and the final-answer prompt stay consistent with what actually ran.
+- [Inbound Chat Webhook Ingest](./pages/inbound-chat-webhook-ingest.md) — why webhook events land on a Rails endpoint in Redmine, hand off through a DB table, and are polled by `InboundAdapter#start` so the gateway core stays unchanged.
+- [Public URL Scope for Chat Adapters](./pages/public-url-scope.md) — ADR-017's amendment to ADR-006: "no public URL required" is an outbound-adapter property, not a whole-plugin invariant.
 
 ## component
 - [Chat Channel Gateway Architecture](./pages/chat-channel-gateway-architecture.md) — core + adapters structure, capability declaration, and gateway operational model.
+- [Inbound Webhook Endpoint](./pages/inbound-webhook-endpoint.md) — the anonymous `POST /ai_helper/chat_webhook/:channel_type` controller: skipped filters, raw-body signature verification, challenge responses, webhook URL display.
+- [Inbound Event Queue](./pages/inbound-event-queue.md) — the `ai_helper_inbound_events` table: atomic claiming, freshness expiry, retention purge, and reply metadata resolved by event id.
 - [Chat Context Import](./pages/chat-context-import.md) — how surrounding messages are imported, cursored, persisted as `context` role, and fed to the LLM.
 - [AI Chat Sidebar](./pages/chat-sidebar.md) — the sidebar UI: view-hook injection, the `AiHelper` JS class, SSE handling, conversation models, and Markdown/XSS.
 - [Issue AI Features](./pages/issue-ai-features.md) — `IssueReadAgent` summarization/caching, reply drafts, sub-issues, assignee suggestion, duplicate check, and inline completion.
@@ -33,3 +37,4 @@ page files, not here.
 
 ## howto
 - [Nginx SSE Proxy Settings](./pages/nginx-sse-proxy.md) — the five directives SSE streaming needs behind Nginx.
+- [Developing an Inbound Chat Adapter](./pages/inbound-adapter-development.md) — subclassing `InboundAdapter`: the methods to implement, settings and webhook URL, proxy rate limiting, and the reference-adapter test pattern.

--- a/wiki/lint-report.md
+++ b/wiki/lint-report.md
@@ -1,31 +1,49 @@
-# Wiki Lint Report — 2026-08-01
+# Wiki Lint Report — 2026-08-08 (second pass)
 
-Scope: full pass. 19 pages, 14 sources. Auto-fix mode: `index-and-links`.
+Scope: full pass. 25 pages, 20 sources. Auto-fix mode: `index-and-links`.
+Supersedes the earlier 2026-08-08 report, whose finding 1 is now **resolved**.
 
 ## Results per check
 
 | Check | Result |
 |-------|--------|
-| index-drift | ✅ clean — all 19 pages listed in `INDEX.md`; no index line points at a missing file |
-| links | ✅ clean — every `./*.md` relative link resolves; every `(Sxxx)` citation names a registered source (S001–S014) |
-| orphans | ✅ clean — every page has ≥1 inbound link (minimums: chat-sidebar, issue-ai-features, vector-search-internals — each reachable from a hub page) |
-| contradictions | ✅ clean — no unresolved `⚠ conflict:` markers. Cross-source claims checked in the high-overlap areas (Anthropic S002↔S004, read-only mode across tool-system/mcp/architecture/sidebar, `messages_for_openai`, `AiHelperMarkdownParser`, `think_chat`) are mutually consistent |
-| stale | ✅ clean — all pages `updated: 2026-08-01`; nothing past the 90-day threshold (2026-05-03); no source re-ingested after its page's last update |
-| citations | ⚠ 1 low-severity finding (repeat from prior report) |
+| index-drift | ✅ clean — all 25 pages appear in `INDEX.md` under the group matching their frontmatter `type`; no index line points at a missing file |
+| links | ✅ clean — every `./*.md` relative link resolves (pages + INDEX); every `(Sxxx)` citation names a registered source (S001–S020) |
+| orphans | ✅ clean — every page has ≥1 inbound link from another page. The five feature-044 pages form a connected cluster reachable from `chat-channel-gateway-architecture.md` |
+| contradictions | ✅ clean — **no `⚠ conflict:` markers remain**. The S002-vs-S018 public-URL conflict was resolved by ingesting ADR-017 (S019): S002's claim now stands scoped to outbound adapters, with the amendment cited to S019 on [Public URL Scope](./pages/public-url-scope.md) |
+| stale | ✅ clean — oldest page is `updated: 2026-08-01`, far inside the 90-day threshold (2026-05-10); no source's `Last ingested` postdates a page citing it |
+| citations | ⚠ 1 finding — one uncited aside, now unchanged across four passes |
+| *(page size — SCHEMA rule, not a listed check)* | ⚠ 1 finding — 7 pages exceed the 600-word split rule, up from 4 |
 
 ## Findings
 
 | # | Check | Severity | Page | Finding | Suggested fix |
 |---|-------|----------|------|---------|---------------|
-| 1 | citations | low | mcp-integration.md:39 | The aside "the project also refers to these as `SubMcpAgent` classes" carries no source ID. It is an editorial reconciliation between S006 (which named the class `AiHelperMcpSlack`) and the project's CLAUDE.md, not a claim from any registered source. **Unchanged since the last lint.** | Reframe as a `> Provenance:` note (as on the architecture/tool/provider pages), or register the plugin's `CLAUDE.md` as a source and cite it. No auto-fix (semantic). |
+| 1 | page-size | structural | inbound-event-queue.md (702), inbound-webhook-endpoint.md (699), agent-write-capability-routing.md (693), mcp-integration.md (671), inbound-chat-webhook-ingest.md (663), chat-channel-gateway-architecture.md (628), vector-search.md (617) | `SCHEMA.md` requires splitting a page past 600 words. 7 of 25 pages now exceed it — the three feature-044 pages joined the list during the S018–S020 ingests, after prose trimming failed to bring them under. Roughly 30–45 words of each inbound page's count is table markup rather than prose, so the true overrun is ~10%. | Judgment call, not mechanical: either accept the overrun (all seven are coherent single topics, and feature 044 already spans five pages) or raise `ingest.page_max_words` in a project `wiki-config.yml` to match how these pages are actually written. Splitting further would scatter one mechanism across two files. Not auto-fixable. |
+| 2 | citations | low | mcp-integration.md:38–39 | The aside "the project also refers to these as `SubMcpAgent` classes" carries no source ID. It reconciles S006 (which named the class `AiHelperMcpSlack`) with the project's `CLAUDE.md`, and belongs to no registered source. **Unchanged across four consecutive lint passes.** | Register `CLAUDE.md` as a source and cite it, or reframe the aside as a `> Provenance:` note (the convention already used on the architecture/tool/provider pages). Not auto-fixable — semantic. |
 
 ## Fixes applied
 
-None. `INDEX.md` and all link targets were already consistent — nothing mechanical to repair.
+None. `INDEX.md` and every link target were already consistent — nothing mechanical to repair.
 
-## Note on source mix
+## Notes
 
-8 of 14 sources are DeepWiki (AI-generated); the rest are 5 specs + the README.
-Several DeepWiki-only claims have since gained spec/README corroboration
-(MCP, provider layer, vector rake tasks, health report, chat sidebar names). No
-action required — tracked here as a confidence signal, not a defect.
+*Observations, not defects — no action required.*
+
+- **Two registration mechanisms, described separately.** `chat-channel-gateway-architecture.md`
+  says adapters register via the `inherited` hook (S001);
+  `inbound-adapter-development.md` says an adapter file is picked up by the
+  `Dir[…adapters/*_adapter.rb]` glob in `init.rb` (S020). These are
+  complementary halves of one flow (the glob loads the file, the hook registers
+  the class), not a contradiction — but neither page mentions the other half.
+  Ingesting `init.rb` or `base_adapter.rb` would let one page state it whole.
+- **Feature 044 coverage is now three-source deep.** Its five pages rest on
+  S018 (design intent), S019 (the accepted ADR) and S020 (the shipped
+  developer guide), the strongest corroboration in the wiki. The remaining
+  unregistered artifacts are the two contract files under
+  `specs/044-inbound-chat-webhook/contracts/`, which S020 names as the
+  method-level authority.
+- **Source mix.** 8 of 20 sources are DeepWiki (AI-generated); the other 12 are
+  7 spec/feature artifacts, the README, 2 ADRs and 2 project docs. The last
+  five ingests were all first-party, so the DeepWiki share keeps falling.
+  Tracked as a confidence signal, not a defect.

--- a/wiki/pages/chat-channel-gateway-architecture.md
+++ b/wiki/pages/chat-channel-gateway-architecture.md
@@ -1,8 +1,8 @@
 ---
 title: Chat Channel Gateway Architecture
 type: component
-sources: [S001, S002]
-updated: 2026-08-01
+sources: [S001, S002, S018, S019]
+updated: 2026-08-08
 ---
 
 # Chat Channel Gateway Architecture
@@ -31,6 +31,10 @@ turned into an `IncomingMessage` and handled through `MessageHandler` (S001).
 - It runs as a **separate background process** that connects *outward* to the
   chat service, so **no public URL** is required for the Redmine server (S002).
   Start it with `rake redmine:plugins:ai_helper:chat_channel:gateway` (S002).
+  ADR-017 scopes that guarantee to **outbound** adapters — it is not a
+  whole-plugin invariant, and enabling an inbound adapter does require a public
+  HTTPS URL. Slack/Discord are unaffected (S019). See
+  [Public URL Scope for Chat Adapters](./public-url-scope.md).
 - Every question is processed under a single Redmine **execution account**
   chosen by the admin; restricting that account's roles restricts what the
   gateway can read and do. Custom commands, agent orchestration, and Langfuse
@@ -62,6 +66,17 @@ simply proceeds with no prior context. This mirrors 028's
 `required_setting_fields` declaration style (S001). Slack and Discord override
 these to `true` and implement both fetch methods.
 
+## Inbound adapters
+
+Feature 044 adds `BaseAdapter.inbound?` in the same declaration style (default
+`false`, `true` on `InboundAdapter`). An inbound adapter has no socket: its
+`start` polls `ai_helper_inbound_events` for webhook events stored by a Rails
+endpoint in Redmine, then `dispatch`es them into the same worker loop, leaving
+`Gateway`, `MessageHandler`, `IncomingMessage` and the Slack/Discord adapters
+unchanged (S018). ADR-017 records that claim as verified: the whole pre-existing
+suite, `gateway_test.rb` and both concrete adapters' tests included, passes
+unmodified (S019).
+
 ## Related
 
 - [Chat Context Import](./chat-context-import.md) — how surrounding messages
@@ -70,9 +85,16 @@ these to `true` and implement both fetch methods.
   details behind the fetch methods.
 - [Discord Message Content Intent](./discord-message-content-intent.md) — a
   hard constraint on the Discord adapter's connection.
+- [Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md) — the
+  decisions behind webhook-push adapters.
+- [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — the receiving
+  controller and its security rules.
+- [Inbound Event Queue](./inbound-event-queue.md) — the event table, claiming,
+  expiry, retention, and reply metadata.
 - [Plugin Overview](./plugin-overview.md) — where the gateway sits among the
   plugin's features.
 
-Design decisions are recorded in ADR-006 (gateway architecture) and ADR-007
-(Discord connection design) under `docs/adr/` (S001). Full setup guides live in
+Design decisions are recorded in ADR-006 (gateway architecture), ADR-007
+(Discord connection design) and ADR-017 (inbound webhook gateway, an accepted
+amendment to ADR-006's scope) under `docs/adr/` (S001, S019). Full setup guides live in
 `docs/slack_gateway_setup.md` and `docs/discord_gateway_setup.md` (S002).

--- a/wiki/pages/inbound-adapter-development.md
+++ b/wiki/pages/inbound-adapter-development.md
@@ -1,0 +1,89 @@
+---
+title: Developing an Inbound Chat Adapter
+type: howto
+sources: [S020]
+updated: 2026-08-08
+---
+
+# Developing an Inbound Chat Adapter
+
+How to support a webhook-push platform (LINE, Teams) on the feature 044
+foundation. This is the *developer* counterpart to `docs/slack_gateway_setup.md`
+/ `docs/discord_gateway_setup.md`, which document *operator* setup for the
+outgoing-connection adapters (S020).
+
+Subclass `RedmineAiHelper::ChatChannel::InboundAdapter`, not `BaseAdapter`,
+whenever the platform pushes events to a URL you register with it instead of
+letting you open a connection. `InboundAdapter` already implements `#start` as
+the polling loop over `ai_helper_inbound_events`; you supply only
+platform-specific parsing and verification (S020).
+
+## The adapter class
+
+Add `lib/redmine_ai_helper/chat_channel/adapters/<name>_adapter.rb` — the same
+location convention as `slack_adapter.rb`/`discord_adapter.rb`, and it is
+picked up automatically by the `Dir[…adapters/*_adapter.rb]` glob in `init.rb`,
+so there is no manual registration step (S020). Declare `channel_type` and
+`required_setting_fields` at class level, then implement:
+
+| Method | Required | Notes |
+|---|---|---|
+| `verify_request(request)` | yes — no default | HMAC over `request.raw_post` |
+| `parse_events(request)` | yes | returns the normalized event hashes |
+| `challenge_response(request)` | no — defaults to `nil` | only if the platform handshakes |
+| `send_message(channel_id:, thread_key:, text:)` | yes | posts the reply via the platform API |
+
+- **`verify_request`** has no default implementation because authenticity for a
+  webhook message can only be established by the adapter — there is no Redmine
+  session involved. Sign `request.raw_post`, the exact bytes the platform
+  signed; a re-serialization of the parsed JSON is not guaranteed byte-identical
+  (S020).
+- **`parse_events`** returns zero or more hashes in the shape documented on
+  [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md); return `[]` when a
+  delivery carries nothing to answer, such as a delivery receipt or the bot's
+  own message (S020).
+- **`reply_metadata_for(thread_key:)`** is worth calling from `send_message`
+  only when replying needs more than `channel_id`/`thread_key` (a reply token,
+  say). Most platforms that can push by channel id alone never need it (S020).
+
+## Settings and the webhook URL
+
+No new settings model: `AiHelperChatAdapterSetting` already carries the columns
+every adapter shares (`enabled`, `app_token`, `bot_token`, execution account,
+default project). Declare the ones you need via `required_setting_fields`,
+exactly as an outbound adapter does (S020).
+
+Once enabled under *Administration → AI Helper → Chat integrations*, the
+adapter's block shows `https://<Setting.host_name>/ai_helper/chat_webhook/<channel_type>`
+to register with the external service. That display is generic — driven by
+`inbound?` — so the settings view needs nothing adapter-specific (S020).
+
+## Rate limiting at the proxy
+
+The plugin does not rate-limit the endpoint (see
+[Public URL Scope](./public-url-scope.md)); the reverse proxy already fronting
+Redmine does. A minimal nginx form is a `limit_req_zone` on
+`$binary_remote_addr` (e.g. `rate=20r/s`) applied to
+`location /ai_helper/chat_webhook/` with a small burst. Tune it to the traffic
+the integration actually expects: per-request work is cheap (verify, normalize,
+insert one row), so the limit exists to bound abuse, not to protect throughput
+(S020).
+
+## Testing
+
+Follow the reference adapter pattern in
+`test/unit/chat_channel/inbound_adapter_test.rb`: a test-only subclass with
+toggles for `verify_request`/`parse_events`/`challenge_response`, registered
+inside the test file and never under `lib/`, driven through one poll cycle by
+stubbing `InboundAdapter.timed_queue_pop` to call `#stop` as a side effect.
+That proves integration with the shared `Gateway`/`MessageHandler` path without
+a real webhook call or a live platform (S020).
+
+## Related
+
+- [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — the event hash
+  and what the controller does with what you return.
+- [Inbound Event Queue](./inbound-event-queue.md) — the constants and lifecycle
+  your `#start` inherits.
+- [Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md) — why the
+  foundation is shaped this way.

--- a/wiki/pages/inbound-chat-webhook-ingest.md
+++ b/wiki/pages/inbound-chat-webhook-ingest.md
@@ -1,0 +1,96 @@
+---
+title: Inbound Chat Webhook Ingest
+type: decision
+sources: [S018, S019]
+updated: 2026-08-08
+---
+
+# Inbound Chat Webhook Ingest
+
+Feature 044 adds the foundation for chat services that **push** messages over a
+webhook (LINE, Microsoft Teams) instead of accepting an outward socket
+connection like Slack/Discord do. Those platforms deliver events *only* by
+POSTing to a URL registered with them, so building on ADR-006 unchanged would
+leave them unsupportable (S019). Concrete service adapters are out of scope;
+the base is proven with a test-only reference adapter (S018), and writing a
+real one means subclassing `InboundAdapter` with `verify_request`,
+`parse_events` and optionally `challenge_response`, touching no core code
+(S019). Decisions 1–2 below are recorded as **ADR-017**
+(`docs/adr/017-inbound-chat-webhook-gateway.md`, Accepted 2026-08-08) (S019).
+
+## 1. The endpoint lives in the Redmine web process
+
+A Rails controller (`AiHelperChatWebhookController`, `POST
+/ai_helper/chat_webhook/:channel_type`) receives events; the gateway process
+embeds **no HTTP server** (S018).
+
+- Reuses Redmine's existing public HTTPS URL, TLS termination and reverse-proxy
+  config, so operators expose no new port (S018).
+- Keeps ADR-006's split intact: the gateway stays a resident process dedicated
+  to receiving and serializing work, rather than gaining a public surface (S018).
+- The endpoint never generates a response, so Puma's multithreading cannot break
+  the `User.current` permission isolation ADR-006 depends on (S018).
+
+**Rejected**: an HTTP server inside the gateway (forces new port/TLS/proxy setup
+on operators); calling the LLM directly in the endpoint (concurrent execution
+breaks `User.current` isolation — ruled out on sight) (S018).
+
+## 2. Handoff is a database table, polled
+
+Verified events are normalized into `ai_helper_inbound_events` and the gateway
+polls for unprocessed rows every 2 seconds by default (S018).
+
+- The only shared storage a Redmine plugin may assume is Redmine's own
+  database; Redis must not become an install requirement. Solid Queue and
+  Redmine's own mail intake use the same "DB as queue" pattern (S018).
+- Worst-case handoff delay equals the poll interval, well inside the 5-second
+  target (S018).
+
+**Rejected**: PostgreSQL `LISTEN/NOTIFY` (Redmine also supports MySQL, and a
+persistent connection complicates the gateway); ActiveJob (Redmine's default
+`:async` adapter runs inside the web process, unreachable from a separate
+gateway — the same reason ADR-006 already rejected it); a file-based queue (not
+shareable across multiple Redmine nodes) (S018).
+
+## 3. The polling loop is `InboundAdapter#start`
+
+Polling is implemented as an adapter's `start`, so **`Gateway`,
+`MessageHandler`, `IncomingMessage` and the existing adapters change by zero
+lines** (S018).
+
+- `Gateway#run` already runs each enabled adapter's `start` on its own thread
+  and serializes `dispatch`ed messages through a single worker; "poll the DB"
+  simply replaces "hold a WebSocket" inside that structure (S018).
+- Per-adapter threads mean existing failure handling (`handle_adapter_exit`:
+  one dead adapter doesn't stop the others; the last one dying ends the
+  gateway) applies to inbound adapters unchanged (S018).
+- `BaseAdapter#stop` (`@stopped = true` → `connection_ended!` → `close_socket`,
+  a no-op when `@ws` is nil) already works for socketless adapters. Waiting on
+  the existing `@connection_ended` queue via `BaseAdapter.timed_queue_pop`
+  makes the poll sleep interruptible, so stop responsiveness matches the
+  socket adapters (S018).
+
+**Rejected**: one shared poller thread in `Gateway` (Gateway would have to route
+channel types to adapters, i.e. know inbound exists); an empty `start` with
+processing elsewhere (the thread exits immediately and `handle_adapter_exit`
+concludes no adapters are alive, shutting the gateway down) (S018).
+
+## Consequence for ADR-006
+
+Decision 1 changes who needs a public URL, so ADR-017 amends the scope of
+ADR-006's "no public URL" premise instead of editing that append-only document
+(S018, S019). ADR-006 decision 5's permission separation is untouched — the
+internet-reachable web process still never runs an LLM request (S019). The
+scope amendment, its negative consequence and the framing it rejects are on
+[Public URL Scope for Chat Adapters](./public-url-scope.md).
+
+## Related
+
+- [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — the receiving
+  controller: anonymous access, signature verification, challenge responses.
+- [Inbound Event Queue](./inbound-event-queue.md) — the mechanics these
+  decisions produce: states, claiming, expiry, retention, reply metadata.
+- [Public URL Scope for Chat Adapters](./public-url-scope.md) — what ADR-017
+  changed about ADR-006's premise, and what it deliberately did not.
+- [Chat Channel Gateway Architecture](./chat-channel-gateway-architecture.md) —
+  the core/adapters structure this plugs into.

--- a/wiki/pages/inbound-event-queue.md
+++ b/wiki/pages/inbound-event-queue.md
@@ -1,0 +1,102 @@
+---
+title: Inbound Event Queue
+type: component
+sources: [S018, S020]
+updated: 2026-08-08
+---
+
+# Inbound Event Queue
+
+What happens to a webhook event after
+[the endpoint](./inbound-webhook-endpoint.md) stores it in
+`ai_helper_inbound_events`, and how the gateway turns it into an answer. The
+rationale is on [Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md)
+(S018).
+
+## States and de-duplication
+
+Rows move one way: `pending → processed` or `pending → expired` (S018).
+
+- **On receipt**: a UNIQUE index on `(channel_type, event_key)` is the dedup
+  guard; a duplicate INSERT raises `ActiveRecord::RecordNotUnique`, which is
+  caught and answered 200 as "already received". An application-level existence
+  check cannot survive concurrent delivery, and external services resend
+  whenever they don't get a 200 (S018).
+- **On pickup**: `UPDATE … SET status='processed' WHERE id=? AND
+  status='pending'` claims a row only if it updates exactly one row. That is
+  atomic across a doubly-started or just-restarted gateway and holds no long
+  transaction — unlike `SELECT … FOR UPDATE`, which would keep a row locked for
+  the whole LLM call (S018).
+- Marking `processed` **before** processing means a crash mid-answer leaves the
+  event un-retried. Deliberate: in chat, a duplicate answer is worse than a
+  missing one (S018).
+
+## Tunables
+
+`InboundAdapter` defines these constants, shared by every inbound adapter
+(S020):
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `POLL_INTERVAL_SECONDS` | 2 | how often the gateway checks for pending events |
+| `POLL_BATCH_SIZE` | 20 | rows claimed per poll |
+| `FRESHNESS_LIMIT_SECONDS` | 120 | past this age at claim time, discard instead of answering |
+| `RETENTION_DAYS` | 7 | how long a row survives, for deduplication, before deletion |
+| `CLEANUP_INTERVAL_SECONDS` | 3600 | minimum gap between retention cleanups |
+
+## Freshness and retention
+
+- Right after a successful claim, an event older than `FRESHNESS_LIMIT_SECONDS`
+  is set `expired`, logged, and dropped without dispatch. Judging at processing
+  start applies one rule to recovery-from-downtime, backlog drain and normal
+  traffic alike; judging before the claim would let several processes log the
+  same expiry (S018). Replying "too old to answer" was rejected as noise (S018).
+- The polling loop purges rows past `RETENTION_DAYS`, scoped to its own channel
+  type — no cron required, and concurrent inbound adapters never collide on
+  deletes (S018).
+
+## Replying to the right event
+
+`reply_metadata` (a JSON string) rides on the event row, and `InboundAdapter`
+exposes `reply_metadata_for(thread_key:)`. The event is identified by **row
+id**, carried on the message: `InboundEventMessage < IncomingMessage` adds
+`event_id`, and `EventScopedHandler < MessageHandler` records it for the
+duration of `#handle` — so `send_message`'s signature, `IncomingMessage` and
+`MessageHandler` all stay untouched and existing adapter tests keep passing
+(S018).
+
+Identifying by thread position instead does not work (S018):
+
+- one poll claims up to `POLL_BATCH_SIZE` rows, so several events in a thread
+  turn `processed` at once;
+- rows linger for `RETENTION_DAYS` while an in-memory cursor dies with the
+  process — after a restart the first reply could pick up metadata from days
+  ago (a lifetime asymmetry between row and cursor);
+- `MessageHandler` calls `send_message` a second time to report a failed reply,
+  so "one call consumes one event" over-advances the cursor.
+
+Resolving through the event id makes the helper safe to call repeatedly: every
+call during one reply returns the same value, and a reply never sees another
+event's metadata — neither a sibling claimed in the same batch nor an event
+answered days ago whose row is still retained. It returns `nil` outside a
+reply, when the event carries no metadata, or when `thread_key` is not the
+thread being answered (S020).
+
+Adapters needing none of this simply never call the helper — the same "not
+using it is the normal case" stance as `supports_history?` (S018).
+
+> LINE's `replyToken` expires in tens of seconds, which the 2-minute freshness
+> window plus LLM latency cannot fit. A LINE adapter is expected to reply with
+> push messages, where `channel_id` alone determines the destination and no
+> metadata is needed (S018).
+
+## Related
+
+- [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — the other half:
+  how events get here.
+- [Developing an Inbound Chat Adapter](./inbound-adapter-development.md) — the
+  guide these constants and helpers are written for.
+- [Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md) — the
+  decisions behind this design.
+- [Chat Channel Gateway Architecture](./chat-channel-gateway-architecture.md) —
+  the adapter thread model the polling loop rides on.

--- a/wiki/pages/inbound-webhook-endpoint.md
+++ b/wiki/pages/inbound-webhook-endpoint.md
@@ -1,0 +1,106 @@
+---
+title: Inbound Webhook Endpoint
+type: component
+sources: [S018, S019, S020]
+updated: 2026-08-08
+---
+
+# Inbound Webhook Endpoint
+
+The HTTP half of feature 044: `AiHelperChatWebhookController` at `POST
+/ai_helper/chat_webhook/:channel_type`, running inside Redmine's web process.
+It verifies, normalizes and stores an event, then answers — it never calls the
+LLM (S018, S019). An inbound adapter supplies three methods to it:
+`verify_request` and `parse_events`, plus `challenge_response` when the service
+needs one (S019). The lifecycle after storage is on
+[Inbound Event Queue](./inbound-event-queue.md); the rationale is on
+[Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md).
+
+## Anonymous by necessity
+
+The controller copies the pattern `AiHelperMcpController` established:
+`skip_before_action :verify_authenticity_token` plus `skip_before_action
+:check_if_login_required, raise: false` (S018).
+
+- Skipping `check_if_login_required` is **mandatory**, not cosmetic: with
+  `Setting.login_required` on, Redmine returns 403 before any custom auth runs
+  — the known Issue #304 problem, which hits webhooks the same way (S018).
+- CSRF tokens defend session cookies and don't apply to server-to-server POSTs.
+  Authenticity comes from the adapter's `verify_request` instead — a **required
+  abstract method with no default implementation** (S018).
+
+## Security rules
+
+- Signature verification needs the **raw request body** (`request.raw_post` /
+  `request.body.read`), because the HMAC covers the pre-parse bytes — never
+  reconstruct it from the parsed hash (S018).
+- Verification failure, unknown channel type and disabled adapter all answer
+  404/401 alike, so which adapters are enabled never leaks (S018).
+- Tokens and signatures are never logged; raw payloads and speaker identity are
+  not persisted (S018).
+- Rate limiting is delegated to the reverse proxy — see
+  [Public URL Scope](./public-url-scope.md) (S018, S019).
+- Target: 95% of webhook responses within 1 second, 100% within 3 (S018).
+
+## The normalized event
+
+`parse_events` returns **exactly** these keys; an event carrying anything else
+is logged as an error and skipped, because it cannot be stored (S020):
+
+| Key | Required | Meaning |
+|---|---|---|
+| `:event_key` | yes | external event id — the dedup key |
+| `:text` | yes | question body, mention markup already stripped |
+| `:channel_id` | yes | channel or DM identifier |
+| `:thread_key` | yes | thread identifier |
+| `:message_ts` | no | per-message id, where the platform has one |
+| `:dm` | no | direct-message flag (default `false`) |
+| `:in_thread` | no | reply-in-thread flag (default `false`) |
+| `:reply_metadata` | no | platform data needed to reply; JSON-encoded into the column by `AiHelperInboundEvent#reply_metadata=` |
+
+The bot's own messages are never included, and speaker identity goes into
+neither `:text` nor `:reply_metadata` — the plugin records only the configured
+service account that answers, as it already does for outbound adapters (S020).
+
+## Failure handling
+
+Errors here favor **not** making the platform retry forever (S020):
+
+- An unparseable request (malformed JSON, unexpected shape) should raise; the
+  controller catches it, logs the full backtrace, and still answers `200`.
+- A single event that cannot be stored is logged with its backtrace and
+  skipped; the other events of that delivery are still stored and the delivery
+  still gets its `200`.
+
+## Connectivity checks
+
+`InboundAdapter#challenge_response(request)` returns nil for a normal event, or
+a status / content-type / body that is returned verbatim, ending the request.
+Challenges are never stored as events (S018).
+
+It is in the base contract from day one because each service differs — Slack's
+`url_verification` echoes a `challenge` value, Bot Framework sends an
+authenticated empty POST, LINE an empty `events` array — so response-body
+generation is adapter-specific knowledge the core must not hold, and a fixed
+200 would make some services refuse the URL registration outright (S018). A
+non-nil return skips event storage for that request entirely (S020).
+
+## Surfacing the URL
+
+`BaseAdapter.inbound?` (default `false`, `true` on `InboundAdapter`) is a
+class-level capability declaration in the style of `supports_history?`; the
+settings view (`_channels_tab.html.erb`) shows a webhook URL only for adapters
+declaring it, built from `Setting.host_name` / `Setting.protocol` via a named
+route helper (S018).
+
+## Related
+
+- [Inbound Event Queue](./inbound-event-queue.md) — the other half: what
+  happens to a stored event.
+- [Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md) — why the
+  endpoint lives in the web process at all.
+- [Developing an Inbound Chat Adapter](./inbound-adapter-development.md) — how
+  to implement the methods this contract calls.
+- [Chat Channel Gateway Architecture](./chat-channel-gateway-architecture.md)
+- [MCP Integration](./mcp-integration.md) — the other anonymous endpoint, whose
+  pattern this one follows.

--- a/wiki/pages/mcp-integration.md
+++ b/wiki/pages/mcp-integration.md
@@ -1,8 +1,8 @@
 ---
 title: MCP Integration
 type: component
-sources: [S002, S006, S007, S016]
-updated: 2026-08-07
+sources: [S002, S006, S007, S016, S018]
+updated: 2026-08-08
 ---
 
 # MCP Integration
@@ -76,6 +76,12 @@ the global `mcp_server_enabled` flag gates the entire endpoint (S002, S006).
   (S006).
 - **No rate limiting** in the initial implementation — deliberately deferred as a
   future extension (S007).
+- **Anonymous-endpoint pattern**: this controller established how the plugin
+  serves anonymous POSTs — `skip_before_action :verify_authenticity_token` plus
+  `skip_before_action :check_if_login_required, raise: false`, the latter being
+  the fix for 403s under `Setting.login_required` (Issue #304). The inbound chat
+  webhook endpoint reuses it verbatim — see
+  [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) (S018).
 
 Internal `RubyLLM::Tool` subclasses are converted into `MCP::Tool` instances by
 `ToolAdapter` (`lib/redmine_ai_helper/mcp/tool_adapter.rb`), with permission

--- a/wiki/pages/public-url-scope.md
+++ b/wiki/pages/public-url-scope.md
@@ -1,0 +1,55 @@
+---
+title: Public URL Scope for Chat Adapters
+type: decision
+sources: [S018, S019]
+updated: 2026-08-08
+---
+
+# Public URL Scope for Chat Adapters
+
+ADR-006 stated "no public URL required" as a premise of the chat channel
+gateway. ADR-017 (Accepted 2026-08-08) amends the **scope** of that guarantee
+rather than editing ADR-006, which is append-only: it is an outbound-adapter
+property, not a whole-plugin invariant (S018, S019).
+
+## What the guarantee now covers
+
+- **Outbound adapters** (Slack Socket Mode, Discord Gateway) open the
+  connection themselves and still need no public URL. ADR-006 decision 1 is
+  neither revisited nor weakened for them, and outbound-only deployments —
+  every deployment before feature 044 — are provably unaffected: the whole
+  pre-existing test suite, `gateway_test.rb` and both adapters' tests included,
+  passes unmodified (S019).
+- **Inbound adapters** do require a public HTTPS URL, because platforms like
+  LINE and Teams deliver events only by POSTing to a URL registered with them.
+  Operators expose `/ai_helper/chat_webhook/:channel_type` behind the reverse
+  proxy already serving Redmine — no new port, no separate TLS setup (S019).
+
+ADR-017 books the extra requirement explicitly as a **negative** consequence:
+unavoidable given how those platforms work, not a choice the feature makes
+(S019).
+
+## Rejected: keep the old framing
+
+Silently reusing ADR-006's "no public URL" wording for every adapter type was
+rejected. It would misdescribe the requirement to operators enabling an inbound
+adapter and risk them leaving the endpoint unreachable — making the amended
+scope explicit is the ADR's whole purpose (S019).
+
+## What does not change
+
+ADR-006 decision 5's permission separation survives intact: the
+internet-reachable web process never runs an LLM request or touches
+`User.current`, and the resident gateway process remains the only one that does
+(S019). Rate limiting on the endpoint is delegated to the reverse-proxy layer,
+matching how the rest of Redmine's public surface is protected, and documented
+in `docs/inbound_chat_adapter_development.md` (S019).
+
+## Related
+
+- [Inbound Chat Webhook Ingest](./inbound-chat-webhook-ingest.md) — the three
+  design decisions this scope change enables.
+- [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — the endpoint the
+  public URL points at.
+- [Chat Channel Gateway Architecture](./chat-channel-gateway-architecture.md) —
+  the outbound operational model the guarantee originally described.

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -22,3 +22,6 @@ Sources are immutable inputs — the wiki never edits them.
 | S015 | docs/adr/009-discord-message-content-intent-required.md | file | 2026-08-01 | 2026-08-01 | discord-message-content-intent.md |
 | S016 | specs/043-issue-create-routing (research.md + plan.md) | feature-artifact | 2026-08-07 | 2026-08-07 | agent-write-capability-routing.md, multi-agent-architecture.md, tool-system.md, mcp-integration.md |
 | S017 | docs/adr/016-issue-agent-read-write-rename.md | file | 2026-08-07 | 2026-08-07 | agent-write-capability-routing.md, issue-ai-features.md, multi-agent-architecture.md |
+| S018 | specs/044-inbound-chat-webhook (research.md + plan.md) | feature-artifact | 2026-08-08 | 2026-08-08 | inbound-chat-webhook-ingest.md, inbound-webhook-endpoint.md, inbound-event-queue.md, chat-channel-gateway-architecture.md, mcp-integration.md |
+| S019 | docs/adr/017-inbound-chat-webhook-gateway.md | file | 2026-08-08 | 2026-08-08 | public-url-scope.md, chat-channel-gateway-architecture.md, inbound-chat-webhook-ingest.md, inbound-webhook-endpoint.md |
+| S020 | docs/inbound_chat_adapter_development.md | file | 2026-08-08 | 2026-08-08 | inbound-adapter-development.md, inbound-webhook-endpoint.md, inbound-event-queue.md |


### PR DESCRIPTION
## Changes

- Add a public webhook endpoint (`AiHelperChatWebhookController`) that verifies inbound requests, answers service verification challenges, and stores normalized events without requiring authentication
- Add the `AiHelperInboundEvent` model and migration for the persistent inbound queue, with deduplication by event key and freshness-based discarding
- Add `ChatChannel::InboundAdapter` and `InboundEventMessage` so inbound-style services (LINE, Teams, etc.) can plug into the existing chat channel gateway flow
- Extend `ChatChannel::BaseAdapter` and the settings UI to expose the per-adapter webhook URL on the Chat integrations tab
- Add ADR 017, inbound adapter development guide, and wiki pages covering the endpoint, event queue, and public URL scope
- Add unit and functional tests for the controller, model, adapter, settings helper, and settings controller

Concrete service adapters (LINE / Microsoft Teams) are out of scope for this change; only the receiving foundation is included.