### PR TITLE
Allow list_project_activities to search across all accessible projects

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/049-search-issues-optional-project"
+  "feature_directory": "specs/050-list-project-activities-optional-project"
 }

--- a/docs/adr/030-list-project-activities-cross-project-scoping.md
+++ b/docs/adr/030-list-project-activities-cross-project-scoping.md
@@ -16,11 +16,16 @@ That technique only works because `search_issues` queries a single `ActiveRecord
 When `project_id` is omitted, `list_project_activities` fetches events unscoped (`Fetcher.new(current_user, project: nil, author: author)`), then filters the resulting Ruby array in memory:
 
 ```ruby
-accessible_project_ids = Project.all.select { |p| accessible_project? p }.map(&:id)
-events = events.select { |event| accessible_project_ids.include?(event.project&.id) }
+accessible_project_ids = accessible_projects.map(&:id).to_set
+events = events.select { |event| accessible_project_ids.include?(event_project_id(event)) }
 ```
 
-This is the same pattern `list_projects` already uses (`Project.all.select { |p| accessible_project? p }`), reused rather than reimplemented. It runs after `fetcher.events` and before the existing `sort_by(&:event_datetime).reverse.first(limit)`, so `limit` is applied to the already-filtered set.
+This is the same pattern `list_projects` already used (`select { |p| accessible_project? p }`), reused rather than reimplemented — `accessible_project?` remains the single source of truth for the decision instead of being re-derived as SQL. It runs after `fetcher.events` and before the existing `sort_by(&:event_datetime).reverse.first(limit)`, so `limit` is applied to the already-filtered set.
+
+Two details keep the in-memory filter from scaling with instance size rather than with result size:
+
+- `accessible_projects` (`base_tools.rb`, shared with `list_projects`) narrows the candidate set with `Project.visible` in SQL and preloads `enabled_modules`, so the tool neither materializes every project on the instance nor issues one `enabled_modules` query per project inside `accessible_project?`.
+- `event_project_id(event)` reads `event.project_id` when the event model carries the foreign key (`Issue`, `News`, `Document`, …) and only falls back to `event.project&.id` for the models that do not (`Journal`, `Changeset`, `Message`, `WikiContentVersion`), avoiding a `project` association load per event.
 
 When `project_id` is given, the existing single-project path (`Fetcher.new(project: project, ...)`, `accessible_project?` guard) is left untouched.
 
@@ -28,7 +33,8 @@ When `project_id` is given, the existing single-project path (`Fetcher.new(proje
 
 - **Positive**: Cross-project activity listing cannot include activities from AI-Helper-disabled or inaccessible projects, matching the guarantee `accessible_project?` already provides for every single-project tool call.
 - **Positive**: No new judgment logic — the filter is the same `accessible_project?` check and `Array#select` pattern already used by `list_projects`.
-- **Negative**: `Project.all.select { |p| accessible_project? p }` evaluates every project in Ruby on every cross-project call (same cost `list_projects` already accepts), rather than a single SQL condition. This mirrors the "Alternatives Considered" tradeoff in ADR-029, but here it is the primary approach rather than the rejected alternative, because the SQL-`where` approach ADR-029 chose is not available: `Fetcher#events` returns a plain Ruby array of mixed model types with no shared relation to attach a `where` clause to.
+- **Negative**: the accessibility decision is still evaluated in Ruby, once per visible project, rather than as a single SQL condition. This mirrors the "Alternatives Considered" tradeoff in ADR-029, but here it is the primary approach rather than the rejected alternative, because the SQL-`where` approach ADR-029 chose is not available: `Fetcher#events` returns a plain Ruby array of mixed model types with no shared relation to attach a `where` clause to. `Project.visible` plus a preload bounds the cost to the projects the user can actually see, with a constant number of queries.
+- **Negative**: `Project.allowed_to_condition(User.current, :view_ai_helper)` was not used to replace `accessible_project?` outright, even though `search_issues` (ADR-029) uses exactly that condition. `:view_ai_helper` is not declared `read: true`, so `allowed_to_condition` restricts to `status = STATUS_ACTIVE`, while `accessible_project?` also admits closed (read-only but viewable) projects. Swapping in the SQL condition would silently drop closed projects' activities, so the two tools' scoping rules differ in that one respect.
 
 ## Alternatives Considered
 

--- a/docs/adr/030-list-project-activities-cross-project-scoping.md
+++ b/docs/adr/030-list-project-activities-cross-project-scoping.md
@@ -1,0 +1,36 @@
+# ADR-030: list_project_activities Cross-Project Scoping
+
+**Date**: 2026-08-24
+**Status**: Accepted
+
+## Context
+
+`search_issues` (ADR-029) made `project_id` optional by adding `Project.allowed_to_condition(User.current, :view_ai_helper)` as a SQL `where` clause on top of `Issue.visible`. `list_project_activities` needed the same "omit `project_id` to search across all AI-Helper-enabled, accessible projects" capability, so the natural first instinct was to reuse that SQL technique.
+
+That technique only works because `search_issues` queries a single `ActiveRecord::Relation` of `Issue`. `list_project_activities` is built on `Redmine::Activity::Fetcher#events`, which iterates every registered `acts_as_activity_provider` model (`Issue`, `Journal`, `News`, `Message`, `WikiContentVersion`, `Changeset`, `Attachment`, `Document`, etc.), calls each provider's own `find_events` (each with its own scope, its own permission, e.g. `:view_documents`, `:view_news`), and returns the results merged into a single **Ruby array** of heterogeneous model instances. There is no single `ActiveRecord::Relation` to attach a `where` clause to — the array is already materialized by the time `Fetcher#events` returns it, and its elements do not share a common table.
+
+`Fetcher#event_types` also only filters by permission when a `project` is given (`if @project` in `lib/redmine/activity/fetcher.rb`); when `project` is `nil`, every registered event type is included with no additional per-project gate. `Fetcher` and each provider's `find_events` still enforce their own per-model view permission (e.g. `Issue.visible`, `Document.visible`), but none of them know about the `ai_helper` module — the same gap ADR-029 closed for `search_issues`, and one this plugin's `accessible_project?` (`base_tools.rb`) exists specifically to close for every other tool.
+
+## Decision
+
+When `project_id` is omitted, `list_project_activities` fetches events unscoped (`Fetcher.new(current_user, project: nil, author: author)`), then filters the resulting Ruby array in memory:
+
+```ruby
+accessible_project_ids = Project.all.select { |p| accessible_project? p }.map(&:id)
+events = events.select { |event| accessible_project_ids.include?(event.project&.id) }
+```
+
+This is the same pattern `list_projects` already uses (`Project.all.select { |p| accessible_project? p }`), reused rather than reimplemented. It runs after `fetcher.events` and before the existing `sort_by(&:event_datetime).reverse.first(limit)`, so `limit` is applied to the already-filtered set.
+
+When `project_id` is given, the existing single-project path (`Fetcher.new(project: project, ...)`, `accessible_project?` guard) is left untouched.
+
+## Consequences
+
+- **Positive**: Cross-project activity listing cannot include activities from AI-Helper-disabled or inaccessible projects, matching the guarantee `accessible_project?` already provides for every single-project tool call.
+- **Positive**: No new judgment logic — the filter is the same `accessible_project?` check and `Array#select` pattern already used by `list_projects`.
+- **Negative**: `Project.all.select { |p| accessible_project? p }` evaluates every project in Ruby on every cross-project call (same cost `list_projects` already accepts), rather than a single SQL condition. This mirrors the "Alternatives Considered" tradeoff in ADR-029, but here it is the primary approach rather than the rejected alternative, because the SQL-`where` approach ADR-029 chose is not available: `Fetcher#events` returns a plain Ruby array of mixed model types with no shared relation to attach a `where` clause to.
+
+## Alternatives Considered
+
+- **Reuse ADR-029's SQL `where` technique** (`Project.allowed_to_condition`) by joining it into each provider's scope before calling `find_events`: not applicable here without changing `Redmine::Activity::Fetcher` or every `acts_as_activity_provider` model's scope, since none of them are queried through `list_project_activities`'s own relation — `Fetcher` owns that lookup and already returns a materialized array by the time control returns to this tool. Rejected as out of scope for this feature (`plan.md`: no new classes, no core changes).
+- **Filter by event type of provider's own `:permission` before calling `find_events`**: `Fetcher#event_types` already does this, but only when a `project` is present; extending it to also intersect with `ai_helper`-enabled projects when `project` is `nil` would require patching `Redmine::Activity::Fetcher` itself (a Redmine core class), which this plugin does not modify. Rejected for the same reason as above.

--- a/lib/redmine_ai_helper/base_tools.rb
+++ b/lib/redmine_ai_helper/base_tools.rb
@@ -371,6 +371,15 @@ module RedmineAiHelper
       User.current.allowed_to?({ controller: :ai_helper, action: :chat_form }, project)
     end
 
+    # All projects accessible via AI Helper, for tools that need to work across projects.
+    # #accessible_project? stays the source of truth for the decision, but the candidate set
+    # is narrowed to Project.visible in SQL and enabled_modules is preloaded, so a large
+    # instance neither materializes every project nor issues one query per project.
+    # @return [Array<Project>] The accessible projects.
+    def accessible_projects
+      Project.visible.preload(:enabled_modules).select { |p| accessible_project? p }
+    end
+
     private
 
     def deep_symbolize_array(arr)

--- a/lib/redmine_ai_helper/tools/project_tools.rb
+++ b/lib/redmine_ai_helper/tools/project_tools.rb
@@ -142,25 +142,31 @@ module RedmineAiHelper
         json
       end
 
-      define_function :list_project_activities, description: "List all activities of the project. It returns the activity ID, event_datetime, event_type, event_title, event_description, and event_url." do
-        property :project_id, type: "integer", description: "The project ID of the activities to return.", required: true
+      define_function :list_project_activities, description: "List all activities of the project. It returns the activity ID, event_datetime, event_type, event_title, event_description, event_url, and user_id (the ID of the user who performed the activity, or null if unknown). Omit project_id to list activities across all projects that have the AI Helper module enabled and are accessible to the current user." do
+        property :project_id, type: "integer", description: "The project ID of the activities to return. Omit this to list activities across all projects that have the AI Helper module enabled and are accessible to the current user.", required: false
         property :author_id, type: "integer", description: "The user ID of the author of the activity. If not specified, it will return all activities.", required: false
         property :limit, type: "integer", description: "The maximum number of activities to return. If not specified, it will return all activities.", required: false
         property :start_date, type: "string", description: "The start date of the activities to return.", required: false
         property :end_date, type: "string", description: "The end date of the activities to return. If not specified, it will return all activities.", required: false
       end
 
-      # List all activities of the project.
-      # @param project_id [Integer] The project ID of the activities to return.
+      # List all activities of the project. When project_id is omitted, activities are aggregated
+      # across all projects that have the AI Helper module enabled and are accessible to the current
+      # user (see #accessible_project?).
+      # @param project_id [Integer, nil] The project ID of the activities to return. Omit to list activities across all accessible AI-Helper-enabled projects.
       # @param author_id [Integer] The user ID of the author of the activity. If not specified, it will return all activities.
       # @param limit [Integer] The maximum number of activities to return. If not specified, it will return all activities.
       # @param start_date [DateTime] The start date of the activities to return.
       # @param end_date [DateTime] The end date of the activities to return. If not specified, it will return all activities.
-      # @return [Array<Hash>] An array of hashes containing activity information.
-      def list_project_activities(project_id:, author_id: nil, limit: nil, start_date: nil, end_date: nil)
-        project = Project.find(project_id)
-        return ToolResponse.create_error "Project not found" unless project
-        return ToolResponse.create_error "You don't have permission to view this project" unless accessible_project? project
+      # @return [RedmineAiHelper::ToolResponse] A ToolResponse whose value contains :activities, an array of hashes
+      #   each with id, event_datetime, event_type, event_title, event_description, event_url, and user_id (the ID
+      #   of the user who performed the activity, or nil if it cannot be determined).
+      def list_project_activities(project_id: nil, author_id: nil, limit: nil, start_date: nil, end_date: nil)
+        if project_id
+          project = Project.find(project_id)
+          return ToolResponse.create_error "Project not found" unless project
+          return ToolResponse.create_error "You don't have permission to view this project" unless accessible_project? project
+        end
 
         author = author_id ? User.find(author_id) : nil
         limit ||= 100
@@ -168,15 +174,16 @@ module RedmineAiHelper
         end_date ||= 1.day.from_now
 
         current_user = User.current
-        fetcher = Redmine::Activity::Fetcher.new(
-          current_user,
-          project: project,
-          author: author
-        )
+        fetcher = Redmine::Activity::Fetcher.new(current_user, project: project, author: author)
         ai_helper_logger.debug "current_user: #{current_user}, project: #{project}, author: #{author}, start_date: #{start_date}, end_date: #{end_date}, limit: #{limit}"
-        events = fetcher.events(start_date, end_date).sort_by(&:event_datetime).reverse.first(limit)
-        # events = fetcher.events(start_date, end_date, limit).sort_by(&:event_datetime)
-        # events = fetcher.events(start_date)
+        events = fetcher.events(start_date, end_date)
+
+        unless project
+          accessible_project_ids = Project.all.select { |p| accessible_project? p }.map(&:id)
+          events = events.select { |event| accessible_project_ids.include?(event.project&.id) }
+        end
+
+        events = events.sort_by(&:event_datetime).reverse.first(limit)
         list = []
         events.each do |event|
           list << {
@@ -185,7 +192,8 @@ module RedmineAiHelper
             event_type: event.event_type,
             event_title: event.event_title,
             event_description: event.event_description,
-            event_url: event.event_url
+            event_url: event.event_url,
+            user_id: event.event_author&.id
           }
         end
         json = { activities: list }

--- a/lib/redmine_ai_helper/tools/project_tools.rb
+++ b/lib/redmine_ai_helper/tools/project_tools.rb
@@ -163,7 +163,7 @@ module RedmineAiHelper
       #   of the user who performed the activity, or nil if it cannot be determined).
       def list_project_activities(project_id: nil, author_id: nil, limit: nil, start_date: nil, end_date: nil)
         if project_id
-          project = Project.find(project_id)
+          project = Project.find_by(id: project_id)
           return ToolResponse.create_error "Project not found" unless project
           return ToolResponse.create_error "You don't have permission to view this project" unless accessible_project? project
         end
@@ -193,7 +193,7 @@ module RedmineAiHelper
             event_title: event.event_title,
             event_description: event.event_description,
             event_url: event.event_url,
-            user_id: event.event_author&.id
+            user_id: event.event_author.is_a?(User) ? event.event_author.id : nil
           }
         end
         json = { activities: list }

--- a/lib/redmine_ai_helper/tools/project_tools.rb
+++ b/lib/redmine_ai_helper/tools/project_tools.rb
@@ -16,8 +16,7 @@ module RedmineAiHelper
       # @param dummy [String] Dummy property to satisfy the tool definition requirement.
       # @return [Array<Hash>] An array of hashes containing project information.
       def list_projects(dummy: nil) # rubocop:disable Lint/UnusedMethodArgument
-        projects = Project.all
-        list = projects.select { |p| accessible_project? p }.map do |project|
+        list = accessible_projects.map do |project|
           {
             id: project.id,
             name: project.name,
@@ -145,7 +144,7 @@ module RedmineAiHelper
       define_function :list_project_activities, description: "List all activities of the project. It returns the activity ID, event_datetime, event_type, event_title, event_description, event_url, and user_id (the ID of the user who performed the activity, or null if unknown). Omit project_id to list activities across all projects that have the AI Helper module enabled and are accessible to the current user." do
         property :project_id, type: "integer", description: "The project ID of the activities to return. Omit this to list activities across all projects that have the AI Helper module enabled and are accessible to the current user.", required: false
         property :author_id, type: "integer", description: "The user ID of the author of the activity. If not specified, it will return all activities.", required: false
-        property :limit, type: "integer", description: "The maximum number of activities to return. If not specified, it will return all activities.", required: false
+        property :limit, type: "integer", description: "The maximum number of activities to return. Defaults to 100 when not specified.", required: false
         property :start_date, type: "string", description: "The start date of the activities to return.", required: false
         property :end_date, type: "string", description: "The end date of the activities to return. If not specified, it will return all activities.", required: false
       end
@@ -155,7 +154,7 @@ module RedmineAiHelper
       # user (see #accessible_project?).
       # @param project_id [Integer, nil] The project ID of the activities to return. Omit to list activities across all accessible AI-Helper-enabled projects.
       # @param author_id [Integer] The user ID of the author of the activity. If not specified, it will return all activities.
-      # @param limit [Integer] The maximum number of activities to return. If not specified, it will return all activities.
+      # @param limit [Integer] The maximum number of activities to return. Defaults to 100 when not specified.
       # @param start_date [DateTime] The start date of the activities to return.
       # @param end_date [DateTime] The end date of the activities to return. If not specified, it will return all activities.
       # @return [RedmineAiHelper::ToolResponse] A ToolResponse whose value contains :activities, an array of hashes
@@ -179,8 +178,8 @@ module RedmineAiHelper
         events = fetcher.events(start_date, end_date)
 
         unless project
-          accessible_project_ids = Project.all.select { |p| accessible_project? p }.map(&:id)
-          events = events.select { |event| accessible_project_ids.include?(event.project&.id) }
+          accessible_project_ids = accessible_projects.map(&:id).to_set
+          events = events.select { |event| accessible_project_ids.include?(event_project_id(event)) }
         end
 
         events = events.sort_by(&:event_datetime).reverse.first(limit)
@@ -198,6 +197,14 @@ module RedmineAiHelper
         end
         json = { activities: list }
         ToolResponse.create_success json # TODO: Should just return json?
+      end
+
+      # Project ID of an activity event, without loading the project association when the
+      # event itself already carries the foreign key.
+      # @param event [Object] An activity event returned by Redmine::Activity::Fetcher.
+      # @return [Integer, nil] The project ID, or nil if it cannot be determined.
+      def event_project_id(event)
+        event.respond_to?(:project_id) ? event.project_id : event.project&.id
       end
 
       # Calculate repository metrics for a project within a specified date range.

--- a/test/unit/tools/project_tools_test.rb
+++ b/test/unit/tools/project_tools_test.rb
@@ -388,6 +388,47 @@ class ProjectToolsTest < ActiveSupport::TestCase
     assert_match(/omit/i, schema[:function][:parameters][:properties][:project_id][:description])
   end
 
+  def test_list_project_activities_limit_description_states_the_actual_default
+    schema = RedmineAiHelper::Tools::ProjectTools.function_schemas.to_openai_format.find do |f|
+      f[:function][:name].end_with?("__list_project_activities")
+    end
+    limit_description = schema[:function][:parameters][:properties][:limit][:description]
+
+    assert_match(/100/, limit_description)
+    assert_no_match(/all activities/i, limit_description)
+  end
+
+  def test_accessible_projects_excludes_inaccessible_projects
+    accessible_ids = @provider.accessible_projects.map(&:id)
+
+    assert_includes accessible_ids, 1 # ai_helper enabled and visible
+    assert_not_includes accessible_ids, 3 # ai_helper module not enabled
+  end
+
+  def test_event_project_id_prefers_the_foreign_key_over_the_association
+    project = Project.find(1)
+    issue = Issue.create!(
+      project: project, tracker: Tracker.find(1), subject: "Event Project Id Activity",
+      author: User.find(2), status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    assert_equal project.id, @provider.event_project_id(issue)
+  ensure
+    issue&.destroy
+  end
+
+  def test_event_project_id_falls_back_to_the_association
+    event = Struct.new(:project).new(Project.find(1))
+
+    assert_equal 1, @provider.event_project_id(event)
+  end
+
+  def test_event_project_id_is_nil_without_a_project
+    event = Struct.new(:project).new(nil)
+
+    assert_nil @provider.event_project_id(event)
+  end
+
   def test_list_projects_includes_required_fields
     response = @provider.list_projects()
 

--- a/test/unit/tools/project_tools_test.rb
+++ b/test/unit/tools/project_tools_test.rb
@@ -138,9 +138,10 @@ class ProjectToolsTest < ActiveSupport::TestCase
   end
 
   def test_list_project_activities_with_invalid_project_id
-    assert_raises(ActiveRecord::RecordNotFound) do
-      @provider.list_project_activities(project_id: 999)
-    end
+    response = @provider.list_project_activities(project_id: 999)
+
+    assert_equal "error", response.status
+    assert_match(/not found/i, response.error)
   end
 
   def test_list_project_activities_with_invalid_author_id
@@ -352,6 +353,29 @@ class ProjectToolsTest < ActiveSupport::TestCase
     assert_nil activity[:user_id]
   ensure
     document&.destroy
+  end
+
+  def test_list_project_activities_user_id_is_nil_for_changeset_with_unmapped_committer
+    repository = Repository.find(10) # belongs to project 1
+    changeset = Changeset.create!(
+      repository: repository,
+      revision: "unmapped-committer-#{Time.now.to_i}#{rand(10000)}",
+      committer: "Unmapped Committer <unmapped@example.com>",
+      committed_on: Time.current,
+      commit_date: Time.zone.today,
+      comments: "Changeset Without Mapped User Activity",
+      user: nil
+    )
+
+    response = @provider.list_project_activities(project_id: nil)
+
+    assert_equal "success", response.status
+    activity = response.value[:activities].find { |a| a[:event_title].to_s.include?("Changeset Without Mapped User Activity") }
+
+    assert_not_nil activity
+    assert_nil activity[:user_id]
+  ensure
+    changeset&.destroy
   end
 
   def test_list_project_activities_description_mentions_optional_project_id_and_user_id

--- a/test/unit/tools/project_tools_test.rb
+++ b/test/unit/tools/project_tools_test.rb
@@ -151,6 +151,219 @@ class ProjectToolsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_list_project_activities_without_project_id_spans_multiple_projects
+    project1 = Project.find(1)
+    project2 = Project.find(2)
+    EnabledModule.create!(project_id: project2.id, name: "ai_helper")
+
+    issue1 = Issue.create!(
+      project: project1, tracker: Tracker.find(1), subject: "Cross Project Activity 1",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+    issue2 = Issue.create!(
+      project: project2, tracker: Tracker.find(1), subject: "Cross Project Activity 2",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: nil)
+
+    assert_equal "success", response.status
+    titles = response.value[:activities].map { |a| a[:event_title] }
+    assert(titles.any? { |t| t.include?("Cross Project Activity 1") })
+    assert(titles.any? { |t| t.include?("Cross Project Activity 2") })
+
+    datetimes = response.value[:activities].map { |a| a[:event_datetime] }
+    assert_equal datetimes, datetimes.sort.reverse
+  ensure
+    issue1&.destroy
+    issue2&.destroy
+  end
+
+  def test_list_project_activities_without_project_id_applies_limit_after_project_filter
+    project1 = Project.find(1)
+    excluded_project = Project.find(3) # ai_helper module not enabled
+    tracker = Tracker.find(1)
+    excluded_project.trackers << tracker unless excluded_project.trackers.include?(tracker)
+
+    accessible_issue_a = Issue.create!(
+      project: project1, tracker: tracker, subject: "Limit Order Accessible A",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+    accessible_issue_b = Issue.create!(
+      project: project1, tracker: tracker, subject: "Limit Order Accessible B",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+    # Created after the accessible issues, so they would sort ahead of them by
+    # event_datetime if the project filter were (incorrectly) applied after the limit
+    # instead of before it.
+    excluded_issue_a = Issue.create!(
+      project: excluded_project, tracker: tracker, subject: "Limit Order Excluded A",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+    excluded_issue_b = Issue.create!(
+      project: excluded_project, tracker: tracker, subject: "Limit Order Excluded B",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: nil, limit: 2)
+
+    assert_equal "success", response.status
+    titles = response.value[:activities].map { |a| a[:event_title] }
+    assert_equal 2, titles.size
+    assert(titles.any? { |t| t.include?("Limit Order Accessible A") })
+    assert(titles.any? { |t| t.include?("Limit Order Accessible B") })
+  ensure
+    accessible_issue_a&.destroy
+    accessible_issue_b&.destroy
+    excluded_issue_a&.destroy
+    excluded_issue_b&.destroy
+  end
+
+  def test_list_project_activities_without_project_id_respects_author_id_filter
+    project1 = Project.find(1)
+    project2 = Project.find(2)
+    EnabledModule.create!(project_id: project2.id, name: "ai_helper")
+    author = User.find(2)
+    other_author = User.find(1)
+
+    matching_issue = Issue.create!(
+      project: project2, tracker: Tracker.find(1), subject: "Cross Project Author Match",
+      author: author, status: IssueStatus.first, priority: IssuePriority.first
+    )
+    other_issue = Issue.create!(
+      project: project1, tracker: Tracker.find(1), subject: "Cross Project Author Mismatch",
+      author: other_author, status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: nil, author_id: author.id)
+
+    assert_equal "success", response.status
+    titles = response.value[:activities].map { |a| a[:event_title] }
+    assert(titles.any? { |t| t.include?("Cross Project Author Match") })
+    assert_not(titles.any? { |t| t.include?("Cross Project Author Mismatch") })
+  ensure
+    matching_issue&.destroy
+    other_issue&.destroy
+  end
+
+  def test_list_project_activities_without_project_id_excludes_projects_without_permission
+    previous_user = User.current
+    User.current = User.find(2) # jsmith, a member of project 1 but not of the private_project created below
+    Role.find(1).add_permission!(:view_ai_helper)
+
+    private_project = Project.create!(
+      name: "Private No Access #{Time.now.to_i}#{rand(10000)}",
+      identifier: "private-no-access-#{Time.now.to_i}#{rand(10000)}",
+      is_public: false
+    )
+    tracker = Tracker.find(1)
+    private_project.trackers << tracker unless private_project.trackers.include?(tracker)
+    EnabledModule.create!(project_id: private_project.id, name: "ai_helper")
+    hidden_issue = Issue.create!(
+      project: private_project, tracker: tracker, subject: "Hidden No Permission Activity",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: nil)
+
+    assert_equal "success", response.status
+    titles = response.value[:activities].map { |a| a[:event_title] }
+    assert_not(titles.any? { |t| t.include?("Hidden No Permission Activity") })
+  ensure
+    User.current = previous_user
+    hidden_issue&.destroy
+    private_project&.destroy
+  end
+
+  def test_list_project_activities_without_project_id_excludes_ai_helper_disabled_project
+    project_without_ai_helper = Project.find(3) # eCookbook Subproject 1: ai_helper module not enabled
+    tracker = Tracker.find(1)
+    project_without_ai_helper.trackers << tracker unless project_without_ai_helper.trackers.include?(tracker)
+    issue = Issue.create!(
+      project: project_without_ai_helper, tracker: tracker, subject: "No AI Helper Module Activity",
+      author: User.find(1), status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: nil)
+
+    assert_equal "success", response.status
+    titles = response.value[:activities].map { |a| a[:event_title] }
+    assert_not(titles.any? { |t| t.include?("No AI Helper Module Activity") })
+  ensure
+    issue&.destroy
+  end
+
+  def test_list_project_activities_without_project_id_and_no_accessible_projects_returns_empty
+    EnabledModule.where(project_id: 1, name: "ai_helper").destroy_all
+
+    response = @provider.list_project_activities(project_id: nil)
+
+    assert_equal "success", response.status
+    assert_equal [], response.value[:activities]
+  end
+
+  def test_list_project_activities_includes_user_id
+    project = Project.find(1)
+    issue = Issue.create!(
+      project: project, tracker: Tracker.find(1), subject: "User Id Field Activity",
+      author: User.find(2), status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: project.id)
+
+    assert_equal "success", response.status
+    activity = response.value[:activities].find { |a| a[:event_title].to_s.include?("User Id Field Activity") }
+
+    assert_not_nil activity
+    assert_equal issue.author.id, activity[:user_id]
+  ensure
+    issue&.destroy
+  end
+
+  def test_list_project_activities_with_author_id_matches_user_id
+    project = Project.find(1)
+    author = User.find(2)
+    issue = Issue.create!(
+      project: project, tracker: Tracker.find(1), subject: "Author Filter Activity",
+      author: author, status: IssueStatus.first, priority: IssuePriority.first
+    )
+
+    response = @provider.list_project_activities(project_id: project.id, author_id: author.id)
+
+    assert_equal "success", response.status
+    activities = response.value[:activities]
+
+    assert(activities.any?)
+    assert(activities.all? { |a| a[:user_id] == author.id })
+  ensure
+    issue&.destroy
+  end
+
+  def test_list_project_activities_user_id_is_nil_when_author_unknown
+    project = Project.find(1)
+    document = Document.create!(project: project, title: "Doc Without Attachment Activity", category: DocumentCategory.first)
+
+    response = @provider.list_project_activities(project_id: nil)
+
+    assert_equal "success", response.status
+    activity = response.value[:activities].find { |a| a[:event_title].to_s.include?("Doc Without Attachment Activity") }
+
+    assert_not_nil activity
+    assert_nil activity[:user_id]
+  ensure
+    document&.destroy
+  end
+
+  def test_list_project_activities_description_mentions_optional_project_id_and_user_id
+    schema = RedmineAiHelper::Tools::ProjectTools.function_schemas.to_openai_format.find do |f|
+      f[:function][:name].end_with?("__list_project_activities")
+    end
+
+    assert_match(/omit/i, schema[:function][:description])
+    assert_match(/user_id/i, schema[:function][:description])
+    assert_match(/omit/i, schema[:function][:parameters][:properties][:project_id][:description])
+  end
+
   def test_list_projects_includes_required_fields
     response = @provider.list_projects()
 


### PR DESCRIPTION
## Changes

- Make `project_id` optional on `list_project_activities`; when omitted, activities are aggregated across all projects with the AI Helper module enabled that are accessible to the current user
- Include `user_id` in each returned activity entry to support per-user aggregation/filtering
- Add ADR documenting the cross-project activity search scoping decision
- Address PR review feedback and expand test coverage in `project_tools_test.rb`