### PR TITLE
Allow search_issues to search without a project_id

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/048-fix-html-head-hook"
+  "feature_directory": "specs/049-search-issues-optional-project"
 }

--- a/docs/adr/029-search-issues-cross-project-scoping.md
+++ b/docs/adr/029-search-issues-cross-project-scoping.md
@@ -1,0 +1,48 @@
+# ADR-029: search_issues Cross-Project Scoping
+
+**Date**: 2026-08-24
+**Status**: Accepted
+
+## Context
+
+`search_issues` required `project_id`, which made it impossible to answer cross-project questions such as "which issues are assigned to me." Making `project_id` optional required deciding how to determine the set of projects a cross-project search may draw issues from.
+
+An earlier community contribution (PR #376, discarded — see spec.md Assumptions) attempted this by relying solely on `Issue.visible(User.current)` when `project_id` was omitted. The plugin maintainer rejected that approach during review:
+
+> This change would make issues from projects where AI Helper is not enabled part of the search results, which goes against this plugin's policy. Some projects do not want their information sent to an LLM, so issues from projects without AI Helper enabled must be excluded from the search.
+
+`Issue.visible` only enforces Redmine's standard `:view_issues` permission; it has no awareness of whether the `ai_helper` module is enabled for a project. Every other read path in this plugin (`accessible_project?` in `base_tools.rb`) treats "AI Helper module enabled + `:view_ai_helper` permission granted" as a mandatory gate before any project data reaches the LLM. A cross-project search that skipped this gate would silently leak issues from projects that opted out of AI Helper.
+
+The PR thread converged on a fix, proposed by the contributor and accepted by the maintainer:
+
+```ruby
+scope = Issue.visible(User.current).open
+if project_id
+  scope = scope.where(project_id: project_id)
+else
+  scope = scope.joins(:project).where(Project.allowed_to_condition(User.current, :view_ai_helper))
+end
+```
+
+`Project.allowed_to_condition(user, :view_ai_helper)` (Redmine core, `app/models/project.rb`) builds a single SQL condition that already encodes: project active status, an `EXISTS` check against `enabled_modules` for the module the permission belongs to (`ai_helper`, since `:view_ai_helper` is declared inside `project_module :ai_helper` in `init.rb`), and role-based permission grant (covering both public/non-member access and membership-based access). This is the SQL-level equivalent of `accessible_project?`, without loading every project into Ruby to test it one at a time.
+
+## Decision
+
+When `project_id` is omitted, `search_issues` scopes the query to projects satisfying `Project.allowed_to_condition(User.current, :view_ai_helper)`, combined with the existing `Issue.visible(User.current)` check. This applies to both the no-filter (open issues) path and the `IssueQueryBuilder` filter path (added to `@query.base_scope`, which already joins `projects`).
+
+When `project_id` is given, the existing single-project path (`@query.project = project`, `accessible_project?` guard) is left untouched — it is not reimplemented in terms of `allowed_to_condition`.
+
+The full PR #376 diff (including its "no module check" no-condition case) is not reused; only the scoping technique agreed upon in its review discussion is.
+
+## Consequences
+
+- **Positive**: Cross-project search cannot return issues from projects that have not opted into AI Helper, closing the gap PR #376's initial version left open.
+- **Positive**: Scoping is a single SQL condition (`EXISTS` + `IN`/`OR` over role-assigned project IDs), not an N-project Ruby-side permission check, so cost does not grow linearly with the number of projects in Ruby-land.
+- **Positive**: When the current user has no `:view_ai_helper`-granted role anywhere, `Project.allowed_to_condition` returns the literal condition `"1=0"`, so the search naturally returns zero results without needing an explicit empty-project-list branch.
+- **Negative**: The single-project and cross-project paths now use two different mechanisms to reach an equivalent guarantee (`accessible_project?` in Ruby vs. `Project.allowed_to_condition` in SQL). This is intentional — see Alternatives Considered — but means a future reader must understand both instead of one.
+
+## Alternatives Considered
+
+- **Reuse `Project.all.select { |p| accessible_project?(p) }.map(&:id)`** (the pattern already used by `list_projects` in `project_tools.rb`) and pass the resulting ID array as an `IN` filter: works, but loads and checks every project row in Ruby on every cross-project search. Rejected in favor of the SQL condition agreed upon in the PR #376 review.
+- **Ship PR #376 as originally written** (`Issue.visible` only, no module-enabled check): rejected by the maintainer during that PR's review — it would leak issues from AI-Helper-disabled projects to the LLM, violating this plugin's core data-handling policy.
+- **Unify the single-project and cross-project paths** by always leaving `@query.project` nil and using an explicit `project_id` filter or `Project.allowed_to_condition` even when `project_id` is given: rejected because `@query.project` being set also affects unrelated `IssueQuery` behavior (subproject inclusion via `Setting.display_subprojects_issues?`, `category_id` filter availability, `rolled_up_custom_fields` vs. all custom fields — see spec.md FR-005 and this feature's research.md R2). Touching the single-project path risked changing its existing, already-relied-upon behavior for no benefit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,3 +81,4 @@ Briefly describe alternatives that were rejected and why.
 | [026](./026-shared-js-helper-extraction-threshold.md) | Shared JS helper extraction threshold (3+ occurrences or substantively identical) | Accepted |
 | [027](./027-eslint-quality-rule-ratchet.md) | ESLint naming/explicitness/size/complexity rules start at a measured baseline and ratchet down | Accepted |
 | [028](./028-eslint-plugin-jsdoc-enforcement.md) | eslint-plugin-jsdoc enforces the existing JSDoc convention | Accepted |
+| [029](./029-search-issues-cross-project-scoping.md) | search_issues cross-project scoping | Accepted |

--- a/lib/redmine_ai_helper/tools/issue_search_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_search_tools.rb
@@ -8,8 +8,8 @@ module RedmineAiHelper
       # related-object sorting (e.g. assignee name) is out of scope.
       SUPPORTED_SORT_FIELDS = %w[id created_on updated_on due_date start_date done_ratio].freeze
 
-      define_function :search_issues, description: "Search issues based on the filter conditions and return matching issues. For search items with '_id', specify the ID instead of the name of the search target. If you do not know the ID, you need to call capable_issue_properties in advance to obtain the ID. Default limit is 50 issues. Only projects with the AI Helper module enabled can be searched." do
-        property :project_id, type: "integer", description: "The project ID of the project to search in. Only projects with the AI Helper module enabled can be searched.", required: true
+      define_function :search_issues, description: "Search issues based on the filter conditions and return matching issues. For search items with '_id', specify the ID instead of the name of the search target. If you do not know the ID, you need to call capable_issue_properties in advance to obtain the ID. Default limit is 50 issues. Only projects with the AI Helper module enabled can be searched. Omit project_id to search across all projects that have the AI Helper module enabled and are accessible to the current user." do
+        property :project_id, type: "integer", description: "The project ID of the project to search in. Only projects with the AI Helper module enabled can be searched. Omit this to search across all projects that have the AI Helper module enabled and are accessible to the current user.", required: false
         property :limit, type: "integer", description: "Maximum number of issues to return. Default is 50.", required: false
         property :fields, type: "array", description: "Search fields for the issue." do
           item type: "object", description: "Search field for the issue." do
@@ -80,7 +80,7 @@ module RedmineAiHelper
         end
       end
       # Search issues based on filter conditions and return matching issues
-      # @param project_id [Integer] The project ID of the project to search in. The project must have the ai_helper module enabled and be accessible to the current user.
+      # @param project_id [Integer, nil] The project ID of the project to search in. The project must have the ai_helper module enabled and be accessible to the current user. When omitted, searches across all projects that have the ai_helper module enabled and are accessible to the current user.
       # @param limit [Integer] Maximum number of issues to return. Default is 50.
       # @param fields [Array] Search fields for the issue.
       # @param date_fields [Array] Date search fields for the issue.
@@ -91,13 +91,9 @@ module RedmineAiHelper
       # @param custom_fields [Array] Custom field search filters.
       # @param sort [Hash] Sort order with :field (one of SUPPORTED_SORT_FIELDS) and optional :direction (asc/desc, default desc). Defaults to id descending when omitted.
       # @return [Hash] A hash containing issues array and total_count.
-      # @raise [RuntimeError] if project_id is missing, or the project is not accessible with the ai_helper module enabled.
-      # @raise [ActiveRecord::RecordNotFound] if no project matches project_id.
-      def search_issues(project_id:, limit: 50, fields: [], date_fields: [], time_fields: [], number_fields: [], text_fields: [], status_field: [], custom_fields: [], sort: nil)
-        # The LLM occasionally omits required parameters; without a project there is
-        # nothing to search, so fail instead of guessing a target.
-        raise "project_id is required" if project_id.nil?
-
+      # @raise [RuntimeError] if project_id is given but the project is not accessible with the ai_helper module enabled.
+      # @raise [ActiveRecord::RecordNotFound] if project_id is given but no project matches it.
+      def search_issues(project_id: nil, limit: 50, fields: [], date_fields: [], time_fields: [], number_fields: [], text_fields: [], status_field: [], custom_fields: [], sort: nil)
         fields = deep_symbolize_array(fields)
         date_fields = deep_symbolize_array(date_fields)
         time_fields = deep_symbolize_array(time_fields)
@@ -108,18 +104,23 @@ module RedmineAiHelper
         sort = normalize_sort_param(deep_symbolize_hash(sort))
 
         limit = [ limit.to_i, 1 ].max
-        project = Project.find(project_id)
-        # Guard both search paths at once: projects without the ai_helper module (or
-        # without access for the current user) must never expose their issues.
-        raise "ai_helper is not enabled for project: id = #{project_id}" unless accessible_project?(project)
+        project = nil
+        if project_id
+          project = Project.find(project_id)
+          # Guard both search paths at once: projects without the ai_helper module (or
+          # without access for the current user) must never expose their issues.
+          raise "ai_helper is not enabled for project: id = #{project_id}" unless accessible_project?(project)
+        end
 
         if fields.empty? && date_fields.empty? && time_fields.empty? && number_fields.empty? && text_fields.empty? && status_field.empty? && custom_fields.empty?
-          # No conditions: return open visible issues for the project (same as Redmine default)
+          # No conditions: return open visible issues for the project (same as Redmine default).
+          # Without a project, scope to all projects the current user may search via AI Helper.
+          scope = Issue.visible(User.current).open
+          scope = project ? scope.where(project_id: project.id) : scope.where(Project.allowed_to_condition(User.current, :view_ai_helper))
           order = sort ? { sort[:field] => sort[:direction] } : { id: :desc }
-          issues = Issue.visible(User.current).open.where(project_id: project_id)
-                        .includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
+          issues = scope.includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
                         .order(order).limit(limit)
-          total_count = Issue.visible(User.current).open.where(project_id: project_id).count
+          total_count = scope.count
           return { issues: format_issues(issues), total_count: total_count }
         end
 
@@ -127,9 +128,11 @@ module RedmineAiHelper
         raise(validate_errors.join("\n")) if validate_errors.length > 0
 
         params = { fields: [], operators: {}, values: {} }
-        params[:fields] << "project_id"
-        params[:operators]["project_id"] = "="
-        params[:values]["project_id"] = [ project_id.to_s ]
+        if project
+          params[:fields] << "project_id"
+          params[:operators]["project_id"] = "="
+          params[:values]["project_id"] = [ project_id.to_s ]
+        end
 
         fields.each do |field|
           params[:fields] << field[:field_name]
@@ -369,30 +372,30 @@ module RedmineAiHelper
         end
 
         # Execute the search and return issues
-        # @param project [Project] The project to search in
+        # @param project [Project, nil] The project to search in. When nil, searches across all projects accessible to the user via AI Helper.
         # @param user [User] The user to check visibility for
         # @param limit [Integer] Maximum number of issues to return
         # @return [Array<Issue>] Array of visible issues
         def execute(project, user: User.current, limit: 50)
           setup_query(project, user)
-          scope = @query.base_scope
+          scope = cross_project_scope(project, @query.base_scope, user)
           scope.includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
                .reorder(@sort[:field] => @sort[:direction]).limit(limit).to_a
         end
 
         # Returns the total count of matching issues
-        # @param project [Project] The project to search in
+        # @param project [Project, nil] The project to search in. When nil, searches across all projects accessible to the user via AI Helper.
         # @param user [User] The user for visibility check
         # @return [Integer] Total count of matching issues
         def count(project, user: User.current)
           setup_query(project, user)
-          @query.issue_count
+          cross_project_scope(project, @query.base_scope, user).count
         end
 
         private
 
         # Setup query with project and filters
-        # @param project [Project] The project to search in
+        # @param project [Project, nil] The project to search in
         # @param user [User] The user for visibility check
         # @return [void]
         def setup_query(project, user)
@@ -403,6 +406,17 @@ module RedmineAiHelper
           apply_filters
           apply_custom_field_filters
           @query_setup_done = true
+        end
+
+        # Restrict the base scope to AI-Helper-accessible projects when no single project was given
+        # @param project [Project, nil] The project passed to execute/count
+        # @param scope [ActiveRecord::Relation] The query's base scope
+        # @param user [User] The user for visibility check
+        # @return [ActiveRecord::Relation] The (possibly restricted) scope
+        def cross_project_scope(project, scope, user)
+          return scope if project
+
+          scope.where(Project.allowed_to_condition(user, :view_ai_helper))
         end
       end
     end

--- a/lib/redmine_ai_helper/tools/issue_search_tools.rb
+++ b/lib/redmine_ai_helper/tools/issue_search_tools.rb
@@ -116,7 +116,7 @@ module RedmineAiHelper
           # No conditions: return open visible issues for the project (same as Redmine default).
           # Without a project, scope to all projects the current user may search via AI Helper.
           scope = Issue.visible(User.current).open
-          scope = project ? scope.where(project_id: project.id) : scope.where(Project.allowed_to_condition(User.current, :view_ai_helper))
+          scope = project ? scope.where(project_id: project.id) : scope.joins(:project).where(Project.allowed_to_condition(User.current, :view_ai_helper))
           order = sort ? { sort[:field] => sort[:direction] } : { id: :desc }
           issues = scope.includes(:status, :priority, :tracker, :assigned_to, :author, :custom_values)
                         .order(order).limit(limit)
@@ -389,7 +389,7 @@ module RedmineAiHelper
         # @return [Integer] Total count of matching issues
         def count(project, user: User.current)
           setup_query(project, user)
-          cross_project_scope(project, @query.base_scope, user).count
+          cross_project_scope(project, @query.base_scope, user).distinct.count(:id)
         end
 
         private

--- a/test/unit/tools/issue_search_tools_test.rb
+++ b/test/unit/tools/issue_search_tools_test.rb
@@ -545,6 +545,7 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
       assert_includes ids, matching1.id
       assert_includes ids, matching2.id
       assert_not_includes ids, non_matching.id
+      assert_operator result[:total_count], :>=, 2
     ensure
       matching1&.destroy
       matching2&.destroy
@@ -665,6 +666,7 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
 
       assert_includes ids, matching_issue.id
       assert_not_includes ids, non_matching_issue.id
+      assert_operator result[:total_count], :>=, 1
     ensure
       matching_issue&.destroy
       non_matching_issue&.destroy

--- a/test/unit/tools/issue_search_tools_test.rb
+++ b/test/unit/tools/issue_search_tools_test.rb
@@ -315,8 +315,8 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
       end
     end
 
-    should "raise an error when project_id is not given" do
-      assert_raises(RuntimeError) do
+    should "not raise when project_id is omitted" do
+      assert_nothing_raised do
         @provider.search_issues(project_id: nil)
       end
     end
@@ -334,6 +334,16 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
 
       assert_match(/AI Helper module enabled/, schema[:function][:description])
       assert_match(/AI Helper module enabled/, schema[:function][:parameters][:properties][:project_id][:description])
+    end
+
+    # T015
+    should "state in the tool description that omitting project_id searches across accessible ai_helper enabled projects" do
+      schema = RedmineAiHelper::Tools::IssueSearchTools.function_schemas.to_openai_format.find do |f|
+        f[:function][:name].end_with?("__search_issues")
+      end
+
+      assert_match(/omit/i, schema[:function][:description])
+      assert_match(/omit/i, schema[:function][:parameters][:properties][:project_id][:description])
     end
   end
 
@@ -477,6 +487,188 @@ class IssueSearchToolsTest < ActiveSupport::TestCase
 
       assert_match(/asc/i, error.message)
       assert_match(/desc/i, error.message)
+    end
+  end
+
+  context "search_issues cross-project (project_id omitted)" do
+    setup do
+      @project1 = Project.find(1)
+      @project2 = Project.find(2)
+      @tracker = Tracker.find(1)
+      @other_tracker = Tracker.find(2)
+      @user = User.find(2)
+      @previous_user = User.current
+      User.current = @user
+
+      # jsmith (user 2) holds role 1 on project 1 (view_ai_helper granted in top-level setup)
+      # and role 2 on project 2; grant the same permission there for a second accessible project.
+      EnabledModule.create!(project_id: 2, name: "ai_helper")
+      Role.find(2).add_permission!(:view_ai_helper)
+    end
+
+    teardown do
+      User.current = @previous_user
+    end
+
+    # T003
+    should "return issues from multiple ai_helper enabled projects when project_id is omitted" do
+      issue1 = Issue.create!(project: @project1, tracker: @tracker, subject: "Cross Project Issue 1",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+      issue2 = Issue.create!(project: @project2, tracker: @tracker, subject: "Cross Project Issue 2",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+
+      result = @provider.search_issues(project_id: nil)
+      ids = result[:issues].map { |i| i[:id] }
+
+      assert_includes ids, issue1.id
+      assert_includes ids, issue2.id
+    ensure
+      issue1&.destroy
+      issue2&.destroy
+    end
+
+    # T004
+    should "return only matching issues across multiple projects when a filter is applied and project_id is omitted" do
+      matching1 = Issue.create!(project: @project1, tracker: @tracker, subject: "Matching In Project 1",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+      matching2 = Issue.create!(project: @project2, tracker: @tracker, subject: "Matching In Project 2",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+      non_matching = Issue.create!(project: @project2, tracker: @other_tracker, subject: "Non Matching Tracker",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+
+      result = @provider.search_issues(
+        project_id: nil,
+        fields: [ { field_name: "tracker_id", operator: "=", values: [ @tracker.id.to_s ] } ]
+      )
+      ids = result[:issues].map { |i| i[:id] }
+
+      assert_includes ids, matching1.id
+      assert_includes ids, matching2.id
+      assert_not_includes ids, non_matching.id
+    ensure
+      matching1&.destroy
+      matching2&.destroy
+      non_matching&.destroy
+    end
+
+    # T009
+    should "exclude issues from a project the user cannot view when project_id is omitted" do
+      private_tracker = Tracker.create!(name: "PrivateTracker#{Time.now.to_i}#{rand(10000)}", default_status: IssueStatus.first)
+      private_project = Project.create!(
+        name: "Cross Private Test",
+        identifier: "cross-private-test-#{Time.now.to_i}#{rand(10000)}",
+        is_public: false
+      )
+      private_project.trackers << private_tracker unless private_project.trackers.include?(private_tracker)
+      EnabledModule.create!(project_id: private_project.id, name: "ai_helper")
+
+      hidden_issue = Issue.create!(
+        project: private_project, tracker: private_tracker, subject: "Hidden From Cross Search",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first
+      )
+
+      result = @provider.search_issues(project_id: nil)
+      ids = result[:issues].map { |i| i[:id] }
+
+      assert_not_includes ids, hidden_issue.id
+    ensure
+      hidden_issue&.destroy
+      private_project&.destroy
+      private_tracker&.destroy
+    end
+
+    # T010
+    should "exclude issues from a viewable project whose ai_helper module is disabled when project_id is omitted" do
+      plain_tracker = Tracker.create!(name: "PlainTracker#{Time.now.to_i}#{rand(10000)}", default_status: IssueStatus.first)
+      plain_project = Project.create!(
+        name: "Cross No Module Test",
+        identifier: "cross-no-module-test-#{Time.now.to_i}#{rand(10000)}",
+        is_public: true
+      )
+      plain_project.trackers << plain_tracker unless plain_project.trackers.include?(plain_tracker)
+      # Deliberately do not enable the ai_helper module for this project.
+
+      excluded_issue = Issue.create!(
+        project: plain_project, tracker: plain_tracker, subject: "Excluded No Module Issue",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first
+      )
+
+      result = @provider.search_issues(project_id: nil)
+      ids = result[:issues].map { |i| i[:id] }
+
+      assert_not_includes ids, excluded_issue.id
+    ensure
+      excluded_issue&.destroy
+      plain_project&.destroy
+      plain_tracker&.destroy
+    end
+
+    # T011
+    should "return an empty result without error when no project is accessible via ai_helper" do
+      Role.find(1).remove_permission!(:view_ai_helper)
+      Role.find(2).remove_permission!(:view_ai_helper)
+
+      result = @provider.search_issues(project_id: nil)
+
+      assert_equal [], result[:issues]
+      assert_equal 0, result[:total_count]
+    end
+
+    # T013
+    should "apply sort and limit across multiple projects when project_id is omitted" do
+      now = Time.current
+      issue_old = Issue.create!(project: @project1, tracker: @tracker, subject: "Cross Sort Old",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+      issue_mid = Issue.create!(project: @project2, tracker: @tracker, subject: "Cross Sort Mid",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+      issue_new = Issue.create!(project: @project1, tracker: @tracker, subject: "Cross Sort New",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first)
+      [ issue_old, issue_mid, issue_new ].each(&:reload)
+      issue_old.update_column(:created_on, now - 3.hours)
+      issue_mid.update_column(:created_on, now - 2.hours)
+      issue_new.update_column(:created_on, now - 1.hour)
+
+      result = @provider.search_issues(project_id: nil, sort: { field: "created_on", direction: "desc" }, limit: 2)
+      ids = result[:issues].map { |i| i[:id] }
+      our_ids = ids.select { |id| [ issue_old.id, issue_mid.id, issue_new.id ].include?(id) }
+
+      assert_equal [ issue_new.id, issue_mid.id ], our_ids
+      assert_operator result[:issues].length, :<=, 2
+    ensure
+      issue_old&.destroy
+      issue_mid&.destroy
+      issue_new&.destroy
+    end
+
+    # T014
+    should "apply a custom_fields filter across multiple projects, excluding issues whose tracker lacks that field" do
+      cf = CustomField.find(1) # "Database" custom field, associated only with tracker 1
+      tracker_without_cf = Tracker.create!(name: "NoCFTracker#{Time.now.to_i}#{rand(10000)}", default_status: IssueStatus.first)
+      @project2.trackers << tracker_without_cf unless @project2.trackers.include?(tracker_without_cf)
+
+      matching_issue = Issue.create!(
+        project: @project1, tracker: @tracker, subject: "Has Database CF",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first,
+        custom_field_values: { cf.id => "MySQL" }
+      )
+
+      non_matching_issue = Issue.create!(
+        project: @project2, tracker: tracker_without_cf, subject: "No Database CF",
+        author: @user, status: IssueStatus.first, priority: IssuePriority.first
+      )
+
+      result = @provider.search_issues(
+        project_id: nil,
+        custom_fields: [ { field_id: cf.id, operator: "=", values: [ "MySQL" ] } ]
+      )
+      ids = result[:issues].map { |i| i[:id] }
+
+      assert_includes ids, matching_issue.id
+      assert_not_includes ids, non_matching_issue.id
+    ensure
+      matching_issue&.destroy
+      non_matching_issue&.destroy
+      tracker_without_cf&.destroy
     end
   end
 

--- a/wiki/INDEX.md
+++ b/wiki/INDEX.md
@@ -16,6 +16,7 @@ page files, not here.
 - [Completion Suppression Scope](./pages/completion-suppression-scope.md) — ADR-019 and ADR-021: why no-change suppression lasts only while a suggestion is displayed, why `clearSuggestion` owns the teardown, and why accept must not write a snapshot.
 - [Testing Classic Scripts via Dynamic Import](./pages/classic-script-testing-strategy.md) — why tests load target files as side-effect-only dynamic imports, the 4 files needing a new `window.X` line, and the `ai_helper.js` `var`→`window.ai_helper` fix.
 - [JavaScript Coverage Ratchet Policy](./pages/js-coverage-ratchet-policy.md) — why the 90% lines threshold is a literal in `vitest.config.js`, raised only, and why it's separate from Ruby's 95%.
+- [search_issues Cross-Project Scoping](./pages/search-issues-cross-project-scoping.md) — why omitting `project_id` scopes to `Project.allowed_to_condition(user, :view_ai_helper)` instead of plain `Issue.visible`, and why the single-project path stays untouched.
 
 ## component
 - [Chat Channel Gateway Architecture](./pages/chat-channel-gateway-architecture.md) — core + adapters structure, capability declaration, and gateway operational model.

--- a/wiki/pages/search-issues-cross-project-scoping.md
+++ b/wiki/pages/search-issues-cross-project-scoping.md
@@ -1,0 +1,80 @@
+---
+title: search_issues Cross-Project Scoping
+type: decision
+sources: [S026]
+updated: 2026-08-24
+---
+
+# search_issues Cross-Project Scoping
+
+`search_issues` (`IssueSearchTools`, part of the [Tool System](./tool-system.md))
+originally required `project_id`, which made cross-project questions like
+"which issues are assigned to me" impossible to answer in one call. An earlier
+community contribution (PR #376) tried making `project_id` optional by relying
+solely on `Issue.visible(User.current)` for the no-project case. The
+maintainer rejected that version during review: it would let issues from
+projects that never enabled the `ai_helper` module leak into search results
+(S026).
+
+## Decision
+
+`project_id` is optional (`required: false`). When omitted, both search paths
+scope to projects satisfying `Project.allowed_to_condition(User.current,
+:view_ai_helper)`, combined with the existing `Issue.visible(User.current)`
+check — the SQL-level equivalent of the `accessible_project?` guard used when
+`project_id` **is** given (S026):
+
+```ruby
+scope = Issue.visible(User.current).open
+if project_id
+  scope = scope.where(project_id: project_id)
+else
+  scope = scope.joins(:project).where(Project.allowed_to_condition(User.current, :view_ai_helper))
+end
+```
+
+- **No-filter path**: `Issue.visible(User.current).open` already includes
+  `joins(:project)`, so the `allowed_to_condition` SQL fragment attaches
+  directly via `.where` (S026).
+- **Filter path (`IssueQueryBuilder`)**: `@query.base_scope` already joins
+  `projects`, so a private `cross_project_scope` helper adds the same
+  `.where` condition in both `execute` and `count`, only when `project` is
+  `nil` (S026).
+- **`project_id`-given path is untouched**: `@query.project = project` and
+  the `accessible_project?` guard keep working exactly as before — the two
+  paths intentionally use different mechanisms (Ruby-side `accessible_project?`
+  vs. SQL-side `allowed_to_condition`) to reach the same guarantee, because
+  unifying them by always leaving `@query.project` nil would change
+  `IssueQuery`'s implicit behavior (subproject inclusion via
+  `Setting.display_subprojects_issues?`, `category_id` filter availability,
+  `rolled_up_custom_fields` vs. all custom fields) for the single-project
+  case (S026).
+- **Zero accessible projects**: no explicit empty-list branch exists.
+  `Project.allowed_to_condition` returns the literal `"1=0"` when the current
+  user holds no role with `:view_ai_helper` anywhere, so the query naturally
+  returns zero results without raising (S026).
+- **`project_id: nil` is a valid input, not a missing-required-param error**:
+  the tool's `nil`-check guideline (raise for essential params) doesn't apply
+  here — `project_id` became genuinely optional, so the prior
+  `raise "project_id is required" if project_id.nil?` was removed (S026).
+
+Recorded as [ADR-029](../../docs/adr/029-search-issues-cross-project-scoping.md).
+
+## Rejected alternatives
+
+- **`Project.all.select { |p| accessible_project?(p) }.map(&:id)`** (the
+  pattern `list_projects` in `ProjectTools` already uses), passed as an `IN`
+  filter: works, but checks every project row in Ruby on every cross-project
+  search instead of one SQL `EXISTS` (S026).
+- **PR #376 as originally written** (`Issue.visible` only, no
+  module-enabled check): rejected by the maintainer — leaks issues from
+  AI-Helper-disabled projects to the LLM (S026).
+- **Unify both paths** by always leaving `@query.project` nil and filtering
+  by `project_id`/`allowed_to_condition` even when a project is given:
+  rejected — touching the single-project path risked changing its
+  already-relied-upon `IssueQuery` behavior for no benefit (S026).
+
+## Related
+
+- [Tool System](./tool-system.md) — `accessible_project?`, the DSL's
+  `required:` flag, and where this tool provider sits.

--- a/wiki/pages/tool-system.md
+++ b/wiki/pages/tool-system.md
@@ -1,8 +1,8 @@
 ---
 title: Tool System
 type: component
-sources: [S008, S016]
-updated: 2026-08-07
+sources: [S008, S016, S026]
+updated: 2026-08-24
 ---
 
 # Tool System
@@ -30,7 +30,12 @@ providers' functions it may call — a per-agent permission boundary (S008).
 ## Security & read-only
 
 - **Read checks**: read tools validate access with `issue.visible?` or
-  `accessible_project?` (S008).
+  `accessible_project?` (S008). A tool's project scope can also be made
+  *optional*: `IssueSearchTools#search_issues`'s `project_id` is
+  `required: false`, and when omitted it scopes to
+  `Project.allowed_to_condition(user, :view_ai_helper)` instead of a single
+  project's `accessible_project?` check — see
+  [search_issues Cross-Project Scoping](./search-issues-cross-project-scoping.md) (S026).
 - **Write checks**: write tools call `User.current.allowed_to?(:action, project)`
   (S008).
 - **Read-only mode**: because each mutating tool is tagged `write: true`, global
@@ -75,3 +80,4 @@ providers' functions it may call — a per-agent permission boundary (S008).
 - [Multi-Agent Architecture](./multi-agent-architecture.md) ·
   [MCP Integration](./mcp-integration.md) · [Vector Search](./vector-search.md)
 - [Agent Write-Capability Routing](./agent-write-capability-routing.md)
+- [search_issues Cross-Project Scoping](./search-issues-cross-project-scoping.md)

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -30,3 +30,4 @@ Sources are immutable inputs — the wiki never edits them.
 | S023 | docs/adr/021-snapshot-teardown-belongs-to-clear-suggestion.md | file | 2026-08-21 | 2026-08-21 | completion-suppression-scope.md, inline-completion-request-flow.md, completion-request-timeout-policy.md, js-test-convention.md |
 | S024 | specs/046-js-quality-tooling (research.md + plan.md) | feature-artifact | 2026-08-22 | 2026-08-22 | js-quality-tooling.md, classic-script-testing-strategy.md, js-coverage-ratchet-policy.md, js-test-convention.md |
 | S025 | docs/adr/024-javascript-coverage-sent-to-codecov-informational-only.md | file | 2026-08-22 | 2026-08-22 | js-coverage-ratchet-policy.md |
+| S026 | specs/049-search-issues-optional-project (research.md + plan.md) | feature-artifact | 2026-08-24 | 2026-08-24 | search-issues-cross-project-scoping.md, tool-system.md |


### PR DESCRIPTION
## Changes

- Make `project_id` optional in `search_issues`; when omitted, search spans all AI Helper-enabled projects the user can access
- Exclude issues from projects without view permission or with the AI Helper module disabled from cross-project results
- Add `total_count` assertions and cross-project test coverage; register ADR-029 documenting the scoping decision
- Ingest the cross-project scoping behavior into the wiki