### PR TITLE
Enforce JSDoc on classes/methods via eslint-plugin-jsdoc

### DIFF
--- a/assets/javascripts/AGENTS.md
+++ b/assets/javascripts/AGENTS.md
@@ -30,6 +30,11 @@ else (Ruby, agents, tools, git workflow).
   same "document the why, not the what" standard as code comments applies
   to the description line; `@param`/`@returns` should still state the type
   and meaning of each value.
+- Enforced by `eslint-plugin-jsdoc` (`jsdoc/*` rules in `eslint.config.js`,
+  all "error"): classes, ES6 class methods, and the `foo = function () {}`
+  class-field method style all require a JSDoc block; every `@param` and
+  `@returns` needs a description, not just a type. See
+  [ADR-028](../../docs/adr/028-eslint-plugin-jsdoc-enforcement.md).
 
 ## Testing
 
@@ -82,6 +87,7 @@ passes locally.
 - [docs/javascript_quality_tooling.md](../../docs/javascript_quality_tooling.md)
 - [ADR-022](../../docs/adr/022-javascript-test-tooling-for-classic-scripts.md) — dynamic-import test strategy
 - [ADR-023](../../docs/adr/023-javascript-coverage-ratchet-policy.md) — coverage ratchet policy
+- [ADR-028](../../docs/adr/028-eslint-plugin-jsdoc-enforcement.md) — eslint-plugin-jsdoc enforcement
 - Wiki: `wiki/pages/js-quality-tooling.md`,
   `wiki/pages/classic-script-testing-strategy.md`,
   `wiki/pages/js-coverage-ratchet-policy.md`,

--- a/assets/javascripts/autocompletion/ai_helper_assignment_suggestion.js
+++ b/assets/javascripts/autocompletion/ai_helper_assignment_suggestion.js
@@ -5,9 +5,9 @@
  */
 class AiHelperAssignmentSuggestion {
   /**
-   * @param {Object} options
+   * @param {object} options - Configuration for the suggestion feature.
    * @param {string} options.endpoint - API endpoint URL
-   * @param {Object} options.labels - I18n labels
+   * @param {object} options.labels - I18n labels
    * @param {string} options.robotIconHtml - HTML for the robot icon SVG
    */
   constructor(options) {
@@ -230,8 +230,8 @@ class AiHelperAssignmentSuggestion {
   /**
    * Escape HTML special characters to prevent XSS.
    * Only used for client-side labels in loading/error states.
-   * @param {string} text
-   * @returns {string}
+   * @param {string} text - The raw text to escape.
+   * @returns {string} The HTML-escaped text.
    */
   escapeHtml(text) {
     const div = document.createElement('div');

--- a/assets/javascripts/autocompletion/ai_helper_auto_completion.js
+++ b/assets/javascripts/autocompletion/ai_helper_auto_completion.js
@@ -1,7 +1,16 @@
 // AI Helper Auto Completion for Redmine Textarea Fields
 // Provides GitHub Copilot-style inline completion for issue descriptions
 
+/**
+ * GitHub Copilot-style inline AI completion for a Redmine textarea (issue
+ * description/notes, wiki body). Debounces input, requests a suggestion from
+ * the server, and renders it as ghost text via an overlay element.
+ */
 class AiHelperAutoCompletion {
+  /**
+   * @param {HTMLTextAreaElement} textareaElement - The textarea to attach completion to.
+   * @param {object} [options] - Configuration; merged over the built-in defaults.
+   */
   constructor(textareaElement, options = {}) {
     this.textarea = textareaElement;
     this.overlay = null;
@@ -34,6 +43,9 @@ class AiHelperAutoCompletion {
     };
   }
 
+  /**
+   * Wire up the checkbox, overlay, event listeners, and saved on/off state.
+   */
   init() {
     this.createCheckbox();
     this.createOverlay();
@@ -41,6 +53,10 @@ class AiHelperAutoCompletion {
     this.loadSettings();
   }
 
+  /**
+   * Locate the ERB-rendered on/off checkbox and container for this field's
+   * context type, and save settings whenever it changes.
+   */
   createCheckbox() {
     // This method now expects the checkbox to be already created in ERB
     // Just find and reference the existing checkbox
@@ -65,6 +81,10 @@ class AiHelperAutoCompletion {
     }
   }
 
+  /**
+   * Create the ghost-text overlay, styled and positioned to sit exactly over
+   * the textarea, and keep it synced to the textarea's size/position.
+   */
   createOverlay() {
     // Create overlay element with same position and size as textarea
     this.overlay = document.createElement('div');
@@ -133,6 +153,9 @@ class AiHelperAutoCompletion {
     this.textarea.style.backgroundColor = 'transparent';
   }
 
+  /**
+   * Bind the textarea's input/keyboard/focus listeners that drive completion.
+   */
   attachEventListeners() {
     // Kept on the instance so destroy() can pass the identical references to
     // removeEventListener: a fresh wrapper would silently remove nothing.
@@ -161,6 +184,9 @@ class AiHelperAutoCompletion {
     this.textarea.addEventListener('keydown', this.boundOnManualTrigger);
   }
 
+  /**
+   * Restore the on/off checkbox state saved in local storage (defaults to off).
+   */
   loadSettings() {
     const saved = localStorage.getItem(this.storageKey);
     const enabled = saved ? JSON.parse(saved).enabled : false; // Default OFF
@@ -170,6 +196,9 @@ class AiHelperAutoCompletion {
     this.isEnabled = enabled;
   }
 
+  /**
+   * Persist the checkbox's current on/off state to local storage.
+   */
   saveSettings() {
     if (this.checkbox) {
       const settings = { enabled: this.checkbox.checked };
@@ -178,6 +207,10 @@ class AiHelperAutoCompletion {
     }
   }
 
+  /**
+   * Handle textarea input/keyup/click: clear the stale suggestion and
+   * (re)schedule a completion request for the new text/cursor state.
+   */
   onTextChange() {
     // keyup and click fire for things that change nothing — a modifier key
     // released, a click landing on the caret. The displayed suggestion still
@@ -196,6 +229,11 @@ class AiHelperAutoCompletion {
     this.scheduleCompletion();
   }
 
+  /**
+   * Accept the current suggestion on Tab, or dismiss it on Escape.
+   * @param {KeyboardEvent} e - The keydown event.
+   * @returns {boolean|undefined} `false` when Tab/Escape was handled, to suppress the default action.
+   */
   onKeyDown(e) {
     if (this.currentSuggestion) {
       if (e.key === 'Tab') {
@@ -210,6 +248,9 @@ class AiHelperAutoCompletion {
     }
   }
 
+  /**
+   * Reveal the overlay when the textarea gains focus.
+   */
   onFocus() {
     // Show overlay when focused
     if (this.overlay) {
@@ -217,6 +258,10 @@ class AiHelperAutoCompletion {
     }
   }
 
+  /**
+   * Hide the overlay and clear any suggestion shortly after the textarea
+   * loses focus (delayed so a click on the suggestion itself isn't missed).
+   */
   onBlur() {
     // Hide overlay when focus is lost (with small delay)
     setTimeout(() => {
@@ -227,6 +272,10 @@ class AiHelperAutoCompletion {
     }, 100);
   }
 
+  /**
+   * Debounce a completion request: cancel any pending one, then (if enabled
+   * and the text meets the minimum length) schedule a new one.
+   */
   scheduleCompletion() {
     // Drop any completion scheduled earlier: either it is superseded by this
     // call, or the conditions below no longer allow it to run
@@ -249,6 +298,10 @@ class AiHelperAutoCompletion {
     }, this.options.debounceDelay);
   }
 
+  /**
+   * Request a completion for the textarea's current text/cursor position,
+   * unless that exact state already has an answer in hand.
+   */
   requestSuggestion() {
     const text = this.textarea.value;
     const cursorPosition = this.textarea.selectionStart;
@@ -272,15 +325,23 @@ class AiHelperAutoCompletion {
     this.callCompletionAPI(text, cursorPosition, requestId);
   }
 
-  // Try to get project_identifier from the URL for new-issue forms
+  /**
+   * Try to get project_identifier from the URL for new-issue forms.
+   * @returns {string|null} The project identifier segment of the URL, or null if absent.
+   */
   getProjectIdentifierFromUrl() {
     const urlMatch = window.location.pathname.match(/\/projects\/([^/]+)/);
     return urlMatch ? urlMatch[1] : null;
   }
 
-  // Build the default completion request body, including project_id/
-  // project_identifier for new-issue forms. Split out of callCompletionAPI
-  // to keep it under ESLint's max-depth limit.
+  /**
+   * Build the default completion request body, including project_id/
+   * project_identifier for new-issue forms. Split out of callCompletionAPI
+   * to keep it under ESLint's max-depth limit.
+   * @param {string} text - The full textarea text.
+   * @param {number} cursorPosition - The cursor offset within `text`.
+   * @returns {object} The JSON-serializable request body.
+   */
   buildDefaultRequestBody(text, cursorPosition) {
     const requestBody = {
       text: text,
@@ -304,6 +365,13 @@ class AiHelperAutoCompletion {
     return requestBody;
   }
 
+  /**
+   * POST the completion request to the endpoint and, if the response still
+   * matches the current text/cursor state, display the suggestion.
+   * @param {string} text - The full textarea text at request time.
+   * @param {number} cursorPosition - The cursor offset within `text` at request time.
+   * @param {number} requestId - This request's sequence number, for staleness checks.
+   */
   callCompletionAPI(text, cursorPosition, requestId) {
     // Get CSRF token
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
@@ -388,17 +456,24 @@ class AiHelperAutoCompletion {
     });
   }
 
-  // Forget the given controller when it is still the current one, so that
-  // a non-null abortController always means a request is in flight
+  /**
+   * Forget the given controller when it is still the current one, so that
+   * a non-null abortController always means a request is in flight.
+   * @param {AbortController} controller - The controller from the settled request.
+   */
   releaseAbortController(controller) {
     if (this.abortController === controller) {
       this.abortController = null;
     }
   }
 
-  // Drop the recorded snapshot when it still describes the given request, so a
-  // newer request that has already overwritten it is left alone. null is used
-  // rather than '' / 0 so the snapshot can never match a real textarea state.
+  /**
+   * Drop the recorded snapshot when it still describes the given request, so a
+   * newer request that has already overwritten it is left alone. null is used
+   * rather than '' / 0 so the snapshot can never match a real textarea state.
+   * @param {string} text - The text of the request whose answer is settled.
+   * @param {number} cursorPosition - The cursor offset of that request.
+   */
   forgetRequestSnapshot(text, cursorPosition) {
     if (this.lastTextSnapshot === text && this.lastCursorPosition === cursorPosition) {
       this.lastTextSnapshot = null;
@@ -406,6 +481,17 @@ class AiHelperAutoCompletion {
     }
   }
 
+  /**
+   * Pure comparison behind the instance-level `isRequestStale`: true if a
+   * newer request has since started, or the text/cursor has since changed.
+   * @param {number} requestId - The sequence number of the request being checked.
+   * @param {number} currentRequestId - The instance's latest request sequence number.
+   * @param {string} originalText - The textarea text when the request was sent.
+   * @param {string} currentText - The textarea's text now.
+   * @param {number} originalCursor - The cursor offset when the request was sent.
+   * @param {number} currentCursor - The cursor offset now.
+   * @returns {boolean} True if the response should be discarded.
+   */
   static isRequestStale(requestId, currentRequestId, originalText, currentText, originalCursor, currentCursor) {
     if (requestId !== currentRequestId) {
       return true;
@@ -413,6 +499,14 @@ class AiHelperAutoCompletion {
     return (originalText !== currentText || originalCursor !== currentCursor);
   }
 
+  /**
+   * Check whether a completion response for `requestId` is still relevant to
+   * the textarea's current state.
+   * @param {number} requestId - The sequence number of the request being checked.
+   * @param {string} originalText - The textarea text when the request was sent.
+   * @param {number} originalCursor - The cursor offset when the request was sent.
+   * @returns {boolean} True if the response should be discarded.
+   */
   isRequestStale(requestId, originalText, originalCursor) {
     return AiHelperAutoCompletion.isRequestStale(
       requestId, this.currentRequestId, originalText,
@@ -420,6 +514,9 @@ class AiHelperAutoCompletion {
     );
   }
 
+  /**
+   * Cancel any scheduled or in-flight completion request without replacing it.
+   */
   cancelPendingRequest() {
     // Drop the completion that is merely scheduled. Nothing reschedules it on
     // the disable, blur and destroy paths, so without this a request still
@@ -444,6 +541,10 @@ class AiHelperAutoCompletion {
   // ai_helper_auto_completion_overlay.js alongside the overlay-rendering
   // concern they share.
 
+  /**
+   * Insert the current suggestion into the textarea at its target cursor
+   * position, then move the cursor to the end of the inserted text.
+   */
   acceptSuggestion() {
     if (!this.currentSuggestion) {
       return;
@@ -473,7 +574,10 @@ class AiHelperAutoCompletion {
     this.textarea.focus();
   }
 
-  // Cleanup method
+  /**
+   * Tear down this instance: remove listeners, cancel pending requests, and
+   * remove the overlay/checkbox DOM elements and textarea style overrides.
+   */
   destroy() {
     // Remove event listeners, using the same references attachEventListeners
     // registered — removeEventListener silently ignores anything else

--- a/assets/javascripts/autocompletion/ai_helper_issue_autocompletion.js
+++ b/assets/javascripts/autocompletion/ai_helper_issue_autocompletion.js
@@ -5,8 +5,8 @@
 
 /**
  * Move `container` to immediately follow `textarea` in the DOM and reveal it.
- * @param {HTMLElement} textarea
- * @param {HTMLElement} container
+ * @param {HTMLElement} textarea - The textarea to position after.
+ * @param {HTMLElement} container - The element to move.
  */
 function moveContainerAfterTextarea(textarea, container) {
   const parent = textarea.parentNode;
@@ -22,7 +22,7 @@ function moveContainerAfterTextarea(textarea, container) {
 /**
  * Initialize description-field auto-completion and move its checkbox
  * into place below the textarea.
- * @param {HTMLElement} descriptionTextarea
+ * @param {HTMLElement} descriptionTextarea - The issue description textarea.
  * @param {object} config Parsed overlay config (`dataset.config`).
  */
 function initializeDescriptionAutoCompletion(descriptionTextarea, config) {
@@ -64,7 +64,7 @@ function initializeDescriptionAutoCompletion(descriptionTextarea, config) {
  * Run the duplicate-check request for the current subject/description and
  * render the results (or an error) into the results container.
  * @param {object} config Parsed overlay config (`dataset.config`).
- * @param {HTMLElement} descriptionTextarea
+ * @param {HTMLElement} descriptionTextarea - The issue description textarea.
  */
 async function runDuplicateCheck(config, descriptionTextarea) {
   const subjectInput = document.getElementById('issue_subject');
@@ -121,8 +121,8 @@ async function runDuplicateCheck(config, descriptionTextarea) {
 /**
  * Place the duplicate-check container below the description checkbox and
  * wire up its trigger button.
- * @param {HTMLElement} duplicateCheckContainer
- * @param {HTMLElement} descriptionTextarea
+ * @param {HTMLElement} duplicateCheckContainer - The duplicate-check results/trigger container.
+ * @param {HTMLElement} descriptionTextarea - The issue description textarea.
  * @param {object} config Parsed overlay config (`dataset.config`).
  */
 function initializeDuplicateCheck(duplicateCheckContainer, descriptionTextarea, config) {
@@ -144,7 +144,7 @@ function initializeDuplicateCheck(duplicateCheckContainer, descriptionTextarea, 
 /**
  * Initialize notes-field auto-completion and move its checkbox into place
  * below the textarea. Only used for existing (persisted) issues.
- * @param {HTMLElement} notesTextarea
+ * @param {HTMLElement} notesTextarea - The issue notes textarea.
  * @param {object} config Parsed overlay config (`dataset.config`).
  */
 function initializeNotesAutoCompletion(notesTextarea, config) {

--- a/assets/javascripts/chat/ai_helper.js
+++ b/assets/javascripts/chat/ai_helper.js
@@ -1,3 +1,7 @@
+/**
+ * Chat sidebar controller: form submission, streaming responses, chat
+ * fold/history state, and the inline sub-issue subject/description editors.
+ */
 class AiHelper {
   ai_helper_urls = {};
   page_info = {
@@ -7,12 +11,19 @@ class AiHelper {
   chat_fold_storage_key = 'aihelper-fold-flag_anonymous';
   interactiveOptionsHandlersInitialized = false;
 
-  // Method to update user ID without recreating the instance
+  /**
+   * Update the user ID without recreating the instance.
+   * @param {string} userId - The current Redmine user's ID.
+   */
   setUserId(userId) {
     this.userId = userId;
     this.chat_fold_storage_key = `aihelper-fold-flag_${userId}`;
   }
 
+  /**
+   * Wire up the chat form's submit button and Enter-to-submit textarea
+   * behavior.
+   */
   set_form_handlers = function () {
     // Prevent the default submit behavior of the form
     const form = document.getElementById("ai_helper_chat_form");
@@ -37,7 +48,9 @@ class AiHelper {
       return false;
     });
 
-    // submitAction
+    /**
+     * Submit the chat form's message via XHR and reset the input.
+     */
     function submitAction() {
       document.getElementById("ai_helper_controller_name").value = ai_helper.page_info["controller_name"];
       document.getElementById("ai_helper_action_name").value = ai_helper.page_info["action_name"];
@@ -121,7 +134,11 @@ class AiHelper {
   // SSE parsing/streaming (static parseSSELines, handleSSEStream) live in
   // ai_helper_streaming.js — see the comment there for why.
 
-  // Attach delegated click/keydown handlers to the container once
+  /**
+   * Attach delegated click/keydown handlers to the interactive-options
+   * container once.
+   * @param {HTMLElement} container - The interactive options container.
+   */
   initializeInteractiveOptionsHandlers = function(container) {
     if (this.interactiveOptionsHandlersInitialized) {return;}
 
@@ -160,7 +177,10 @@ class AiHelper {
     this.interactiveOptionsHandlersInitialized = true;
   };
 
-  // Render interactive option buttons for the given choices array
+  /**
+   * Render interactive option buttons for the given choices array.
+   * @param {Array<{label: string, value: string}>} choices - Options offered by the assistant's reply.
+   */
   renderInteractiveOptions = function(choices) {
     const container = document.getElementById('aihelper-interactive-options');
     if (!container) {return;}
@@ -193,7 +213,9 @@ class AiHelper {
     }
   };
 
-  // Hide the interactive options container (on reload/clear)
+  /**
+   * Hide the interactive options container (on reload/clear).
+   */
   hideInteractiveOptions = function() {
     const container = document.getElementById('aihelper-interactive-options');
     if (container) {
@@ -201,6 +223,10 @@ class AiHelper {
     }
   };
 
+  /**
+   * Send the current page context to the LLM endpoint and stream the
+   * response into the chat conversation.
+   */
   call_llm = function () {
     const url = ai_helper_urls.call_llm;
     const data = JSON.stringify(this.page_info);
@@ -273,6 +299,10 @@ class AiHelper {
     xhr.send(data);
   };
 
+  /**
+   * Show or hide the chat's "clear history" button.
+   * @param {boolean} flag - Whether the button should be visible.
+   */
   setClearButtonVisible(flag) {
     const clearButton = document.getElementById("aihelper-chat-clear");
     if (clearButton) {
@@ -289,6 +319,12 @@ class AiHelper {
   // ai_helper_history.js alongside the chat-history/dropdown-menu concern
   // they share.
 
+  /**
+   * Fold or unfold the chat area, animating the transition unless disabled,
+   * and persist the fold state to local storage.
+   * @param {boolean} flag - True to fold (collapse) the chat, false to unfold it.
+   * @param {boolean} [disableAnimation] - Skip the slide animation (used on initial page load).
+   */
   fold_chat = function (flag, disableAnimation = false) {
     const chatArea = document.getElementById("aihelper-foldable-area");
     const arrowDown = document.getElementById("aihelper-arrow-down");
@@ -343,6 +379,9 @@ class AiHelper {
     localStorage.setItem(this.chat_fold_storage_key, flag);
   };
 
+  /**
+   * Apply the chat's fold state saved in local storage on page load.
+   */
   init_fold_flag = function () {
     const flag = localStorage.getItem(this.chat_fold_storage_key);
     if (flag === "true") {
@@ -352,6 +391,12 @@ class AiHelper {
     }
   };
 
+  /**
+   * Set an element's HTML and execute any `<script>` tags it contains.
+   * Plain `element.innerHTML = html` does not execute embedded scripts.
+   * @param {HTMLElement} element - The element to fill.
+   * @param {string} html - HTML string, server-rendered from ERB templates.
+   */
   innerHTMLwithScripts = function (element, html) {
     element.innerHTML = html;
 
@@ -365,6 +410,9 @@ class AiHelper {
 
   }
 
+  /**
+   * Copy the AI-generated reply text into the issue's notes field.
+   */
   apply_generated_issue_reply = function () {
     const replyEl = document.getElementById("ai-helper-generated-reply-content");
     if (!replyEl) {return;}
@@ -375,6 +423,10 @@ class AiHelper {
     replyInputArea.value = replyContent;
   }
 
+  /**
+   * Switch a suggested sub-issue's subject row into edit mode.
+   * @param {number} i - Index of the sub-issue in the suggestion list.
+   */
   edit_sub_issue_subject = function(i) {
     const subjectSpan = document.getElementById(`ai_helper_sub_issue_subject_${i}`);
     const subjectEditSpan = document.getElementById(`ai_helper_sub_issue_subject_edit_${i}`);
@@ -383,6 +435,10 @@ class AiHelper {
     subjectEditSpan.style.display = 'inline';
   }
 
+  /**
+   * Save the edited subject back onto a suggested sub-issue and exit edit mode.
+   * @param {number} i - Index of the sub-issue in the suggestion list.
+   */
   apply_sub_issue_subject = function(i) {
     const subjectSpan = document.getElementById(`ai_helper_sub_issue_subject_${i}`);
     const subjectEditSpan = document.getElementById(`ai_helper_sub_issue_subject_edit_${i}`);
@@ -401,6 +457,10 @@ class AiHelper {
     subjectEditSpan.style.display = 'none';
   }
 
+  /**
+   * Discard the subject edit and exit edit mode, restoring the original text.
+   * @param {number} i - Index of the sub-issue in the suggestion list.
+   */
   cancel_sub_issue_subject = function(i) {
     const subjectSpan = document.getElementById(`ai_helper_sub_issue_subject_${i}`);
     const subjectEditSpan = document.getElementById(`ai_helper_sub_issue_subject_edit_${i}`);
@@ -412,6 +472,10 @@ class AiHelper {
     subjectEditSpan.style.display = 'none';
   }
 
+  /**
+   * Switch a suggested sub-issue's description row into edit mode.
+   * @param {number} i - Index of the sub-issue in the suggestion list.
+   */
   edit_sub_issue_description = function(i) {
     const descriptionSpan = document.getElementById(`ai_helper_sub_issue_description_${i}`);
     const descriptionEditSpan = document.getElementById(`ai_helper_sub_issue_description_edit_${i}`);
@@ -420,6 +484,10 @@ class AiHelper {
     descriptionEditSpan.style.display = 'inline';
   }
 
+  /**
+   * Save the edited description back onto a suggested sub-issue and exit edit mode.
+   * @param {number} i - Index of the sub-issue in the suggestion list.
+   */
   apply_sub_issue_description = function(i) {
     const descriptionSpan = document.getElementById(`ai_helper_sub_issue_description_${i}`);
     const descriptionEditSpan = document.getElementById(`ai_helper_sub_issue_description_edit_${i}`);
@@ -436,6 +504,10 @@ class AiHelper {
     descriptionEditSpan.style.display = 'none';
   }
 
+  /**
+   * Discard the description edit and exit edit mode, restoring the original text.
+   * @param {number} i - Index of the sub-issue in the suggestion list.
+   */
   cancel_sub_issue_description = function(i) {
     const descriptionSpan = document.getElementById(`ai_helper_sub_issue_description_${i}`);
     const descriptionEditSpan = document.getElementById(`ai_helper_sub_issue_description_edit_${i}`);

--- a/assets/javascripts/chat/ai_helper_chat.js
+++ b/assets/javascripts/chat/ai_helper_chat.js
@@ -69,6 +69,7 @@ const AiHelperChat = (() => {
 
   /**
    * Merge the sidebar's data-additional-info JSON into ai_helper.page_info.
+   * @param {HTMLElement} sidebarElement - The `#aihelper-sidebar` element.
    */
   function applyAdditionalInfo(sidebarElement) {
     try {

--- a/assets/javascripts/chat/ai_helper_command_completion.js
+++ b/assets/javascripts/chat/ai_helper_command_completion.js
@@ -2,8 +2,16 @@
 (function() {
   const COMMAND_PREFIX = '/';
 
-  // Make CommandCompletion class available globally for dynamic initialization
+  /**
+   * Slash-command autocompletion for the chat input: shows matching command
+   * suggestions as the user types and lets them accept one via click or
+   * keyboard.
+   */
   class CommandCompletion {
+    /**
+     * @param {HTMLElement} inputElement - The chat message input.
+     * @param {string|null} [commandsUrl] - Endpoint returning commands matching a prefix.
+     */
     constructor(inputElement, commandsUrl = null) {
       this.input = inputElement;
       this.commandsUrl = commandsUrl;
@@ -17,11 +25,17 @@
       this.init();
     }
 
+    /**
+     * Build the suggestion box and wire up event listeners.
+     */
     init() {
       this.createSuggestionBox();
       this.attachEventListeners();
     }
 
+    /**
+     * Create and insert the (initially hidden) suggestion box element.
+     */
     createSuggestionBox() {
       this.suggestionBox = document.createElement('div');
       this.suggestionBox.className = 'ai-helper-command-suggestions';
@@ -29,12 +43,20 @@
       this.input.parentElement.appendChild(this.suggestionBox);
     }
 
+    /**
+     * Bind input/keydown handlers on the chat input and an outside-click
+     * handler on the document to dismiss suggestions.
+     */
     attachEventListeners() {
       this.input.addEventListener('input', this.handleInput.bind(this));
       this.input.addEventListener('keydown', this.handleKeyDown.bind(this));
       document.addEventListener('click', this.handleDocumentClick.bind(this));
     }
 
+    /**
+     * React to input changes: fetch and show command suggestions when the
+     * input starts with `/`, otherwise hide them.
+     */
     handleInput() {
       const value = this.input.value;
 
@@ -47,6 +69,10 @@
       this.fetchCommands(commandPart);
     }
 
+    /**
+     * Fetch commands matching a prefix from `commandsUrl` and show them.
+     * @param {string} prefix - The text typed after `/`, up to the first whitespace.
+     */
     async fetchCommands(prefix) {
       if (!this.commandsUrl) {
         return;
@@ -67,6 +93,9 @@
       }
     }
 
+    /**
+     * Render the fetched commands into the suggestion box and reveal it.
+     */
     showSuggestions() {
       if (this.commands.length === 0) {
         this.hideSuggestions();
@@ -99,6 +128,9 @@
       this.suggestionBox.style.display = 'block';
     }
 
+    /**
+     * Hide the suggestion box and clear the selected index.
+     */
     hideSuggestions() {
       this.suggestionBox.style.display = 'none';
       this.selectedIndex = -1;
@@ -106,7 +138,7 @@
 
     /**
      * Returns whether the suggestion list is currently visible
-     * @returns {boolean}
+     * @returns {boolean} True if the suggestion box is shown and non-empty.
      */
     isSuggestionsVisible() {
       return this.suggestionBox.style.display !== 'none' && this.commands.length > 0;
@@ -128,6 +160,11 @@
       return true;
     }
 
+    /**
+     * Handle arrow-key navigation, Enter-to-accept, and Escape-to-dismiss
+     * while suggestions are visible.
+     * @param {KeyboardEvent} event - The keydown event.
+     */
     handleKeyDown(event) {
       if (this.suggestionBox.style.display === 'none') {
         return;
@@ -154,6 +191,10 @@
       }
     }
 
+    /**
+     * Move the highlighted suggestion by `direction`, clamped to the list bounds.
+     * @param {number} direction - `1` to move down, `-1` to move up.
+     */
     moveSelection(direction) {
       const items = this.suggestionBox.querySelectorAll('.suggestion-item');
 
@@ -166,6 +207,11 @@
       items[this.selectedIndex].scrollIntoView({ block: 'nearest' });
     }
 
+    /**
+     * Replace the `/command` token in the input with the selected command,
+     * preserving any text typed after it.
+     * @param {number} index - Index of the command in `this.commands`.
+     */
     selectCommand(index) {
       const command = this.commands[index];
       const currentValue = this.input.value;
@@ -176,6 +222,10 @@
       this.input.focus();
     }
 
+    /**
+     * Dismiss the suggestion box when a click lands outside it and the input.
+     * @param {MouseEvent} event - The document click event.
+     */
     handleDocumentClick(event) {
       if (!this.suggestionBox.contains(event.target) && event.target !== this.input) {
         this.hideSuggestions();

--- a/assets/javascripts/project_health/ai_helper_comparison.js
+++ b/assets/javascripts/project_health/ai_helper_comparison.js
@@ -2,7 +2,12 @@
 if (!window.aiHelperComparisonInitialized) {
   window.aiHelperComparisonInitialized = true;
 
-  // Append a hidden input with the given name/value to a form.
+  /**
+   * Append a hidden input with the given name/value to a form.
+   * @param {HTMLFormElement} form - The form to append the input to.
+   * @param {string} name - The input's `name` attribute.
+   * @param {string} value - The input's `value` attribute.
+   */
   function appendHiddenInput(form, name, value) {
     const field = document.createElement('input');
     field.type = 'hidden';
@@ -11,7 +16,10 @@ if (!window.aiHelperComparisonInitialized) {
     form.appendChild(field);
   }
 
-  // Submit the comparison content (PDF or Markdown export) via a generated form.
+  /**
+   * Submit the comparison content (PDF or Markdown export) via a generated form.
+   * @param {MouseEvent} event - The export link's click event.
+   */
   function handleComparisonExport(event) {
     event.preventDefault();
     const hiddenField = document.getElementById('ai-helper-comparison-content');
@@ -56,6 +64,10 @@ if (!window.aiHelperComparisonInitialized) {
 
     let currentEventSource = null;
 
+    /**
+     * Open an SSE connection to the analysis endpoint and stream the
+     * rendered comparison into the result panel, closing any prior stream.
+     */
     function startAnalysis() {
       if (currentEventSource) {
         currentEventSource.close();
@@ -138,7 +150,11 @@ if (!window.aiHelperComparisonInitialized) {
       };
     }
 
-    // Function to update hidden field with comparison content
+    /**
+     * Store the finished comparison content in the hidden field the export
+     * links read from.
+     * @param {string} content - The finished, un-rendered comparison markdown.
+     */
     function updateComparisonContent(content) {
       const hiddenField = document.getElementById('ai-helper-comparison-content');
       if (hiddenField) {

--- a/assets/javascripts/project_health/ai_helper_master_detail.js
+++ b/assets/javascripts/project_health/ai_helper_master_detail.js
@@ -4,7 +4,14 @@
 // Guard against multiple script loading
 if (typeof window.AiHelperMasterDetail === 'undefined') {
 
+/**
+ * Master-detail layout controller for the project health report history:
+ * report selection, AJAX detail loading/deletion, and export handlers.
+ */
 class AiHelperMasterDetail {
+  /**
+   * Initialize state and set up the layout if present on the page.
+   */
   constructor() {
     this.selectedReportId = null;
     this.masterPane = null;
@@ -13,6 +20,10 @@ class AiHelperMasterDetail {
     this.init();
   }
 
+  /**
+   * Locate the layout's panes and wire up event listeners, if the layout is
+   * present on this page.
+   */
   init() {
     if (!this.checkElements()) {
       return;
@@ -26,11 +37,18 @@ class AiHelperMasterDetail {
     this.initializeSelection();
   }
 
+  /**
+   * Check whether the master-detail layout is present on the current page.
+   * @returns {boolean} True if the layout element exists.
+   */
   checkElements() {
     const layout = document.querySelector('.ai-helper-master-detail-layout');
     return layout !== null;
   }
 
+  /**
+   * Bind click handlers for selecting a report row and deleting a report.
+   */
   attachEventListeners() {
     // Clickable cell events (ID and created_on columns)
     const clickableCells = document.querySelectorAll('.ai-helper-clickable-cell');
@@ -53,6 +71,10 @@ class AiHelperMasterDetail {
     });
   }
 
+  /**
+   * Restore `selectedReportId` from whichever row is already marked
+   * selected (server-rendered on page load).
+   */
   initializeSelection() {
     // Initialize with already selected report if any
     const selectedRow = document.querySelector('.ai-helper-report-row.selected');
@@ -61,6 +83,11 @@ class AiHelperMasterDetail {
     }
   }
 
+  /**
+   * Select a report row and render its detail from the row's own data
+   * attributes (no AJAX round-trip needed).
+   * @param {HTMLElement} row - The `.ai-helper-report-row` element clicked.
+   */
   selectReport(row) {
     const reportId = row.dataset.reportId;
     const reportContent = row.dataset.reportContent;
@@ -87,6 +114,11 @@ class AiHelperMasterDetail {
     this.renderReportDetail(data);
   }
 
+  /**
+   * Mark `row` as the selected report row and clear selection from the rest.
+   * @param {HTMLElement} row - The row to select.
+   * @param {string} reportId - The report's id, stored as the current selection.
+   */
   updateSelection(row, reportId) {
     // Remove selection from all rows
     document.querySelectorAll('.ai-helper-report-row').forEach(r => {
@@ -98,6 +130,10 @@ class AiHelperMasterDetail {
     this.selectedReportId = reportId;
   }
 
+  /**
+   * Fetch a report's detail JSON via AJAX and render it.
+   * @param {string} url - The report detail endpoint.
+   */
   loadReportDetail(url) {
     // Show loading state
     this.showLoading();
@@ -128,6 +164,11 @@ class AiHelperMasterDetail {
     xhr.send();
   }
 
+  /**
+   * Render a report's detail into the detail pane, fading out/in around the
+   * content swap.
+   * @param {object} data - Report fields: `id`, `health_report`, `created_at`, `user.name`, and optionally `formatted_html`.
+   */
   renderReportDetail(data) {
     // Fade out
     this.detailContainer.style.opacity = '0';
@@ -154,6 +195,12 @@ class AiHelperMasterDetail {
     }, 300);
   }
 
+  /**
+   * Build the detail pane's HTML for a report.
+   * @param {object} data - Report fields (see `renderReportDetail`).
+   * @param {string} formattedContent - The report body, already rendered from markdown to HTML.
+   * @returns {string} HTML for the detail pane.
+   */
   buildDetailHTML(data, formattedContent) {
     const createdAt = this.formatDateTime(data.created_at);
     const userName = this.escapeHtml(data.user.name);
@@ -193,10 +240,17 @@ class AiHelperMasterDetail {
     `;
   }
 
+  /**
+   * Show a loading spinner in the detail pane.
+   */
   showLoading() {
     this.detailContainer.innerHTML = '<div class="ai-helper-loader"></div>';
   }
 
+  /**
+   * Show an error message in the detail pane.
+   * @param {string} message - The error text to display.
+   */
   showError(message) {
     this.detailContainer.innerHTML = `
       <div class="ai-helper-error">
@@ -205,6 +259,11 @@ class AiHelperMasterDetail {
     `;
   }
 
+  /**
+   * Confirm and delete a report via AJAX, removing its row and selecting
+   * the next report if the deleted one was selected.
+   * @param {HTMLElement} link - The clicked delete (`.icon-del`) link.
+   */
   handleDelete(link) {
     const confirmMessage = link.dataset.confirm || this.getI18nText('text_are_you_sure', 'Are you sure?');
     if (!confirm(confirmMessage)) {
@@ -246,6 +305,9 @@ class AiHelperMasterDetail {
     xhr.send();
   }
 
+  /**
+   * Select the first remaining report row, or show the placeholder if none remain.
+   */
   selectNextReport() {
     const rows = document.querySelectorAll('.ai-helper-report-row');
     if (rows.length > 0) {
@@ -257,6 +319,9 @@ class AiHelperMasterDetail {
     }
   }
 
+  /**
+   * Show the "select a report" placeholder and clear the current selection.
+   */
   showPlaceholder() {
     const placeholderText = this.getI18nText('label_ai_helper_select_report_to_view',
                                              'Generate a report or select one from the history on the left');
@@ -268,6 +333,11 @@ class AiHelperMasterDetail {
     this.selectedReportId = null;
   }
 
+  /**
+   * Bind the detail pane's markdown export link (PDF export needs no
+   * handler; its href is already correct).
+   * @param {object} data - Report fields (see `renderReportDetail`).
+   */
   attachExportEvents(data) {
     const markdownExportLink = document.getElementById('ai-helper-markdown-export-detail');
 
@@ -281,6 +351,11 @@ class AiHelperMasterDetail {
     // PDF export link already has correct href, no additional handler needed
   }
 
+  /**
+   * Submit the report content to the markdown export endpoint via a
+   * dynamically-built form POST (triggers a file download).
+   * @param {string} content - The report's raw markdown content.
+   */
   exportMarkdown(content) {
     // Create form to submit markdown export
     const form = document.createElement('form');
@@ -305,28 +380,52 @@ class AiHelperMasterDetail {
   }
 
   // Utility methods
+  /**
+   * Format an ISO date string using the browser's locale.
+   * @param {string} dateString - An ISO 8601 date/time string.
+   * @returns {string} The locale-formatted date/time.
+   */
   formatDateTime(dateString) {
     const date = new Date(dateString);
     return date.toLocaleString();
   }
 
+  /**
+   * Escape HTML special characters to prevent XSS.
+   * @param {string} text - The raw text to escape.
+   * @returns {string} The HTML-escaped text.
+   */
   escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
   }
 
+  /**
+   * Extract the current project's identifier from the page URL.
+   * @returns {string} The project id/identifier, or `''` if not found.
+   */
   getProjectId() {
     // Extract project ID from URL
     const match = window.location.pathname.match(/\/projects\/([^/]+)/);
     return match ? match[1] : '';
   }
 
+  /**
+   * Build the markdown export endpoint URL for the current project.
+   * @returns {string} The markdown export URL.
+   */
   getMarkdownExportUrl() {
     const projectId = this.getProjectId();
     return `/projects/${projectId}/ai_helper/project_health_markdown`;
   }
 
+  /**
+   * Look up an internationalized string from its meta tag.
+   * @param {string} key - The i18n key (meta tag is `i18n-<key>`).
+   * @param {string} defaultText - Fallback text if the meta tag is absent.
+   * @returns {string} The localized text, or `defaultText` if unavailable.
+   */
   getI18nText(key, defaultText) {
     // Get internationalized text from meta tags if available
     const metaTag = document.querySelector(`meta[name="i18n-${key}"]`);
@@ -381,7 +480,9 @@ window.updateHealthReportHistory = function(callback) {
 // Store class in global scope
 window.AiHelperMasterDetail = AiHelperMasterDetail;
 
-// Enable comparison button only when two different reports are selected
+/**
+ * Enable the compare-reports button only when two different reports are selected.
+ */
 function updateComparisonButton() {
   const oldRadio = document.querySelector('.old-radio:checked');
   const newRadio = document.querySelector('.new-radio:checked');

--- a/assets/javascripts/project_health/ai_helper_project_health.js
+++ b/assets/javascripts/project_health/ai_helper_project_health.js
@@ -2,6 +2,11 @@
 if (!window.aiHelperProjectHealthInitialized) {
   window.aiHelperProjectHealthInitialized = true;
 
+  /**
+   * Read the project health metadata endpoint URL and "created" label from
+   * their meta tags.
+   * @returns {{url: string|null, label: string}} The metadata refresh config.
+   */
   function getProjectHealthMetadataConfig() {
     const urlMeta = document.querySelector('meta[name="ai-helper-project-health-metadata-url"]');
     const labelMeta = document.querySelector('meta[name="ai-helper-project-health-created-label"]');
@@ -11,6 +16,12 @@ if (!window.aiHelperProjectHealthInitialized) {
     };
   }
 
+  /**
+   * Render (or remove, if `formattedValue` is falsy) the "created" metadata
+   * paragraph above the health report.
+   * @param {string} label - The metadata label (e.g. "Created").
+   * @param {string|null} formattedValue - The formatted timestamp, or null/empty to clear it.
+   */
   function renderProjectHealthMetadata(label, formattedValue) {
     const container = document.querySelector('.ai-helper-project-health');
     if (!container) {
@@ -47,6 +58,10 @@ if (!window.aiHelperProjectHealthInitialized) {
     metaParagraph.appendChild(document.createTextNode(' ' + formattedValue));
   }
 
+  /**
+   * Fetch the latest "created" metadata for the report and re-render it.
+   * Silently ignores failures so a metadata refresh never interrupts the UX.
+   */
   function refreshProjectHealthMetadata() {
     const metadata = getProjectHealthMetadataConfig();
     if (!metadata.url) {
@@ -78,8 +93,10 @@ if (!window.aiHelperProjectHealthInitialized) {
       });
   }
 
-  // Auto-scroll the streaming result container to the bottom. Split out to
-  // keep the eventSource.onmessage handler under ESLint's max-depth limit.
+  /**
+   * Auto-scroll the streaming result container to the bottom. Split out to
+   * keep the eventSource.onmessage handler under ESLint's max-depth limit.
+   */
   function scrollHealthContentToBottom() {
     const scrollableContainer = document.querySelector('.ai-helper-project-health-content.has-report');
     if (scrollableContainer) {
@@ -87,8 +104,13 @@ if (!window.aiHelperProjectHealthInitialized) {
     }
   }
 
-  // Render an incoming streaming chunk. Split out of eventSource.onmessage
-  // to keep it under ESLint's max-depth limit.
+  /**
+   * Render an incoming streaming chunk. Split out of eventSource.onmessage
+   * to keep it under ESLint's max-depth limit.
+   * @param {HTMLElement} resultDiv - The report result container.
+   * @param {AiHelperMarkdownParser} parser - Parser used to render the accumulated markdown.
+   * @param {string} content - The full accumulated content so far.
+   */
   function appendStreamingChunk(resultDiv, parser, content) {
     // Hide loader on first content
     const loader = resultDiv.querySelector('.ai-helper-loader');
@@ -106,9 +128,11 @@ if (!window.aiHelperProjectHealthInitialized) {
     scrollHealthContentToBottom();
   }
 
-  // Update the health report history in the master-detail layout once
-  // generation finishes. Split out of eventSource.onmessage to keep it
-  // under ESLint's max-depth limit.
+  /**
+   * Update the health report history in the master-detail layout once
+   * generation finishes. Split out of eventSource.onmessage to keep it
+   * under ESLint's max-depth limit.
+   */
   function refreshHealthReportHistory() {
     if (typeof window.updateHealthReportHistory !== 'function') {
       refreshProjectHealthMetadata();
@@ -134,8 +158,13 @@ if (!window.aiHelperProjectHealthInitialized) {
     }, 1000);
   }
 
-  // Render the completed report once streaming finishes. Split out of
-  // eventSource.onmessage to keep it under ESLint's max-depth limit.
+  /**
+   * Render the completed report once streaming finishes. Split out of
+   * eventSource.onmessage to keep it under ESLint's max-depth limit.
+   * @param {HTMLElement} resultDiv - The report result container.
+   * @param {AiHelperMarkdownParser} parser - Parser used to render the final markdown.
+   * @param {string} content - The full generated report content.
+   */
   function finalizeStreamingContent(resultDiv, parser, content) {
     const formattedContent = parser.parse(content);
     const finalHTML = '<div class="ai-helper-final-content">' +
@@ -158,7 +187,9 @@ if (!window.aiHelperProjectHealthInitialized) {
     refreshProjectHealthMetadata();
   }
 
-  // Function to add PDF export button after report generation
+  /**
+   * Add the PDF/Markdown export links below the report, unless already present.
+   */
   function addPdfExportButton() {
     const healthDiv = document.querySelector('.ai-helper-project-health');
     if (healthDiv) {
@@ -206,7 +237,9 @@ if (!window.aiHelperProjectHealthInitialized) {
     }
   }
 
-  // Function to remove PDF export button
+  /**
+   * Remove the PDF/Markdown export links, if present.
+   */
   function removePdfExportButton() {
     const healthDiv = document.querySelector('.ai-helper-project-health');
     if (healthDiv) {
@@ -217,7 +250,11 @@ if (!window.aiHelperProjectHealthInitialized) {
     }
   }
 
-  // Function to update hidden field with report content
+  /**
+   * Store the report's markdown content in a hidden field for later export,
+   * creating the field if it doesn't exist yet.
+   * @param {string} content - The report's raw markdown content.
+   */
   function updateHiddenReportContent(content) {
     let hiddenField = document.getElementById('ai-helper-health-report-content');
     if (!hiddenField) {
@@ -231,7 +268,11 @@ if (!window.aiHelperProjectHealthInitialized) {
     hiddenField.value = content;
   }
 
-  // Function to handle PDF export with current content
+  /**
+   * Submit the stored report content to the PDF export endpoint via a
+   * generated form.
+   * @param {MouseEvent} event - The export link's click event.
+   */
   function handlePdfExport(event) {
     event.preventDefault();
     const hiddenField = document.getElementById('ai-helper-health-report-content');
@@ -259,7 +300,11 @@ if (!window.aiHelperProjectHealthInitialized) {
     }
   }
 
-  // Function to handle Markdown export with current content
+  /**
+   * Submit the stored report content to the Markdown export endpoint via a
+   * generated form.
+   * @param {MouseEvent} event - The export link's click event.
+   */
   function handleMarkdownExport(event) {
     event.preventDefault();
     const hiddenField = document.getElementById('ai-helper-health-report-content');

--- a/assets/javascripts/settings/ai_helper_chat_settings.js
+++ b/assets/javascripts/settings/ai_helper_chat_settings.js
@@ -1,5 +1,10 @@
 "use strict";
 
+/**
+ * Show or hide an adapter's settings (and bindings, if rendered) based on
+ * whether its enabled checkbox is checked.
+ * @param {string} channelType - The adapter's channel type (e.g. "slack").
+ */
 function setAdapterSettingsVisible(channelType) {
   const checkbox = document.querySelector(
     `input[type=checkbox][data-adapter-type="${channelType}"]`
@@ -14,6 +19,10 @@ function setAdapterSettingsVisible(channelType) {
   if (bindingsFieldset) {bindingsFieldset.style.display = display;}
 }
 
+/**
+ * Wire each adapter's enabled checkbox to toggle its settings visibility.
+ * @returns {string[]} The channel types found, for the caller's initial sync.
+ */
 function setupAdapterCheckboxListeners() {
   const checkboxes = document.querySelectorAll(".adapter-enabled-checkbox");
   const adapterTypes = [];
@@ -29,6 +38,10 @@ function setupAdapterCheckboxListeners() {
   return adapterTypes;
 }
 
+/**
+ * Sync each adapter's user-lookup text input to its hidden `redmine_user_id`
+ * field by matching the typed text against the backing `<datalist>` options.
+ */
 function setupDatalistHandlers() {
   const textInputs = document.querySelectorAll(
     'input[list^="ai-helper-users-datalist-"]'
@@ -41,6 +54,10 @@ function setupDatalistHandlers() {
     );
     if (!hiddenInput) {return;}
 
+    /**
+     * Set the hidden field to the matched option's user ID, or clear it when
+     * the typed text doesn't match any datalist option.
+     */
     function syncHiddenInput() {
       const enteredText = textInput.value.trim();
       const datalist = document.getElementById(listAttr);
@@ -57,16 +74,22 @@ function setupDatalistHandlers() {
   });
 }
 
-// Each adapter's "add binding" fields share the same `name` attributes
-// (they all live inside the single settings <form>), so submitting one
-// adapter's fields would otherwise carry along every other adapter's
-// same-named fields. Disable every other adapter's fields right before
-// submission so only the clicked adapter's binding is submitted.
+/**
+ * Disable every other adapter's binding fields right before an adapter's
+ * "add binding" submit, so only the clicked adapter's fields are submitted.
+ * Each adapter's binding fields share the same `name` attributes (they all
+ * live inside the single settings `<form>`), so submitting one adapter's
+ * fields would otherwise carry along every other adapter's same-named fields.
+ */
 function setupBindingFormIsolation() {
   const bindingFieldsets = document.querySelectorAll(
     'fieldset[id^="adapter-bindings-"]'
   );
 
+  /**
+   * @param {HTMLFieldSetElement} fieldset - A `fieldset[id^="adapter-bindings-"]` element.
+   * @returns {NodeList} That fieldset's channel-binding input/select fields.
+   */
   function bindingFields(fieldset) {
     return fieldset.querySelectorAll(
       'input[name^="ai_helper_channel_binding"], select[name^="ai_helper_channel_binding"]'
@@ -101,6 +124,10 @@ document.addEventListener("DOMContentLoaded", function () {
   setupHelpDialogDragging();
 });
 
+/**
+ * Wire each adapter's help trigger link to open (lazily fetching its body on
+ * first open) and each dialog's close button to close it.
+ */
 function setupHelpDialogListeners() {
   document.querySelectorAll(".adapter-help-trigger").forEach(function (link) {
     link.addEventListener("click", function (e) {
@@ -137,6 +164,12 @@ function setupHelpDialogListeners() {
   });
 }
 
+/**
+ * Position a help dialog just below-right of its trigger link, clamped to
+ * stay within the viewport.
+ * @param {HTMLDialogElement} dialog - The help dialog to position.
+ * @param {HTMLElement} trigger - The link that opened the dialog.
+ */
 function positionHelpDialog(dialog, trigger) {
   const margin = 8;
   const linkRect = trigger.getBoundingClientRect();
@@ -155,6 +188,10 @@ function positionHelpDialog(dialog, trigger) {
   dialog.style.left = left + "px";
 }
 
+/**
+ * Make each help dialog draggable by its header, clamped to stay within the
+ * viewport.
+ */
 function setupHelpDialogDragging() {
   document.querySelectorAll(".adapter-help-dialog").forEach(function (dialog) {
     const header = dialog.querySelector(".adapter-help-dialog-header");
@@ -166,6 +203,10 @@ function setupHelpDialogDragging() {
     let startLeft = 0;
     let startTop = 0;
 
+    /**
+     * Move the dialog to follow the pointer while dragging, clamped to the viewport.
+     * @param {MouseEvent} e - The mousemove event.
+     */
     function onMouseMove(e) {
       if (!dragging) {return;}
       const dialogRect = dialog.getBoundingClientRect();
@@ -177,6 +218,9 @@ function setupHelpDialogDragging() {
       dialog.style.top = top + "px";
     }
 
+    /**
+     * End the drag and remove the document-level move/up listeners.
+     */
     function onMouseUp() {
       dragging = false;
       document.removeEventListener("mousemove", onMouseMove);

--- a/assets/javascripts/settings/ai_helper_custom_commands.js
+++ b/assets/javascripts/settings/ai_helper_custom_commands.js
@@ -4,6 +4,9 @@
  * Extracted from custom_commands/_form.html.erb.
  */
 const AiHelperCustomCommands = (() => {
+  /**
+   * Wire the user-scope field's visibility to the selected command type.
+   */
   function init() {
     const commandTypeField = document.getElementById('ai_helper_custom_command_command_type');
     const userScopeField = document.getElementById('user_scope_field');
@@ -11,6 +14,9 @@ const AiHelperCustomCommands = (() => {
 
     if (!commandTypeField || !userScopeField) {return;}
 
+    /**
+     * Show the user-scope field only when the command type is "user".
+     */
     function updateVisibility() {
       const commandType = commandTypeField.value;
       if (commandType === 'user') {

--- a/assets/javascripts/settings/ai_helper_model_profile.js
+++ b/assets/javascripts/settings/ai_helper_model_profile.js
@@ -97,8 +97,8 @@ const AiHelperModelProfile = (() => {
     }
 
     /**
-     * @param {HTMLElement|null} element
-     * @param {boolean} visible
+     * @param {HTMLElement|null} element - The element to show/hide, if it exists.
+     * @param {boolean} visible - Whether the element should be visible.
      */
     function setVisible(element, visible) {
       if (element) {element.style.display = visible ? 'block' : 'none';}

--- a/assets/javascripts/settings/ai_helper_settings.js
+++ b/assets/javascripts/settings/ai_helper_settings.js
@@ -4,6 +4,10 @@
  * Extracted from ai_helper_settings/index.html.erb.
  */
 
+/**
+ * Read the settings page's configuration JSON from its container element.
+ * @returns {object} Parsed config (model profile/vector-search options, labels, etc.), or `{}` if absent.
+ */
 function getAiHelperSettingsConfig() {
   const container = document.getElementById('ai-helper-settings-index');
   return container ? JSON.parse(container.dataset.config || '{}') : {};
@@ -15,8 +19,8 @@ function getAiHelperSettingsConfig() {
  * settings page can't rely on the shared `ai_helper` global's equivalent
  * helper, since `ai_helper.js` is only loaded on pages with a project (via
  * `_html_header.html.erb`) and this admin page has none.
- * @param {HTMLElement} element
- * @param {string} html
+ * @param {HTMLElement} element - The element to fill.
+ * @param {string} html - HTML string, server-rendered from ERB templates.
  */
 function setHtmlAndRunScripts(element, html) {
   element.innerHTML = html;
@@ -31,7 +35,7 @@ function setHtmlAndRunScripts(element, html) {
  * Load a model profile's detail view via AJAX into the description area.
  * Uses `setHtmlAndRunScripts` (not plain innerHTML) because the loaded
  * partial ends in a bridge `<script>` that must execute on each load.
- * @param {number|string} id
+ * @param {number|string} id - The model profile's ID.
  */
 function loadModelProfile(id) {
   const config = getAiHelperSettingsConfig();
@@ -51,6 +55,9 @@ function loadModelProfile(id) {
     });
 }
 
+/**
+ * Load the selected model profile's detail view, or clear it when none is selected.
+ */
 function setModelProfile() {
   const select = document.getElementById('ai_helper_setting_model_profile_id');
   const selectedId = select.value;
@@ -61,18 +68,28 @@ function setModelProfile() {
   }
 }
 
+/**
+ * Show or hide the "think model" settings section based on its checkbox.
+ */
 function setThinkModelVisible() {
   const thinkEnabled = document.getElementById('ai_helper_setting_use_think_model').checked;
   const settingsDiv = document.getElementById('ai-helper-think-model-settings');
   settingsDiv.style.display = thinkEnabled ? '' : 'none';
 }
 
+/**
+ * Show or hide the attachment-sending settings section based on its checkbox.
+ */
 function setAttachmentSettingsVisible() {
   const attachmentEnabled = document.getElementById('ai_helper_setting_attachment_send_enabled').checked;
   const settingsDiv = document.getElementById('ai-helper-attachment-settings');
   settingsDiv.style.display = attachmentEnabled ? '' : 'none';
 }
 
+/**
+ * Show or hide the vector-search settings section based on its checkbox,
+ * and sync the dependent vector-model-profile toggle's visibility.
+ */
 function setVectorSearchVisible() {
   const vectorSearchEnabled = document.getElementById('ai_helper_setting_vector_search_enabled').checked;
   const vectorSearchDiv = document.getElementById('ai-helper-vector-search');
@@ -80,6 +97,9 @@ function setVectorSearchVisible() {
   setVectorModelProfileToggleVisible();
 }
 
+/**
+ * Hide the target-projects picker when "register all projects" is checked.
+ */
 function setVectorTargetProjectsVisible() {
   const registerAll = document.getElementById('ai_helper_setting_vector_register_all_projects');
   const container = document.getElementById('ai-helper-vector-target-projects');
@@ -87,12 +107,19 @@ function setVectorTargetProjectsVisible() {
   container.style.display = registerAll.checked ? 'none' : '';
 }
 
+/**
+ * Show or hide the vector-search model profile settings based on its checkbox.
+ */
 function setVectorModelProfileVisible() {
   const enabled = document.getElementById('ai_helper_setting_use_vector_model_profile').checked;
   const settingsDiv = document.getElementById('ai-helper-vector-model-profile-settings');
   settingsDiv.style.display = enabled ? '' : 'none';
 }
 
+/**
+ * Show the "use a dedicated vector model profile" row only while vector
+ * search is enabled, and sync its dependent settings section.
+ */
 function setVectorModelProfileToggleVisible() {
   const vectorSearchEnabled = document.getElementById('ai_helper_setting_vector_search_enabled').checked;
   const toggleRow = document.getElementById('ai_helper_setting_use_vector_model_profile');
@@ -110,6 +137,10 @@ function setVectorModelProfileToggleVisible() {
   }
 }
 
+/**
+ * Show the "send user ID" row only when the currently loaded model type
+ * supports it.
+ */
 function setSendUserIdVisible() {
   const config = getAiHelperSettingsConfig();
   // ai_helper_model_type only exists once the model tab's profile detail is
@@ -121,6 +152,10 @@ function setSendUserIdVisible() {
 }
 window.setSendUserIdVisible = setSendUserIdVisible;
 
+/**
+ * Show/hide the model-type-specific fields (dimension, embedding URL) for
+ * the just-loaded model profile, and refresh the "send user ID" visibility.
+ */
 function modelTypeChanged() {
   const config = getAiHelperSettingsConfig();
   const modelType = document.getElementById('ai_helper_model_type')?.textContent || '';

--- a/assets/javascripts/shared/ai_helper_collapsible_fieldset.js
+++ b/assets/javascripts/shared/ai_helper_collapsible_fieldset.js
@@ -8,7 +8,7 @@
 const AiHelperCollapsibleFieldset = (() => {
   /**
    * Toggle the open/closed state of a fieldset to match `flag`.
-   * @param {string} fieldsetId
+   * @param {string} fieldsetId - DOM id of the fieldset element.
    * @param {boolean} flag - true to expand, false to collapse.
    */
   function setExpanded(fieldsetId, flag) {

--- a/assets/javascripts/shared/ai_helper_markdown_parser.js
+++ b/assets/javascripts/shared/ai_helper_markdown_parser.js
@@ -1,6 +1,14 @@
 // Prevent duplicate class declaration
 if (typeof AiHelperMarkdownParser === "undefined") {
+  /**
+   * A minimal client-side Markdown-to-HTML renderer for streamed/cached
+   * AI-generated content (summaries, replies, health reports). Escapes and
+   * sanitizes its input/output since it renders untrusted LLM text.
+   */
   window.AiHelperMarkdownParser = class {
+    /**
+     * Set up the ordered list of regex-based rendering rules applied by `parse`.
+     */
     constructor() {
       this.rules = [
         // Headers
@@ -60,6 +68,11 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       ];
     }
 
+    /**
+     * Render a Markdown string to sanitized HTML.
+     * @param {string} markdown - The raw (untrusted) Markdown source.
+     * @returns {string} The rendered, sanitized HTML.
+     */
     parse(markdown) {
       // Escape HTML special characters in the source so any raw HTML embedded
       // in the report content (e.g. <script>, <img onerror=...>, attribute
@@ -94,6 +107,13 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return html;
     }
 
+    /**
+     * Turn `#123`-style issue references into links, using
+     * `ai_helper_urls.issue_base`. Existing `<a>`/`<pre>`/`<code>` blocks are
+     * masked out first so their content is never re-linked.
+     * @param {string} html - HTML already rendered by the other rules.
+     * @returns {string} HTML with issue references linkified.
+     */
     linkifyIssueReferences(html) {
       const template = (typeof ai_helper_urls !== 'undefined') ? ai_helper_urls.issue_base : null;
       if (!template) {return html;}
@@ -143,8 +163,12 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return unmasked;
     }
 
-    // Remove dangerous HTML patterns from the output using DOMParser
-    // for robust sanitization that handles nested/malformed tags correctly.
+    /**
+     * Remove dangerous HTML patterns from the output using DOMParser for
+     * robust sanitization that handles nested/malformed tags correctly.
+     * @param {string} html - HTML already rendered by the other rules.
+     * @returns {string} Sanitized HTML, with dangerous tags/attributes stripped.
+     */
     sanitizeOutput(html) {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       // Remove dangerous elements and their content
@@ -168,7 +192,11 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return doc.body.innerHTML;
     }
 
-    // Escape HTML special characters so raw HTML in the input renders as text.
+    /**
+     * Escape HTML special characters so raw HTML in the input renders as text.
+     * @param {string} text - The raw value to escape (`null`/`undefined` become `''`).
+     * @returns {string} The HTML-escaped text.
+     */
     static escapeHtml(text) {
       if (text == null) {return "";}
       return String(text)
@@ -179,7 +207,11 @@ if (typeof AiHelperMarkdownParser === "undefined") {
         .replace(/'/g, "&#39;");
     }
 
-    // Validate URL protocol to prevent javascript: XSS
+    /**
+     * Validate URL protocol to prevent javascript: XSS.
+     * @param {string} url - The URL from a `[text](url)` markdown link.
+     * @returns {string|null} The trimmed URL if its protocol is allowed, otherwise `null`.
+     */
     static sanitizeUrl(url) {
       if (!url) {return null;}
       const trimmed = url.trim();
@@ -193,6 +225,12 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return null;
     }
 
+    /**
+     * Render GitHub-flavored Markdown tables (with header/alignment rows)
+     * to HTML `<table>` markup; lines outside of a table pass through unchanged.
+     * @param {string} markdown - The (HTML-escaped) source text.
+     * @returns {string} The source with tables replaced by HTML.
+     */
     processTables(markdown) {
       const tableRegex = /^\|(.+)\|$/;
       const headerSeparatorRegex = /^\|(\s*:?-+:?\s*\|)+$/;
@@ -263,6 +301,12 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return html.join("\n");
     }
 
+    /**
+     * Build a `<table>` element's HTML from parsed rows and column alignments.
+     * @param {string[][]} tableData - Cell text, one array per row (row 0 is the header).
+     * @param {string[]} alignments - Per-column alignment (`'left'`, `'center'`, or `'right'`).
+     * @returns {string} The rendered `<table>` HTML, or `''` if `tableData` is empty.
+     */
     convertTableToHtml(tableData, alignments) {
       if (tableData.length === 0) {return "";}
 
@@ -299,6 +343,12 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return html.join("\n");
     }
 
+    /**
+     * Render (possibly nested) Markdown bullet/numbered lists to HTML
+     * `<ul>`/`<ol>` markup, tracking nesting via indentation.
+     * @param {string} markdown - The (HTML-escaped) source text.
+     * @returns {string} The source with lists replaced by HTML.
+     */
     processLists(markdown) {
       const lines = markdown.split("\n");
       const html = [];
@@ -353,9 +403,14 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       return html.join("\n");
     }
 
-    // Handles a non-empty, non-list-item line encountered while walking the
-    // markdown for processLists(). Split out to keep processLists() under
-    // ESLint's max-depth limit.
+    /**
+     * Handles a non-empty, non-list-item line encountered while walking the
+     * markdown for processLists(). Split out to keep processLists() under
+     * ESLint's max-depth limit.
+     * @param {string} line - The current source line.
+     * @param {Array<{type: string, indent: number}>} listStack - Currently open lists, outermost first.
+     * @param {string[]} html - Output buffer; mutated in place.
+     */
     processNonListLine(line, listStack, html) {
       if (listStack.length === 0) {
         html.push(line);
@@ -376,8 +431,13 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       html.push(line);
     }
 
-    // Close any list levels deeper than currentLevel. Split out of
-    // processLists() to keep it under ESLint's max-depth limit.
+    /**
+     * Close any list levels deeper than currentLevel. Split out of
+     * processLists() to keep it under ESLint's max-depth limit.
+     * @param {Array<{type: string, indent: number}>} listStack - Currently open lists; mutated in place.
+     * @param {string[]} html - Output buffer; mutated in place.
+     * @param {number} currentLevel - The indent level of the line being processed.
+     */
     closeDeeperLists(listStack, html, currentLevel) {
       while (
         listStack.length > 0 &&
@@ -392,8 +452,14 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       }
     }
 
-    // Close the current-level list if the list type (ul/ol) changed. Split
-    // out of processLists() to keep it under ESLint's max-depth limit.
+    /**
+     * Close the current-level list if the list type (ul/ol) changed. Split
+     * out of processLists() to keep it under ESLint's max-depth limit.
+     * @param {Array<{type: string, indent: number}>} listStack - Currently open lists; mutated in place.
+     * @param {string[]} html - Output buffer; mutated in place.
+     * @param {number} currentLevel - The indent level of the line being processed.
+     * @param {string} currentListType - `'ul'` or `'ol'`, the list type of the line being processed.
+     */
     closeSameLevelListIfTypeChanged(listStack, html, currentLevel, currentListType) {
       if (
         listStack.length > 0 &&
@@ -408,8 +474,14 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       }
     }
 
-    // Open a new nested list, or continue the current one. Split out of
-    // processLists() to keep it under ESLint's max-depth limit.
+    /**
+     * Open a new nested list, or continue the current one. Split out of
+     * processLists() to keep it under ESLint's max-depth limit.
+     * @param {Array<{type: string, indent: number}>} listStack - Currently open lists; mutated in place.
+     * @param {string[]} html - Output buffer; mutated in place.
+     * @param {number} currentLevel - The indent level of the line being processed.
+     * @param {string} currentListType - `'ul'` or `'ol'`, the list type of the line being processed.
+     */
     openOrContinueList(listStack, html, currentLevel, currentListType) {
       if (
         listStack.length === 0 ||
@@ -428,8 +500,12 @@ if (typeof AiHelperMarkdownParser === "undefined") {
       }
     }
 
-    // Close all remaining open lists. Split out of processLists() to keep
-    // it under ESLint's max-depth limit.
+    /**
+     * Close all remaining open lists. Split out of processLists() to keep
+     * it under ESLint's max-depth limit.
+     * @param {Array<{type: string, indent: number}>} listStack - Currently open lists; mutated in place (emptied).
+     * @param {string[]} html - Output buffer; mutated in place.
+     */
     closeAllLists(listStack, html) {
       while (listStack.length > 0) {
         html.push("</li>");

--- a/assets/javascripts/stuff_todo/ai_helper_stuff_todo.js
+++ b/assets/javascripts/stuff_todo/ai_helper_stuff_todo.js
@@ -49,7 +49,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
   let currentEventSource = null;
 
-  // Open modal and start streaming
+  /**
+   * Open the stuff-todo modal and start streaming suggestions into it.
+   */
   function openModal() {
     overlay.style.display = 'block';
     modal.style.display = 'block';
@@ -57,7 +59,9 @@ document.addEventListener('DOMContentLoaded', function() {
     streamStuffTodo();
   }
 
-  // Close modal and abort streaming
+  /**
+   * Close the stuff-todo modal and abort any in-flight streaming.
+   */
   function closeModal() {
     overlay.style.display = 'none';
     modal.style.display = 'none';
@@ -67,7 +71,10 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  // Stream stuff todo suggestions via SSE
+  /**
+   * Open an SSE connection to `stuffTodoUrl` and render the streamed
+   * markdown content into the modal body as it arrives.
+   */
   function streamStuffTodo() {
     if (currentEventSource) {
       currentEventSource.close();

--- a/assets/javascripts/sub_issues/ai_helper_sub_issues.js
+++ b/assets/javascripts/sub_issues/ai_helper_sub_issues.js
@@ -3,7 +3,11 @@
   
   let initialized = false;
   
-  // Load assignees for a specific tracker
+  /**
+   * Fetch and populate the assignable-users list for a sub-issue row's
+   * tracker select, preserving the currently selected value if still valid.
+   * @param {HTMLSelectElement} trackerSelect - The sub-issue's tracker select element.
+   */
   function loadAssignees(trackerSelect) {
     const trackerId = trackerSelect.value;
     const projectId = trackerSelect.dataset.projectId;
@@ -40,7 +44,10 @@
       });
   }
   
-  // Initialize all tracker selects
+  /**
+   * Load assignees for every sub-issue tracker select currently on the page,
+   * once.
+   */
   function initializeAllTrackers() {
     if (initialized) {return;}
     
@@ -64,7 +71,10 @@
     }
   });
   
-  // Setup MutationObserver to detect when sub-issues are loaded
+  /**
+   * Watch the page for the sub-issues list being loaded (it arrives via AJAX
+   * after this script runs) and initialize tracker selects once it appears.
+   */
   function setupObserver() {
     let mainContent = document.querySelector('#content');
 

--- a/assets/javascripts/summary/ai_helper_issue_summary.js
+++ b/assets/javascripts/summary/ai_helper_issue_summary.js
@@ -5,6 +5,10 @@
  * Extracted from issues/_bottom.html.erb.
  */
 
+/**
+ * Read the issue summary panel's config JSON from its data attribute.
+ * @returns {object} Parsed config (`{}` if the panel isn't on the page).
+ */
 function getIssueSummaryConfig() {
   const container = document.getElementById('ai-helper-summary-fields');
   return container ? JSON.parse(container.dataset.config || '{}') : {};
@@ -14,7 +18,6 @@ function getIssueSummaryConfig() {
  * Fetch the (cached or freshly generated) issue summary and render it into
  * the summary area. Exposed on `window` because ai_helper.js calls it
  * directly after a summary-generation stream completes.
- *
  * @param {boolean} [update] - when true, requests a forced regeneration.
  */
 function getSummary(update) {
@@ -51,6 +54,9 @@ function getSummary(update) {
 }
 window.getSummary = getSummary;
 
+/**
+ * Trigger streaming (re)generation of the issue summary via ai_helper.js.
+ */
 function generateSummaryStream() {
   const config = getIssueSummaryConfig();
   ai_helper.generateSummaryStream(config.generateUrl, config.errorMessage);
@@ -115,14 +121,19 @@ function findSimilarIssues() {
 }
 window.findSimilarIssues = findSimilarIssues;
 
-// Get selected scope value from radio buttons
+/**
+ * Get the selected similar-issues search scope from the radio buttons.
+ * @returns {string} The selected scope value (defaults to `'with_subprojects'`).
+ */
 function getSelectedScope() {
   const selected = document.querySelector('input[name="ai_helper_scope"]:checked');
   return selected ? selected.value : 'with_subprojects';
 }
 
-// Recompute the suggested hours weighted average from the currently
-// checked similar issues, mirroring RedmineAiHelper::EffortEstimation.suggest.
+/**
+ * Recompute the suggested hours weighted average from the currently checked
+ * similar issues, mirroring RedmineAiHelper::EffortEstimation.suggest.
+ */
 function recalculateSuggestedHours() {
   const block = document.getElementById('ai-helper-suggested-hours-block');
   if (!block) {return;}
@@ -162,16 +173,21 @@ function recalculateSuggestedHours() {
   }
 }
 
-// Recompute both the suggested hours and the select-all checkbox state.
-// These two are always refreshed together whenever the checked set of
-// effort checkboxes may have changed.
+/**
+ * Recompute both the suggested hours and the select-all checkbox state.
+ * These two are always refreshed together whenever the checked set of
+ * effort checkboxes may have changed.
+ */
 function refreshEffortUI() {
   recalculateSuggestedHours();
   recalculateEffortSelectAllState();
 }
 
-// Set every row effort checkbox to match the header select-all checkbox,
-// then recompute the suggestion.
+/**
+ * Set every row effort checkbox to match the header select-all checkbox,
+ * then recompute the suggestion.
+ * @param {boolean} checked - The header select-all checkbox's new state.
+ */
 function toggleAllEffortCheckboxes(checked) {
   const checkboxes = document.querySelectorAll('.ai-helper-effort-checkbox');
   checkboxes.forEach(function(checkbox) {
@@ -180,9 +196,11 @@ function toggleAllEffortCheckboxes(checked) {
   refreshEffortUI();
 }
 
-// Recompute the header select-all checkbox's checked/indeterminate state
-// from the current row checkboxes: all checked -> checked, none checked ->
-// unchecked, a mix of both -> indeterminate.
+/**
+ * Recompute the header select-all checkbox's checked/indeterminate state
+ * from the current row checkboxes: all checked -> checked, none checked ->
+ * unchecked, a mix of both -> indeterminate.
+ */
 function recalculateEffortSelectAllState() {
   const selectAll = document.getElementById('ai-helper-effort-select-all');
   if (!selectAll) {return;}
@@ -202,10 +220,12 @@ function recalculateEffortSelectAllState() {
   }
 }
 
-// Write the currently suggested hours into the issue's Estimated time field.
-// That field lives inside the "#update" edit form, which Redmine keeps
-// collapsed (display:none) until the user opens it, so reveal and scroll to
-// it (via Redmine core's own showAndScrollTo helper) to make the change visible.
+/**
+ * Write the currently suggested hours into the issue's Estimated time field.
+ * That field lives inside the "#update" edit form, which Redmine keeps
+ * collapsed (display:none) until the user opens it, so reveal and scroll to
+ * it (via Redmine core's own showAndScrollTo helper) to make the change visible.
+ */
 function applySuggestedHours() {
   const valueSpan = document.getElementById('ai-helper-suggested-hours-value');
   const estimatedHoursField = document.getElementById('issue_estimated_hours');
@@ -215,7 +235,9 @@ function applySuggestedHours() {
   }
 }
 
-// Function to move similar issues section to after relations
+/**
+ * Move the similar-issues section to just after the relations section.
+ */
 function moveSimilarIssuesToRelations() {
   const similarIssuesSection = document.getElementById('ai-helper-similar-issues-section');
   if (!similarIssuesSection) {return;}

--- a/assets/javascripts/summary/ai_helper_wiki_summary.js
+++ b/assets/javascripts/summary/ai_helper_wiki_summary.js
@@ -8,7 +8,6 @@
  * Fetch the (cached or freshly generated) wiki summary and render it into
  * the summary area. Exposed on `window` because ai_helper.js calls it
  * directly after a summary-generation stream completes.
- *
  * @param {boolean} [update] - when true, requests a forced regeneration.
  */
 function getWikiSummary(update) {
@@ -48,6 +47,9 @@ function getWikiSummary(update) {
 }
 window.getWikiSummary = getWikiSummary;
 
+/**
+ * Trigger streaming (re)generation of the wiki summary via ai_helper.js.
+ */
 function generateWikiSummaryStream() {
   const container = document.getElementById('ai-helper-wiki-summary-fields');
   if (!container) {return;}
@@ -75,6 +77,11 @@ function aiHelperSaveWikiSummaryState() {
 }
 window.aiHelperSaveWikiSummaryState = aiHelperSaveWikiSummaryState;
 
+/**
+ * Wire up the wiki summary panel: relocate it to the top of the wiki
+ * content, restore its fold state, bind the generate button, and load an
+ * existing summary if one is cached.
+ */
 function initWikiSummary() {
   const container = document.getElementById('ai-helper-wiki-summary-fields');
   if (!container) {return;}

--- a/assets/javascripts/typo_checker/ai_helper_typo_checker.js
+++ b/assets/javascripts/typo_checker/ai_helper_typo_checker.js
@@ -1,4 +1,12 @@
+/**
+ * AI-powered typo/spelling check for a Redmine textarea: sends the text to
+ * the server, then overlays accept/reject suggestions inline over it.
+ */
 class AiHelperTypoChecker {
+  /**
+   * @param {HTMLTextAreaElement} textarea - The textarea to check.
+   * @param {object} [options] - Configuration (endpoint, labels, debounceDelay, minLength).
+   */
   constructor(textarea, options = {}) {
     this.textarea = textarea;
     this.options = {
@@ -19,6 +27,9 @@ class AiHelperTypoChecker {
     this.isCheckingTypos = false;
   }
 
+  /**
+   * Wire up the overlay, control panel, check button, and event listeners.
+   */
   init() {
     this.createOverlay();
     this.findControlPanel();
@@ -26,6 +37,10 @@ class AiHelperTypoChecker {
     this.attachEventListeners();
   }
 
+  /**
+   * Locate this textarea's suggestion control panel (apply-all/close
+   * buttons), move it under the textarea's parent, and bind its buttons.
+   */
   findControlPanel() {
     // Map textarea IDs to control panel IDs
     const textareaToControlPanelMap = {
@@ -75,6 +90,10 @@ class AiHelperTypoChecker {
     }
   }
 
+  /**
+   * Create the suggestion overlay, styled and positioned to sit exactly over
+   * the textarea, and keep it (and the control panel) synced to its position.
+   */
   createOverlay() {
     // Create overlay element with same position and size as textarea (same as autocomplete)
     this.overlay = document.createElement('div');
@@ -154,6 +173,9 @@ class AiHelperTypoChecker {
     this.textarea.classList.add('ai-helper-textarea-positioned');
   }
 
+  /**
+   * Locate this textarea's "check typos" button by its known ID mapping.
+   */
   findExistingButton() {
     // Map textarea IDs to button IDs
     const textareaToButtonMap = {
@@ -168,6 +190,10 @@ class AiHelperTypoChecker {
     }
   }
 
+  /**
+   * Bind the check button, and the input/keydown/click/focus/scroll
+   * listeners that dismiss the overlay or keep it in sync.
+   */
   attachEventListeners() {
     if (this.checkButton) {
       // Remove any existing event listeners to prevent duplicates
@@ -225,6 +251,11 @@ class AiHelperTypoChecker {
     });
   }
 
+  /**
+   * Disable and clear any active description/notes/wiki autocompletion
+   * instances while the typo overlay is shown, so the two features don't
+   * fight over the textarea.
+   */
   disableAutocompletion() {
     // Disable autocomplete functionality when typo overlay is active
     if (window.aiHelperInstances) {
@@ -244,6 +275,10 @@ class AiHelperTypoChecker {
     }
   }
 
+  /**
+   * Re-enable any autocompletion instance whose checkbox is still checked,
+   * once the typo overlay is hidden.
+   */
   enableAutocompletion() {
     // Re-enable autocomplete functionality when typo overlay is hidden
     if (window.aiHelperInstances) {
@@ -260,6 +295,10 @@ class AiHelperTypoChecker {
     }
   }
 
+  /**
+   * Send the textarea's current text to the check endpoint and display the
+   * returned suggestions, showing a "checking..." state on the button meanwhile.
+   */
   async checkTypos() {
     // Prevent duplicate execution
     if (this.isCheckingTypos) {
@@ -328,6 +367,11 @@ class AiHelperTypoChecker {
   // (displayTypoOverlay, buildOverlayContent, accept/reject*, hideOverlay,
   // showNoSuggestionsMessage, showErrorMessage, and their static helpers)
   // live in ai_helper_typo_suggestion_overlay.js — see the comment there.
+  /**
+   * Resolve the textarea's effective background color, falling back to the
+   * parent's, then to white, when it (or its parent) is transparent.
+   * @returns {string} A CSS color value.
+   */
   getTextareaBackgroundColor() {
     const computedStyle = window.getComputedStyle(this.textarea);
     let bgColor = computedStyle.backgroundColor;
@@ -347,16 +391,23 @@ class AiHelperTypoChecker {
     return bgColor;
   }
 
+  /**
+   * @returns {string} The page's CSRF token, or `''` if the meta tag is absent.
+   */
   getCSRFToken() {
     return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
   }
 
-  // Helper method to check if overlay is visible using CSS classes
+  /**
+   * @returns {boolean} Whether the suggestion overlay is currently shown.
+   */
   isOverlayActive() {
     return this.overlay && this.overlay.classList.contains('ai-helper-typo-overlay-active');
   }
 
-  // Sync overlay scroll with textarea scroll
+  /**
+   * Sync the overlay's scroll position to the textarea's.
+   */
   syncScroll() {
     if (this.overlay && this.textarea) {
       this.overlay.scrollTop = this.textarea.scrollTop;
@@ -364,7 +415,10 @@ class AiHelperTypoChecker {
     }
   }
 
-  // Check if scrolling is needed and enable it when content exceeds height
+  /**
+   * Check if scrolling is needed and enable it when content exceeds height,
+   * otherwise restore the overlay's default (non-scrollable) styling.
+   */
   checkAndEnableScrolling() {
     if (!this.overlay) {return;}
     
@@ -406,7 +460,9 @@ class AiHelperTypoChecker {
     }
   }
 
-  // Reset scrolling settings to default state
+  /**
+   * Reset scrolling settings to default state.
+   */
   resetScrolling() {
     if (!this.overlay) {return;}
     
@@ -419,7 +475,11 @@ class AiHelperTypoChecker {
     this.removeScrollableEventListeners();
   }
 
-  // Add event listeners for scrollable overlay mode
+  /**
+   * Add event listeners for scrollable overlay mode, forwarding clicks/keys
+   * to the textarea except when they target the accept/reject buttons or
+   * scroll keys.
+   */
   addScrollableEventListeners() {
     if (!this.overlay) {return;}
     
@@ -449,7 +509,9 @@ class AiHelperTypoChecker {
     this.overlay.addEventListener('keydown', this.scrollableKeydownHandler);
   }
 
-  // Remove event listeners for scrollable overlay mode
+  /**
+   * Remove the event listeners added by `addScrollableEventListeners`.
+   */
   removeScrollableEventListeners() {
     if (!this.overlay || !this.scrollableClickHandler) {return;}
     
@@ -466,11 +528,10 @@ window.AiHelperTypoChecker = AiHelperTypoChecker;
 /**
  * Factory: create and init a typo checker from a container element's data-config.
  * Also binds a check button if its ID matches the textarea-to-button map.
- *
  * @param {HTMLElement} container - Element with data-config (JSON: {endpoint, labels})
  * @param {string} textareaId - ID of the target textarea
  * @param {string} [buttonId] - If provided, bind the button's click to checkTypos()
- * @returns {AiHelperTypoChecker|null}
+ * @returns {AiHelperTypoChecker|null} The created checker, or null if the container/textarea is missing.
  */
 AiHelperTypoChecker.initFromConfig = function(container, textareaId, buttonId) {
   if (!container) {return null;}

--- a/assets/javascripts/typo_checker/ai_helper_typo_suggestion_overlay.js
+++ b/assets/javascripts/typo_checker/ai_helper_typo_suggestion_overlay.js
@@ -7,7 +7,12 @@
 // class body. Must load after ai_helper_typo_checker.js (which declares
 // `window.AiHelperTypoChecker`).
 
-// Find the occurrence of `original` closest to the suggestion's reported position
+/**
+ * Find the occurrence of `original` closest to the suggestion's reported position.
+ * @param {number[]} positions - Candidate positions where the original text occurs.
+ * @param {number} targetPosition - The suggestion's reported (possibly stale) position.
+ * @returns {number} The candidate position closest to `targetPosition`.
+ */
 function findClosestPosition(positions, targetPosition) {
   let bestPosition = positions[0];
   let minDistance = Math.abs(positions[0] - targetPosition);

--- a/docs/adr/028-eslint-plugin-jsdoc-enforcement.md
+++ b/docs/adr/028-eslint-plugin-jsdoc-enforcement.md
@@ -1,0 +1,77 @@
+# ADR-028: eslint-plugin-jsdoc enforces the existing JSDoc convention
+
+**Date**: 2026-08-23
+**Status**: Accepted
+
+## Context
+
+`assets/javascripts/AGENTS.md` already documented a convention — "Document
+every class and every non-trivial method with JSDoc (`@param`, `@returns`,
+and a one-line description)" — but nothing in `eslint.config.js` checked it.
+Compliance depended entirely on manual review, and in practice about 14 of
+25 files had partial JSDoc coverage with no consistent enforcement of
+`@param`/`@returns` descriptions or JSDoc syntax validity.
+
+## Decision
+
+- Add `eslint-plugin-jsdoc` as a dev dependency and apply its
+  `flat/recommended` rule set to the `assets/javascripts/**` block in
+  `eslint.config.js`, scoped there only (not `test/javascript/**`, where
+  Vitest's `describe`/`it` structure isn't the kind of API surface this
+  convention targets).
+- Per this repo's established policy (ADR-027: warnings are routinely
+  ignored, so start at "error" with a truthful baseline instead), every
+  `jsdoc/*` rule from the recommended preset — which ships at `"warn"` — is
+  promoted to `"error"` via a small map in `eslint.config.js`, rather than
+  listed rule-by-rule, so a future plugin upgrade that adds a rule to the
+  preset inherits the same policy automatically.
+- `jsdoc/require-jsdoc`'s default `require` only checks top-level `function`
+  declarations. Widened to also require documentation on `ClassDeclaration`,
+  `ClassExpression`, and `MethodDefinition` (ES6 class methods) to match
+  "every class and every non-trivial method". Additionally targets the
+  `foo = function () {}` class-field method style used throughout this
+  codebase (e.g. `ai_helper.js`'s `set_form_handlers`, `call_llm`,
+  `fold_chat`) via `contexts: ["PropertyDefinition > FunctionExpression",
+  "PropertyDefinition > ArrowFunctionExpression"]` — deliberately narrower
+  than the blanket `require: { FunctionExpression: true }` option, which
+  would also flag every nested callback assigned to a property (e.g.
+  `xhr.onload = function () {}` inside a method body). Those are
+  implementation detail, not the class/method API surface the convention
+  means to document, and requiring JSDoc on them would produce noise
+  disproportionate to their value (250+ violations measured vs. 182 with
+  the narrower scope).
+- All ~182 pre-existing violations measured at adoption (missing JSDoc
+  blocks, missing `@param`/`@returns` descriptions, `Object`/`String` type
+  names where `jsdoc/check-types` prefers lowercase `object`/`string`) were
+  fixed in the same change — consistent with ADR-027's approach to
+  pass/fail rules with no meaningful "threshold" to ratchet: fix directly
+  rather than start at `"warn"`.
+
+## Consequences
+
+- `npm run lint` now fails on a class, method, or class-field method that's
+  missing a JSDoc block, or on a `@param`/`@returns` missing a description
+  or using a non-standard type name — from this change onward, not just as
+  a documented-but-unenforced convention.
+- Nested function expressions and arrow-function callbacks are still not
+  required to carry JSDoc, matching AGENTS.md's "non-trivial method" scope
+  rather than every closure in the codebase.
+- A new file/class/method must be documented when it's added, not
+  retrofitted later — the same ratchet-adjacent expectation as ADR-027's
+  size/complexity rules.
+
+## Alternatives Considered
+
+- **Adopt `flat/recommended`'s rules and `require-jsdoc` defaults as-is (no
+  `require`/`contexts` widening)**: rejected — its default `require` only
+  covers top-level `function` declarations, so it would have left every
+  class, ES6 method, and class-field method in the codebase unchecked,
+  missing the actual convention in AGENTS.md.
+- **`require: { FunctionExpression: true }` instead of the narrower
+  `contexts` targeting**: rejected — flags every nested callback assigned to
+  a property, not just class-field methods, producing ~250 violations
+  instead of 182, with the excess being implementation-detail closures
+  AGENTS.md's convention was never meant to cover.
+- **Add the rules as `"warn"` until the codebase catches up**: rejected for
+  the same reason as ADR-027 — warnings are routinely ignored in practice,
+  and the 182 violations were small enough to fix directly in the same PR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,3 +79,5 @@ Briefly describe alternatives that were rejected and why.
 | [024](./024-javascript-coverage-sent-to-codecov-informational-only.md) | JavaScript coverage is uploaded to Codecov as an informational-only flag | Accepted |
 | [025](./025-erb-js-bridge-value-passing-pattern.md) | ERB-JS bridge value passing pattern (data-* attributes + init call) | Accepted |
 | [026](./026-shared-js-helper-extraction-threshold.md) | Shared JS helper extraction threshold (3+ occurrences or substantively identical) | Accepted |
+| [027](./027-eslint-quality-rule-ratchet.md) | ESLint naming/explicitness/size/complexity rules start at a measured baseline and ratchet down | Accepted |
+| [028](./028-eslint-plugin-jsdoc-enforcement.md) | eslint-plugin-jsdoc enforces the existing JSDoc convention | Accepted |

--- a/docs/javascript_quality_tooling.md
+++ b/docs/javascript_quality_tooling.md
@@ -72,6 +72,15 @@ as the coverage threshold below. See
 [ADR-027](adr/027-eslint-quality-rule-ratchet.md) for the measured baseline
 and full rationale.
 
+## JSDoc enforcement
+
+`eslint-plugin-jsdoc`'s `flat/recommended` rules (all promoted to `"error"`)
+check every class, ES6 class method, and `foo = function () {}` class-field
+method for a JSDoc block with a description and `@param`/`@returns`
+descriptions. See
+[ADR-028](adr/028-eslint-plugin-jsdoc-enforcement.md) for the exact scope
+and why nested callbacks are excluded.
+
 ## Coverage threshold ratchet
 
 `vitest.config.js`'s `coverage.thresholds.lines` starts at the coverage

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,24 @@
 import js from "@eslint/js";
+import jsdoc from "eslint-plugin-jsdoc";
 import globals from "globals";
+
+// This repo's lint rules are enforced as "error", not "warn" (see ADR-027:
+// warnings are routinely ignored, so a truthful baseline at "error" gives
+// the same regression signal without that risk). eslint-plugin-jsdoc's
+// recommended preset ships every rule at "warn"; promote them all to
+// "error" here rather than one-by-one, so a future plugin upgrade that adds
+// a rule to the preset inherits the same policy automatically.
+const jsdocRecommendedRules = Object.fromEntries(
+  Object.entries(jsdoc.configs["flat/recommended"].rules).map(([rule, severity]) => [
+    rule,
+    severity === "warn" ? "error" : severity,
+  ]),
+);
 
 export default [
   {
     files: ["assets/javascripts/**/*.js"],
+    plugins: { jsdoc },
     languageOptions: {
       sourceType: "script",
       globals: {
@@ -25,6 +40,30 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
+      ...jsdocRecommendedRules,
+      // AGENTS.md requires JSDoc on every class and non-trivial method; the
+      // recommended preset's default `require` only covers top-level
+      // `function` declarations, so widen it to classes, ES6 class methods,
+      // and the `foo = function () {}` class-field method style used
+      // throughout this codebase (see ai_helper.js). Deliberately narrower
+      // than `require: { FunctionExpression: true }`: that also flags every
+      // nested callback assigned to a property (e.g. `xhr.onload = function
+      // () {}`), which is implementation detail, not the "class/method" API
+      // surface AGENTS.md means to document. Targeting
+      // `PropertyDefinition > FunctionExpression` via `contexts` instead
+      // catches only a class-field method's own top-level assignment.
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            ClassDeclaration: true,
+            ClassExpression: true,
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+          },
+          contexts: ["PropertyDefinition > FunctionExpression", "PropertyDefinition > ArrowFunctionExpression"],
+        },
+      ],
       "no-var": "error",
       "prefer-const": "error",
       // Callback signatures sometimes need a positional parameter that isn't

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@eslint/js": "^10.0.1",
         "@vitest/coverage-v8": "^4.1.11",
         "eslint": "^10.9.0",
+        "eslint-plugin-jsdoc": "^64.2.1",
         "globals": "^17.11.0",
         "jsdom": "^30.0.1",
         "vitest": "^4.1.11"
@@ -261,6 +262,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.95.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.95.1.tgz",
+      "integrity": "sha512-LO/RI08Fo9bhXwB7Od9G+1j3eSNq63+ZS5CQO8YLXHbDg6kx6S/DhTeY0+Fc9uZrjK1zZSyTx8Sg5gv5DIoCnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.67.0",
+        "comment-parser": "1.4.8",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~9.1.2"
+      },
+      "engines": {
+        "node": "^22.22.2 || >=24.15.0"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -793,6 +821,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -838,6 +879,20 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.11",
@@ -1023,6 +1078,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.1.1.tgz",
+      "integrity": "sha512-sqRsNQBwbKLRX0jV5Cu5uzmtflf892n4Vukz7T659ebL4pz3mpOqCMU7lxMoBTFwnp10E3YB5ZcyHM41W5bcDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1086,6 +1151,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.8.tgz",
+      "integrity": "sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -1285,6 +1360,48 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "64.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.2.1.tgz",
+      "integrity": "sha512-6GpSYxLPcbMw38S94Cngrgs1Zv8yLinQS1O17OxJVZ6deLbrMRCERUYQKceweSqEuG2kx5Amn4l3aKPkCp4geQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.95.1",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.1.1",
+        "comment-parser": "1.4.8",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^5.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^5.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || >=24.15.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {
@@ -1557,6 +1674,23 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -1666,6 +1800,19 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.1.2.tgz",
+      "integrity": "sha512-9EXymowgk1mb9RY1VxuwKc+AhaxfBk2CV0dWxgGM+l5RURTtiUoAx7MlKwcsiVcEXK5HEPa7FeH/tsRpqjEPRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9"
+      },
+      "engines": {
+        "node": "^22.22.2 || >=24.15.0"
+      }
     },
     "node_modules/jsdom": {
       "version": "30.0.1",
@@ -2146,6 +2293,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -2209,6 +2363,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -2329,6 +2500,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
@@ -2429,6 +2613,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-5.0.0.tgz",
+      "integrity": "sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2526,6 +2735,23 @@
       "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
-  "dependencies": {},
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "^4.1.11",
     "eslint": "^10.9.0",
+    "eslint-plugin-jsdoc": "^64.2.1",
     "globals": "^17.11.0",
     "jsdom": "^30.0.1",
     "vitest": "^4.1.11"


### PR DESCRIPTION
## Changes

- Add `eslint-plugin-jsdoc` and apply its `flat/recommended` rules to `assets/javascripts/**`, promoted to `"error"` (matches this repo's existing lint-rule policy — see ADR-027)
- Widen `jsdoc/require-jsdoc` to cover classes, ES6 class methods, and the `foo = function () {}` class-field method style already used throughout this codebase, without flagging nested implementation-detail callbacks
- Add missing JSDoc across all 21 affected files to satisfy the new rules (comment-only, no behavior changes)
- Document the decision and scoping rationale in ADR-028; update `assets/javascripts/AGENTS.md` and `docs/javascript_quality_tooling.md` accordingly

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 608/608 passed
- [x] `npm run test:coverage` — threshold maintained
- [x] `.devcontainer/regression-check.sh` — YARD 100% documented, RuboCop 0 offenses, full Redmine test suite 2560 runs / 0 failures / 0 errors