### PR TITLE
Reject subscriptions/listen and stop advertising change notifications on MCP endpoint

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/050-list-project-activities-optional-project"
+  "feature_directory": "specs/051-mcp-reject-subscriptions-listen"
 }

--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ DELETE /ai_helper/mcp    — MCP spec required; not used in stateless mode
 
 The server uses the MCP Streamable HTTP transport in **stateless, JSON-response mode** (`stateless: true`, `enable_json_response: true`). All communication happens via POST with JSON-RPC — SSE streaming is not used.
 
+**Change notifications are not supported.** This server does not implement change-notification subscription streams (`subscriptions/listen`, SEP-2575) or the related `listChanged`/`subscribe` capabilities. Because the endpoint is stateless with no shared subscription registry, a `subscriptions/listen` request is answered with a JSON-RPC *Method not found* error rather than opening a stream. Clients should poll `tools/list`, `prompts/list`, or `resources/list` instead of subscribing to change notifications.
+
 **Enabling the endpoint:**
 
 1. Open the AI Helper settings page from the Administration menu.

--- a/app/controllers/ai_helper_mcp_controller.rb
+++ b/app/controllers/ai_helper_mcp_controller.rb
@@ -2,6 +2,8 @@
 
 require "redmine_ai_helper/mcp/server"
 require "redmine_ai_helper/mcp/session_strategy"
+require "redmine_ai_helper/mcp/transport"
+require "redmine_ai_helper/logger"
 
 # Controller that exposes the MCP (Model Context Protocol) Streamable HTTP
 # endpoint at +/ai_helper/mcp+.
@@ -14,6 +16,8 @@ require "redmine_ai_helper/mcp/session_strategy"
 # +StreamableHTTPTransport+ in stateless mode, which handles JSON-RPC
 # framing, +initialize+, +tools/list+, and +tools/call+ methods.
 class AiHelperMcpController < ApplicationController
+  include RedmineAiHelper::Logger
+
   # Authentication is enforced by authenticate_mcp_request below using the
   # X-Redmine-API-Key request header. Because authentication is header-based
   # (not session-cookie-based) and no session state is mutated by this
@@ -65,11 +69,30 @@ class AiHelperMcpController < ApplicationController
     # this endpoint authenticates with a stateless X-Redmine-API-Key header rather
     # than ambient browser credentials, so the DNS rebinding threat model does not
     # apply, and the Host varies per Redmine deployment so no fixed allowlist fits.
-    transport = MCP::Server::Transports::StreamableHTTPTransport.new(
+    transport = RedmineAiHelper::Mcp::Transport.new(
       server, stateless: true, enable_json_response: true, dns_rebinding_protection: false
     )
 
     rack_status, rack_headers, body_parts = transport.call(rack_env)
+
+    # A body responding to +call+ (a Rack streaming Proc) can never be represented as a
+    # complete JSON-RPC response. Implicitly stringifying it via +Array(body_parts).join+
+    # would silently ship a broken "#<Proc:0x…>" body as a 200 (the exact bug this
+    # feature fixes for +subscriptions/listen+); instead this fails loudly with a
+    # logged error and a JSON-RPC internal-error response (FR-005, Constitution III).
+    if body_parts.respond_to?(:call)
+      offending_method = parsed_request && parsed_request["method"]
+      ai_helper_logger.error(
+        "MCP transport returned a non-enumerable (streaming) body for method #{offending_method.inspect}"
+      )
+      render status: :internal_server_error,
+             json: {
+               jsonrpc: "2.0",
+               id: parsed_request && parsed_request["id"],
+               error: { code: -32603, message: "Internal error" }
+             }
+      return
+    end
 
     rack_headers.each { |k, v| response.set_header(k, v) }
     render status: rack_status,

--- a/app/controllers/ai_helper_mcp_controller.rb
+++ b/app/controllers/ai_helper_mcp_controller.rb
@@ -81,14 +81,14 @@ class AiHelperMcpController < ApplicationController
     # feature fixes for +subscriptions/listen+); instead this fails loudly with a
     # logged error and a JSON-RPC internal-error response (FR-005, Constitution III).
     if body_parts.respond_to?(:call)
-      offending_method = parsed_request && parsed_request["method"]
+      offending_method = parsed_request&.[]("method")
       ai_helper_logger.error(
         "MCP transport returned a non-enumerable (streaming) body for method #{offending_method.inspect}"
       )
       render status: :internal_server_error,
              json: {
                jsonrpc: "2.0",
-               id: parsed_request && parsed_request["id"],
+               id: parsed_request&.[]("id"),
                error: { code: -32603, message: "Internal error" }
              }
       return

--- a/docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md
+++ b/docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md
@@ -1,0 +1,109 @@
+# ADR-031: MCP Endpoint Rejects subscriptions/listen
+
+**Date**: 2026-08-26
+**Status**: Accepted
+
+## Context
+
+Issue #410 reported a request storm against `/ai_helper/mcp`: roughly 59,000 requests/day against
+only 16 real `tools/call` invocations. Investigation traced this to the endpoint's handling of
+`subscriptions/listen` (SEP-2575 change-notification streaming):
+
+- `RedmineAiHelper::Mcp::Server.build` passed no explicit `capabilities:` to `MCP::Server.new`, so
+  the `mcp` gem's default capabilities advertised `listChanged: true` for `tools`, `prompts` and
+  `resources` — a promise the plugin never fulfilled, since it never emits any
+  `notifications/*/list_changed` event.
+- A well-behaved MCP client that reads this capability opens a `subscriptions/listen` stream. The
+  gem's `StreamableHTTPTransport` serves this at the transport layer with a Rack streaming `Proc`
+  body (`streamable_http_transport.rb:886`), *before* dispatching to `Server#handle` and without
+  consulting `serves_subscriptions_listen?`.
+- `AiHelperMcpController#handle_request` rendered the response body with `Array(body_parts).join`.
+  For a `Proc`, `Array(proc)` wraps it in a one-element array and `join` calls `#to_s` on it,
+  producing the literal string `"#<Proc:0x0000ffff…>"` — returned as **HTTP 200 /
+  `text/event-stream`**.
+- The client sees a stream that opened and closed immediately with a 200, treats it as a
+  successfully-but-briefly-open connection, does not back off per any error-handling path, and
+  reconnects instantly — the observed storm.
+- The `#<Proc:0x…>` string is also an internal-object-address disclosure to an unauthenticated
+  read of server memory layout (mitigated by the same fix, though not the primary driver).
+
+The endpoint is deliberately stateless: `RedmineAiHelper::Mcp::Server.build` and the transport are
+constructed fresh per request, with no shared subscription registry, no `ActionController::Live`,
+and no long-lived connection. There is therefore no mechanism by which a correctly implemented
+`subscriptions/listen` stream could ever deliver a notification — the plugin has nothing to push
+and nowhere durable to register the request that would receive it. Implementing real streaming
+would mean holding a thread and a DB connection open per connected client, indefinitely, to
+deliver events that never occur, and would not work across Redmine's multi-process deployments
+without an external event bus.
+
+## Decision
+
+Reject `subscriptions/listen` and stop advertising the capability, using three coordinated
+changes verified against the installed `mcp` 1.3.0 gem by prototype:
+
+1. **Declare honestly.** `RedmineAiHelper::Mcp::Server.build` now passes explicit
+   `capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} }` to `MCP::Server.new`,
+   removing the false `listChanged`/`subscribe` promises from both the modern `server/discover`
+   result and the legacy `initialize` result. `logging` is kept because `logging/setLevel` is
+   genuinely served by the gem.
+2. **Refuse cleanly.** A new `RedmineAiHelper::Mcp::Transport < MCP::Server::Transports::StreamableHTTPTransport`
+   overrides the public `serves_subscriptions_listen?` to return `false` (defence in depth for
+   `discover_capabilities`' own stripping logic) and overrides the private
+   `handle_subscriptions_listen(body)` to return a one-shot Rack triple: HTTP `404`, a plain
+   `application/json` content type, and a JSON-RPC `-32601` ("Method not found") body echoing the
+   request `id`. Both overrides are required — the transport intercepts the method before
+   consulting capabilities at all, so the capability change alone would not stop a client that
+   ignores the declaration.
+3. **Never lie by accident.** The controller no longer stringifies whatever the transport hands
+   back. `Array(body_parts).join` is replaced with an explicit check: a body responding to `call`
+   (a streaming `Proc`) is logged via `ai_helper_logger.error`, naming the offending JSON-RPC
+   method, and answered with HTTP `500` and a JSON-RPC `-32603` ("Internal error") body. This is
+   orthogonal insurance against any future gem version that streams a different method — the
+   condition is a value-shape check, not a method-name allowlist.
+
+The `404`/`-32601` pairing mirrors the gem's own mapping for an unknown modern method
+(`modern_http_status`), so unmodified clients need no special-casing to recognise the rejection
+and back off normally.
+
+## Consequences
+
+- **Positive**: idle client traffic against the endpoint drops to connection setup only; daily
+  request volume returns to the same order of magnitude as actual `tools/call` usage.
+- **Positive**: a `subscriptions/listen` attempt now fails loudly and observably (a standard
+  JSON-RPC error) instead of silently succeeding with garbage content, removing both the traffic
+  storm and the incidental internal-object-address leak.
+- **Positive**: any future non-enumerable transport body (not just `subscriptions/listen`) is now
+  caught by the same guard and produces a logged 500 instead of a silent broken 200.
+- **Negative**: this is coupled to two `mcp` gem internals — `serves_subscriptions_listen?` and the
+  private `handle_subscriptions_listen` — named explicitly, with the targeted gem version recorded
+  in a comment in `transport.rb`. A future gem upgrade that renames or restructures either member
+  will regress silently unless the functional test suite (which asserts the observable
+  404/-32601/no-`listChanged` contract, not the override mechanism) is run.
+- **Negative**: real change-notification support remains unimplemented. If a future requirement
+  needs it, it requires a genuinely different architecture (a shared, cross-process subscription
+  registry and a way to fan out events), not an incremental extension of this fix.
+
+## Alternatives Considered
+
+- **Implement real notification streaming** (`ActionController::Live`, a subscription registry,
+  and actual `notifications/*/list_changed` emission): rejected. The endpoint's statelessness is
+  load-bearing elsewhere in this plugin's design (see the per-request `Server.build`), and the
+  plugin has no events to push in the first place — building the infrastructure would add a
+  standing resource cost (one thread + one DB connection per idle client, forever) to deliver
+  nothing, and would not work across Redmine's multi-process deployments without a new external
+  event bus.
+- **Rely solely on the capability declaration and skip the transport-level rejection**: rejected —
+  `handle_subscriptions_listen` is invoked unconditionally for the method before the gem consults
+  `serves_subscriptions_listen?`, so a client that ignores (or never fetches) the capability
+  declaration would still open the broken stream.
+- **Rely solely on the transport-level rejection and skip the explicit capability declaration**:
+  rejected — it would satisfy the modern `server/discover` path (via
+  `serves_subscriptions_listen?`) but not the legacy `initialize` path, which serialises
+  `capabilities` directly and does not consult transport state at all.
+- **Monkey-patch the gem's transport class in place**: rejected in favor of a local subclass, which
+  is easier to grep for, does not risk affecting other MCP client code sharing the same process
+  (e.g. `ruby_llm-mcp`), and keeps the override list explicit and reviewable.
+- **Silently render an empty or truncated body for a non-enumerable transport response**: rejected
+  — this plugin's Constitution forbids silent fallbacks, and a quiet failure of exactly this shape
+  (a garbage 200 with no log trace) is what let the original bug run for a full day before
+  detection.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,3 +82,5 @@ Briefly describe alternatives that were rejected and why.
 | [027](./027-eslint-quality-rule-ratchet.md) | ESLint naming/explicitness/size/complexity rules start at a measured baseline and ratchet down | Accepted |
 | [028](./028-eslint-plugin-jsdoc-enforcement.md) | eslint-plugin-jsdoc enforces the existing JSDoc convention | Accepted |
 | [029](./029-search-issues-cross-project-scoping.md) | search_issues cross-project scoping | Accepted |
+| [030](./030-list-project-activities-cross-project-scoping.md) | list_project_activities cross-project scoping | Accepted |
+| [031](./031-mcp-endpoint-rejects-subscriptions-listen.md) | MCP endpoint rejects subscriptions/listen | Accepted |

--- a/lib/redmine_ai_helper/mcp/server.rb
+++ b/lib/redmine_ai_helper/mcp/server.rb
@@ -12,7 +12,7 @@ module RedmineAiHelper
     #
     # @example
     #   server = Server.build
-    #   transport = MCP::Server::Transports::StreamableHTTPTransport.new(server, stateless: true)
+    #   transport = RedmineAiHelper::Mcp::Transport.new(server, stateless: true)
     class Server
       include RedmineAiHelper::Logger
       class << self

--- a/lib/redmine_ai_helper/mcp/server.rb
+++ b/lib/redmine_ai_helper/mcp/server.rb
@@ -18,6 +18,13 @@ module RedmineAiHelper
       class << self
         # Builds and returns a configured MCP::Server with tools filtered for the given user.
         #
+        # Capabilities are declared explicitly rather than left to the gem's defaults:
+        # `tools`, `prompts` and `resources` are advertised without `listChanged`
+        # (and `resources` without `subscribe`) because this plugin never emits
+        # change-notifications and the endpoint is stateless per request. `logging` is
+        # kept because `logging/setLevel` is genuinely served by the gem. See
+        # `specs/051-mcp-reject-subscriptions-listen/research.md` §1.
+        #
         # @param user [User] authenticated user (defaults to User.current)
         # @return [MCP::Server] server instance with permitted tools registered
         def build(user: User.current)
@@ -27,7 +34,8 @@ module RedmineAiHelper
             name: "redmine-ai-helper",
             version: plugin_version,
             instructions: "Redmine AI Helper MCP Server. All tools respect Redmine permissions.",
-            tools: mcp_tools
+            tools: mcp_tools,
+            capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} }
           )
         end
 

--- a/lib/redmine_ai_helper/mcp/transport.rb
+++ b/lib/redmine_ai_helper/mcp/transport.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "mcp"
+
+module RedmineAiHelper
+  module Mcp
+    # Subclass of the `mcp` gem's Streamable HTTP transport (gem version 1.3.0,
+    # +MCP::Server::Transports::StreamableHTTPTransport+) whose sole purpose is to
+    # declare, honestly and at the transport layer, that this endpoint does not serve
+    # `subscriptions/listen` (SEP-2575 change-notification streaming).
+    #
+    # This plugin's MCP endpoint is stateless: a fresh +MCP::Server+ and transport are
+    # built per request (see {RedmineAiHelper::Mcp::Server.build}), so there is no
+    # process-local registry to fan notifications out to, and the plugin never emits
+    # `notifications/*/list_changed`. Left unmodified, the gem still advertises
+    # `listChanged`/`subscribe` capabilities and serves `subscriptions/listen` with a
+    # long-lived SSE stream, which invites well-behaved clients to open a subscription
+    # that is silently closed — see +docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md+.
+    #
+    # Two overrides answer this:
+    # - {#serves_subscriptions_listen?} (capability-declaration honesty)
+    # - `handle_subscriptions_listen` (transport-level rejection of the method)
+    class Transport < MCP::Server::Transports::StreamableHTTPTransport
+      # Declares that this endpoint does not serve `subscriptions/listen` (SEP-2575).
+      #
+      # Overrides the gem's hardcoded `true` (mcp 1.3.0,
+      # `streamable_http_transport.rb:265`). Consumed by
+      # `MCP::Server#discover_capabilities` (`server.rb:1188`), which strips the
+      # `listChanged`/`subscribe` capability flags from the `server/discover` result
+      # when this is falsey. This is defence in depth alongside the explicit
+      # `capabilities:` passed by {RedmineAiHelper::Mcp::Server.build}: even if a future
+      # gem version reintroduces a default `listChanged` promise, `server/discover`
+      # stays honest.
+      #
+      # @return [Boolean] always `false`
+      def serves_subscriptions_listen?
+        false
+      end
+
+      private
+
+      # Rejects `subscriptions/listen` (SEP-2575) as an unknown method instead of opening
+      # the gem's default SSE notification stream.
+      #
+      # Overrides the private +StreamableHTTPTransport#handle_subscriptions_listen+
+      # (mcp 1.3.0, `streamable_http_transport.rb:824`), which +handle_modern+ calls
+      # unconditionally for this method, *without* consulting
+      # {#serves_subscriptions_listen?} — so this override is required in addition to
+      # that one (see `specs/051-mcp-reject-subscriptions-listen/contracts/transport-internal.md`).
+      #
+      # Only `body[:id]` is read; `body[:params]` (including any `notifications` filter)
+      # is never inspected, no entry is added to `@listen_subscriptions`, and no thread is
+      # started — the request is answered and forgotten.
+      #
+      # @param body [Hash] the parsed JSON-RPC request, with symbol keys
+      # @return [Array(Integer, Hash, Array<String>)] a one-shot Rack triple: HTTP 404,
+      #   a plain `application/json` header, and a single JSON-RPC "Method not found"
+      #   (`-32601`) error body echoing the request `id` (`null` when absent)
+      def handle_subscriptions_listen(body)
+        json = JSON.generate(
+          jsonrpc: "2.0",
+          id: body[:id],
+          error: {
+            code: JsonRpcHandler::ErrorCode::METHOD_NOT_FOUND,
+            message: "Method not found",
+            data: "subscriptions/listen"
+          }
+        )
+
+        [ 404, { "content-type" => "application/json" }, [ json ] ]
+      end
+    end
+  end
+end

--- a/test/functional/ai_helper_mcp_controller_test.rb
+++ b/test/functional/ai_helper_mcp_controller_test.rb
@@ -325,6 +325,144 @@ class AiHelperMcpControllerTest < ActionController::TestCase
     end
   end
 
+  # ─── subscriptions/listen rejection (US1) ──────────────────────────────────
+
+  context "subscriptions/listen" do
+    setup { set_valid_auth_headers }
+
+    should "return 404 with JSON-RPC Method not found for a modern request (C-1.1-C-1.3)" do
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: 42, params: { notifications: { "notifications/tools/list_changed" => true } }),
+           as: :json
+
+      assert_response :not_found
+      body = JSON.parse(@response.body)
+
+      assert_equal(-32601, body.dig("error", "code"))
+      assert_equal "Method not found", body.dig("error", "message")
+      assert_equal "subscriptions/listen", body.dig("error", "data")
+      assert_equal 42, body["id"]
+    end
+
+    should "respond as a one-shot JSON document with no streaming headers or Proc body (C-1.4-C-1.6)" do
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: 42, params: { notifications: { "notifications/tools/list_changed" => true } }),
+           as: :json
+
+      assert_equal "application/json", @response.media_type
+      assert_not_equal "text/event-stream", @response.media_type
+      assert_nil @response.headers["cache-control"]
+      assert_nil @response.headers["connection"]
+      assert_nil @response.headers["x-accel-buffering"]
+      assert_no_match(/#<Proc/, @response.body)
+    end
+
+    should "ignore params.notifications filter value (C-1.7)" do
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: 42, params: { notifications: { "notifications/resources/list_changed" => false } }),
+           as: :json
+
+      assert_response :not_found
+      body = JSON.parse(@response.body)
+
+      assert_equal(-32601, body.dig("error", "code"))
+    end
+
+    should "return 404 with null id when id is omitted (C-2)" do
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: nil, params: { notifications: {} }),
+           as: :json
+
+      assert_response :not_found
+      body = JSON.parse(@response.body)
+
+      assert_equal(-32601, body.dig("error", "code"))
+      assert_nil body["id"]
+    end
+  end
+
+  context "subscriptions/listen auth precedence (C-6)" do
+    should "return 401 with a missing/invalid API key rather than 404" do
+      @request.headers["X-Redmine-API-Key"] = "definitely_invalid_key_xyz"
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: 1, params: { notifications: {} }),
+           as: :json
+
+      assert_response :unauthorized
+    end
+
+    should "return 403 when MCP server is disabled rather than 404" do
+      @setting.update_column(:mcp_server_enabled, false)
+      set_valid_auth_headers
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: 1, params: { notifications: {} }),
+           as: :json
+
+      assert_response :forbidden
+    end
+  end
+
+  # ─── capability declaration honesty (US2) ──────────────────────────────────
+
+  context "capability declaration" do
+    setup { set_valid_auth_headers }
+
+    should "advertise no listChanged/subscribe on the modern server/discover path (C-3)" do
+      post :handle_request, body: modern_request_payload("server/discover", id: 1), as: :json
+
+      assert_response :success
+      capabilities = JSON.parse(@response.body).dig("result", "capabilities")
+
+      assert_equal %w[tools prompts resources logging].sort, capabilities.keys.sort
+      capabilities.each_value do |cap|
+        assert_not cap.key?("listChanged"), "expected no listChanged in #{cap.inspect}"
+        assert_not cap.key?("subscribe"), "expected no subscribe in #{cap.inspect}"
+      end
+    end
+
+    should "advertise no listChanged/subscribe on the legacy initialize path (C-4)" do
+      post :handle_request, body: initialize_payload, as: :json
+
+      assert_response :success
+      body = JSON.parse(@response.body)
+      capabilities = body.dig("result", "capabilities")
+
+      assert_equal %w[tools prompts resources logging].sort, capabilities.keys.sort
+      capabilities.each_value do |cap|
+        assert_not cap.key?("listChanged"), "expected no listChanged in #{cap.inspect}"
+        assert_not cap.key?("subscribe"), "expected no subscribe in #{cap.inspect}"
+      end
+      assert_predicate body.dig("result", "protocolVersion"), :present?
+      assert_predicate body.dig("result", "serverInfo", "name"), :present?
+    end
+  end
+
+  # ─── streaming-body guard (US3) ────────────────────────────────────────────
+
+  context "streaming body guard" do
+    setup { set_valid_auth_headers }
+
+    should "return 500 with a JSON-RPC internal error and log the offending method, never stringifying a Proc (C-5)" do
+      streaming_body = proc { |stream| stream.write("unused") }
+      RedmineAiHelper::Mcp::Transport.any_instance
+        .stubs(:call)
+        .returns([ 200, { "content-type" => "text/event-stream" }, streaming_body ])
+      RedmineAiHelper::CustomLogger.instance.expects(:error).with(regexp_matches(/subscriptions\/listen/))
+
+      post :handle_request,
+           body: modern_request_payload("subscriptions/listen", id: 7, params: { notifications: {} }),
+           as: :json
+
+      assert_response :internal_server_error
+      body = JSON.parse(@response.body)
+
+      assert_equal 7, body["id"]
+      assert_equal(-32603, body.dig("error", "code"))
+      assert_equal "Internal error", body.dig("error", "message")
+      assert_no_match(/#<Proc/, @response.body)
+    end
+  end
+
   # ─── tools/call permission enforcement (T021) ──────────────────────────────
 
   context "tools/call permission enforcement" do
@@ -400,5 +538,29 @@ class AiHelperMcpControllerTest < ActionController::TestCase
       method: "tools/call",
       params: { name: tool_name, arguments: arguments }
     }.to_json
+  end
+
+  # Sets the modern SEP-2575 request headers and returns a JSON body for +method+ with
+  # +params+ merged with the required `_meta` envelope (protocol version + client
+  # capabilities). Without both the headers and the `_meta` envelope, the transport
+  # treats the request as legacy and never reaches the modern-path interception point
+  # (see specs/051-mcp-reject-subscriptions-listen/research.md §10).
+  def modern_request_payload(method, id: 1, params: {})
+    @request.headers["MCP-Protocol-Version"] = "2026-07-28"
+    @request.headers["Mcp-Method"] = method
+    @request.headers["Accept"] = "application/json, text/event-stream"
+
+    body = {
+      jsonrpc: "2.0",
+      method: method,
+      params: params.merge(
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion" => "2026-07-28",
+          "io.modelcontextprotocol/clientCapabilities" => {}
+        }
+      )
+    }
+    body[:id] = id unless id.nil?
+    body.to_json
   end
 end

--- a/test/unit/mcp/server_test.rb
+++ b/test/unit/mcp/server_test.rb
@@ -38,6 +38,15 @@ class McpServerBuilderTest < ActiveSupport::TestCase
       assert server.tools.key?("list_projects"),
              "expected list_projects tool to be present"
     end
+
+    should "configure explicit capabilities with no listChanged/subscribe promises" do
+      server = RedmineAiHelper::Mcp::Server.build
+
+      assert_equal(
+        { tools: {}, prompts: {}, resources: {}, logging: {} },
+        server.capabilities
+      )
+    end
   end
 
   context "mcp_tool_allowed?" do

--- a/wiki/INDEX.md
+++ b/wiki/INDEX.md
@@ -10,6 +10,7 @@ page files, not here.
 
 ## decision
 - [Agent Write-Capability Routing](./pages/agent-write-capability-routing.md) — why `can_write?`/`requires_write` guard write steps at dispatch time instead of being exposed to the router, and how skipped steps and the final-answer prompt stay consistent with what actually ran.
+- [MCP subscriptions/listen Rejection](./pages/mcp-listen-rejection.md) — ADR-031: the root cause (a streaming Proc body stringified into a fake 200), the three-part fix, alternatives rejected, and the gem-version-coupling gotcha it leaves behind.
 - [Inbound Chat Webhook Ingest](./pages/inbound-chat-webhook-ingest.md) — why webhook events land on a Rails endpoint in Redmine, hand off through a DB table, and are polled by `InboundAdapter#start` so the gateway core stays unchanged.
 - [Public URL Scope for Chat Adapters](./pages/public-url-scope.md) — ADR-017's amendment to ADR-006: "no public URL required" is an outbound-adapter property, not a whole-plugin invariant.
 - [Completion Request Timeout Policy](./pages/completion-request-timeout-policy.md) — ADR-018: why completion LLM calls override RubyLLM's 300 s / 3-retry defaults per context, the injection path, and the alternatives rejected.
@@ -26,7 +27,8 @@ page files, not here.
 - [AI Chat Sidebar](./pages/chat-sidebar.md) — the sidebar UI: view-hook injection, the `AiHelper` JS class, SSE handling, conversation models, and Markdown/XSS.
 - [Issue AI Features](./pages/issue-ai-features.md) — `IssueReadAgent` summarization/caching, reply drafts, sub-issues, assignee suggestion, duplicate check, and inline completion.
 - [Inline Completion Request Flow](./pages/inline-completion-request-flow.md) — AbortController cancellation, no-change suppression, debounce-timer clearing, and where the autocompletion settings are read and validated.
-- [MCP Integration](./pages/mcp-integration.md) — consuming external MCP servers (dynamic agent generation, read-only gotcha) and exposing Redmine as an MCP server.
+- [MCP Integration](./pages/mcp-integration.md) — consuming external MCP servers: dynamic agent generation and the read-only gotcha. See [MCP Server Endpoint](./pages/mcp-server-endpoint.md) for the other direction.
+- [MCP Server Endpoint](./pages/mcp-server-endpoint.md) — exposing Redmine as an MCP server: stateless mode, auth, permissions, tool groups, and the anonymous-endpoint pattern reused by inbound webhooks.
 - [Custom Commands](./pages/custom-commands.md) — reusable `/command` prompt shortcuts, scope precedence, template variables.
 - [Project Health Report](./pages/health-report.md) — `ProjectAgent` dual-pattern generation, `AiHelperHealthReport` storage, streamed comparison, export, and REST API.
 - [Think Model](./pages/think-model.md) — optional deep-reasoning model profile, its scope, validation, and no-fallback rules.

--- a/wiki/lint-report.md
+++ b/wiki/lint-report.md
@@ -1,49 +1,27 @@
-# Wiki Lint Report — 2026-08-08 (second pass)
+# Wiki Lint Report — 2026-08-26
 
-Scope: full pass. 25 pages, 20 sources. Auto-fix mode: `index-and-links`.
-Supersedes the earlier 2026-08-08 report, whose finding 1 is now **resolved**.
+All 3 findings from the prior pass were fixed by hand (citation swaps, not
+lint auto-fixes — semantic findings are never auto-rewritten).
 
-## Results per check
+| # | Check | Severity | Page | Finding | Outcome |
+|---|-------|----------|------|---------|---------|
+| 1 | citations | semantic | inline-completion-request-flow.md | "`ai_helper_logger` falls back to `Rails.logger`" was cited only as `(ADR-020)`, missing source ID **S022**. | Fixed: citation is now `(ADR-020, S022)`; `S022` added to frontmatter `sources`. |
+| 2 | citations | semantic | completion-request-timeout-policy.md | "a timeout never locks completion where it happened" was cited only as `(ADR-021)`, missing source ID **S023**. | Fixed: citation is now `(ADR-021, S023)`; `S023` added to frontmatter `sources`. |
+| 3 | citations | semantic | completion-suppression-scope.md | "ADR-021 folded it into `clearSuggestion`…" was cited only `(S021)`, missing source ID **S023**. | Fixed: citation is now `(S021, S023)`; `S023` added to frontmatter `sources`. |
 
-| Check | Result |
-|-------|--------|
-| index-drift | ✅ clean — all 25 pages appear in `INDEX.md` under the group matching their frontmatter `type`; no index line points at a missing file |
-| links | ✅ clean — every `./*.md` relative link resolves (pages + INDEX); every `(Sxxx)` citation names a registered source (S001–S020) |
-| orphans | ✅ clean — every page has ≥1 inbound link from another page. The five feature-044 pages form a connected cluster reachable from `chat-channel-gateway-architecture.md` |
-| contradictions | ✅ clean — **no `⚠ conflict:` markers remain**. The S002-vs-S018 public-URL conflict was resolved by ingesting ADR-017 (S019): S002's claim now stands scoped to outbound adapters, with the amendment cited to S019 on [Public URL Scope](./pages/public-url-scope.md) |
-| stale | ✅ clean — oldest page is `updated: 2026-08-01`, far inside the 90-day threshold (2026-05-10); no source's `Last ingested` postdates a page citing it |
-| citations | ⚠ 1 finding — one uncited aside, now unchanged across four passes |
-| *(page size — SCHEMA rule, not a listed check)* | ⚠ 1 finding — 7 pages exceed the 600-word split rule, up from 4 |
+Note: the original report's row 3 misquoted line 11 of this page as an
+ADR-021 claim — it is actually about ADR-019 (a separate, still-uncited
+decision not covered by S022/S023 and out of scope for this fix). Only the
+genuine ADR-021/S023 gap on line 30 was corrected.
 
-## Findings
+## Checks with no findings
 
-| # | Check | Severity | Page | Finding | Suggested fix |
-|---|-------|----------|------|---------|---------------|
-| 1 | page-size | structural | inbound-event-queue.md (702), inbound-webhook-endpoint.md (699), agent-write-capability-routing.md (693), mcp-integration.md (671), inbound-chat-webhook-ingest.md (663), chat-channel-gateway-architecture.md (628), vector-search.md (617) | `SCHEMA.md` requires splitting a page past 600 words. 7 of 25 pages now exceed it — the three feature-044 pages joined the list during the S018–S020 ingests, after prose trimming failed to bring them under. Roughly 30–45 words of each inbound page's count is table markup rather than prose, so the true overrun is ~10%. | Judgment call, not mechanical: either accept the overrun (all seven are coherent single topics, and feature 044 already spans five pages) or raise `ingest.page_max_words` in a project `wiki-config.yml` to match how these pages are actually written. Splitting further would scatter one mechanism across two files. Not auto-fixable. |
-| 2 | citations | low | mcp-integration.md:38–39 | The aside "the project also refers to these as `SubMcpAgent` classes" carries no source ID. It reconciles S006 (which named the class `AiHelperMcpSlack`) with the project's `CLAUDE.md`, and belongs to no registered source. **Unchanged across four consecutive lint passes.** | Register `CLAUDE.md` as a source and cite it, or reframe the aside as a `> Provenance:` note (the convention already used on the architecture/tool/provider pages). Not auto-fixable — semantic. |
+- **index-drift** — all 35 pages under `pages/` are listed in `INDEX.md`; no dangling index entries.
+- **links** — no relative links to missing pages across any page.
+- **orphans** — every page is linked from at least one other page.
+- **contradictions** — no unresolved `⚠ conflict` markers; spot-checked the highest-overlap source groups (S002, S016, S018, S021, S027/S028) for incompatible claims, none found.
+- **stale** — all pages `updated` within the last 26 days (well under the 90-day `stale_after_days` threshold); no page's cited source has a `Last ingested` date newer than the page's own `updated` date.
 
-## Fixes applied
+## Mechanical fixes applied
 
-None. `INDEX.md` and every link target were already consistent — nothing mechanical to repair.
-
-## Notes
-
-*Observations, not defects — no action required.*
-
-- **Two registration mechanisms, described separately.** `chat-channel-gateway-architecture.md`
-  says adapters register via the `inherited` hook (S001);
-  `inbound-adapter-development.md` says an adapter file is picked up by the
-  `Dir[…adapters/*_adapter.rb]` glob in `init.rb` (S020). These are
-  complementary halves of one flow (the glob loads the file, the hook registers
-  the class), not a contradiction — but neither page mentions the other half.
-  Ingesting `init.rb` or `base_adapter.rb` would let one page state it whole.
-- **Feature 044 coverage is now three-source deep.** Its five pages rest on
-  S018 (design intent), S019 (the accepted ADR) and S020 (the shipped
-  developer guide), the strongest corroboration in the wiki. The remaining
-  unregistered artifacts are the two contract files under
-  `specs/044-inbound-chat-webhook/contracts/`, which S020 names as the
-  method-level authority.
-- **Source mix.** 8 of 20 sources are DeepWiki (AI-generated); the other 12 are
-  7 spec/feature artifacts, the README, 2 ADRs and 2 project docs. The last
-  five ingests were all first-party, so the DeepWiki share keeps falling.
-  Tracked as a confidence signal, not a defect.
+None needed — `INDEX.md` already matched `pages/` exactly and no links were broken or renamed.

--- a/wiki/pages/completion-request-timeout-policy.md
+++ b/wiki/pages/completion-request-timeout-policy.md
@@ -1,8 +1,8 @@
 ---
 title: Completion Request Timeout Policy
 type: decision
-sources: [S021]
-updated: 2026-08-21
+sources: [S021, S023]
+updated: 2026-08-26
 ---
 
 # Completion Request Timeout Policy
@@ -61,7 +61,7 @@ exceptions keep the existing error-level log + `""` behaviour (S021).
 A timeout therefore reaches the browser as `200` with `{"suggestion": ""}` —
 indistinguishable from "the model had nothing to add". The client treats both the
 same way and frees the position for a later request, so a timeout never locks
-completion where it happened (ADR-021).
+completion where it happened (ADR-021, S023).
 
 ## Alternatives rejected
 

--- a/wiki/pages/completion-suppression-scope.md
+++ b/wiki/pages/completion-suppression-scope.md
@@ -1,8 +1,8 @@
 ---
 title: Completion Suppression Scope
 type: decision
-sources: [S021]
-updated: 2026-08-21
+sources: [S021, S023]
+updated: 2026-08-26
 ---
 
 # Completion Suppression Scope
@@ -28,7 +28,7 @@ compares against is **discarded on three paths** (S021):
 Path 3 was originally a separate `dismissSuggestion()` that only Esc and blur
 called, which left the checkbox and `onTextChange` paths clearing the suggestion
 while the snapshot survived. ADR-021 folded it into `clearSuggestion` — the one
-way a suggestion can leave the screen — so the rule holds by construction (S021).
+way a suggestion can leave the screen — so the rule holds by construction (S021, S023).
 
 ## Why suppression must not outlive the suggestion
 

--- a/wiki/pages/inbound-webhook-endpoint.md
+++ b/wiki/pages/inbound-webhook-endpoint.md
@@ -102,5 +102,5 @@ route helper (S018).
 - [Developing an Inbound Chat Adapter](./inbound-adapter-development.md) — how
   to implement the methods this contract calls.
 - [Chat Channel Gateway Architecture](./chat-channel-gateway-architecture.md)
-- [MCP Integration](./mcp-integration.md) — the other anonymous endpoint, whose
-  pattern this one follows.
+- [MCP Server Endpoint](./mcp-server-endpoint.md) — the other anonymous
+  endpoint, whose pattern this one follows.

--- a/wiki/pages/inline-completion-request-flow.md
+++ b/wiki/pages/inline-completion-request-flow.md
@@ -1,8 +1,8 @@
 ---
 title: Inline Completion Request Flow
 type: component
-sources: [S021]
-updated: 2026-08-21
+sources: [S021, S022]
+updated: 2026-08-26
 ---
 
 # Inline Completion Request Flow
@@ -101,7 +101,7 @@ error still stops the instance from booting, because `init.rb` builds
 `CustomLogger` at boot and that reads the same file through `load_config`
 (S021). Reporting the problem cannot depend on the plugin logger for the same
 reason, which is why `ai_helper_logger` falls back to `Rails.logger`
-(ADR-020).
+(ADR-020, S022).
 
 ## Related
 

--- a/wiki/pages/mcp-integration.md
+++ b/wiki/pages/mcp-integration.md
@@ -1,8 +1,8 @@
 ---
 title: MCP Integration
 type: component
-sources: [S002, S006, S007, S016, S018]
-updated: 2026-08-08
+sources: [S002, S006, S016]
+updated: 2026-08-26
 ---
 
 # MCP Integration
@@ -12,7 +12,9 @@ The plugin has **two independent MCP capabilities** (S002):
 1. **Consume external MCP servers** — connect to Slack, GitHub, etc. and use
    their tools inside the AI chat.
 2. **Expose Redmine as an MCP server** — external clients (Claude Desktop, other
-   agents) query Redmine's own tools.
+   agents) query Redmine's own tools. See
+   [MCP Server Endpoint](./mcp-server-endpoint.md) for that side, including the
+   endpoint's auth, permissions, and its `subscriptions/listen` rejection.
 
 ## Consuming external MCP servers
 
@@ -51,58 +53,11 @@ transparent (S006). See [Multi-Agent Architecture](./multi-agent-architecture.md
 > agent above. See
 > [Agent Write-Capability Routing](./agent-write-capability-routing.md) (S016).
 
-## Exposing Redmine as an MCP server
-
-Served by `AiHelperMcpController`, enabled via the "MCP Server" admin setting —
-the global `mcp_server_enabled` flag gates the entire endpoint (S002, S006).
-
-- **Endpoints**: `POST /ai_helper/mcp` carries JSON-RPC; `GET`/`DELETE` exist
-  only because the MCP spec requires them and are unused in stateless mode (S002).
-  The transport is **Streamable HTTP only** — no other transport is offered (S007).
-- **Mode**: MCP Streamable HTTP in **stateless, JSON-response** mode
-  (`stateless: true`, `enable_json_response: true`) — all traffic is POST +
-  JSON-RPC, no SSE streaming (S002). Sessions hold **no server-side state**; each
-  request re-authenticates by its API key (S007).
-- **Protocol methods** supported: `initialize`, `tools/list`, `tools/call`, and
-  the `notifications/initialized` message (S007).
-- **Change notifications are not supported.** The endpoint does not implement
-  `subscriptions/listen` (SEP-2575) or advertise `listChanged`/`subscribe`
-  capabilities — `RedmineAiHelper::Mcp::Server.build` declares empty
-  capabilities for `tools`/`prompts`/`resources` (keeping only `logging`, which
-  is genuinely served), and a `RedmineAiHelper::Mcp::Transport` subclass rejects
-  a `subscriptions/listen` request with a JSON-RPC *Method not found* error
-  instead of opening an SSE stream. This closed a request storm caused by
-  well-behaved clients opening — and immediately losing — a subscription the
-  stateless endpoint could never fulfill (S027, S028).
-- **Auth gotcha**: every request needs the `X-Redmine-API-Key` header, validated
-  per-request (via `SessionStrategy`) against the user account. No/invalid key →
-  **HTTP 401**; MCP server disabled → **HTTP 403** (S002, S006, S007).
-- **Permissions**: **all** tools are exposed by default; access is governed
-  entirely by Redmine's existing permission system, checked at **each tool
-  execution** against `User.current` (`view_ai_helper`, project membership, etc.)
-  (S007). Every call passes `tool_call_permitted?`, which checks **both** Redmine
-  permissions **and** plugin settings (e.g. whether the Vector DB is available)
-  (S006).
-- **No rate limiting** in the initial implementation — deliberately deferred as a
-  future extension (S007).
-- **Anonymous-endpoint pattern**: this controller established how the plugin
-  serves anonymous POSTs — `skip_before_action :verify_authenticity_token` plus
-  `skip_before_action :check_if_login_required, raise: false`, the latter being
-  the fix for 403s under `Setting.login_required` (Issue #304). The inbound chat
-  webhook endpoint reuses it verbatim — see
-  [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) (S018).
-
-Internal `RubyLLM::Tool` subclasses are converted into `MCP::Tool` instances by
-`ToolAdapter` (`lib/redmine_ai_helper/mcp/tool_adapter.rb`), with permission
-checks enforced in **both** the adapter and the server layer so unprivileged
-clients never see a tool (S006).
-
-Tool groups exposed: Issue, Project, Wiki, Repository, Board, User, Version,
-File (`analyze_content_files`), and Vector (`find_similar_issues`,
-`ask_with_filter` — requires [Vector Search](./vector-search.md) setup) (S002).
-
 ## Related
 
+- [MCP Server Endpoint](./mcp-server-endpoint.md) — exposing Redmine as an MCP
+  server: auth, permissions, tool groups, and the `subscriptions/listen`
+  rejection (ADR-031).
 - [Multi-Agent Architecture](./multi-agent-architecture.md) — where generated MCP
   agents plug in, and the read-only mode they respect.
 - [Plugin Overview](./plugin-overview.md)

--- a/wiki/pages/mcp-integration.md
+++ b/wiki/pages/mcp-integration.md
@@ -65,6 +65,15 @@ the global `mcp_server_enabled` flag gates the entire endpoint (S002, S006).
   request re-authenticates by its API key (S007).
 - **Protocol methods** supported: `initialize`, `tools/list`, `tools/call`, and
   the `notifications/initialized` message (S007).
+- **Change notifications are not supported.** The endpoint does not implement
+  `subscriptions/listen` (SEP-2575) or advertise `listChanged`/`subscribe`
+  capabilities — `RedmineAiHelper::Mcp::Server.build` declares empty
+  capabilities for `tools`/`prompts`/`resources` (keeping only `logging`, which
+  is genuinely served), and a `RedmineAiHelper::Mcp::Transport` subclass rejects
+  a `subscriptions/listen` request with a JSON-RPC *Method not found* error
+  instead of opening an SSE stream. This closed a request storm caused by
+  well-behaved clients opening — and immediately losing — a subscription the
+  stateless endpoint could never fulfill (S027, S028).
 - **Auth gotcha**: every request needs the `X-Redmine-API-Key` header, validated
   per-request (via `SessionStrategy`) against the user account. No/invalid key →
   **HTTP 401**; MCP server disabled → **HTTP 403** (S002, S006, S007).

--- a/wiki/pages/mcp-listen-rejection.md
+++ b/wiki/pages/mcp-listen-rejection.md
@@ -1,0 +1,79 @@
+---
+title: MCP subscriptions/listen Rejection
+type: decision
+sources: [S027, S028, S029]
+updated: 2026-08-26
+---
+
+# MCP `subscriptions/listen` Rejection (ADR-031)
+
+Part of [MCP Server Endpoint](./mcp-server-endpoint.md). **Change
+notifications are not supported**, by design (ADR-031, S028). The endpoint
+does not implement `subscriptions/listen` (SEP-2575) or advertise
+`listChanged`/`subscribe` capabilities.
+
+**Root cause it fixed**: `Server.build` used to pass no explicit
+`capabilities:`, so the `mcp` gem's defaults advertised `listChanged: true`
+for `tools`/`prompts`/`resources` — a promise never kept, since the plugin
+never emits `notifications/*/list_changed`. A well-behaved client that read
+this capability opened a `subscriptions/listen` stream; the gem serves that
+at the **transport layer** as a Rack streaming `Proc` body, and the
+controller's `Array(body_parts).join` silently called `Proc#to_s` on it,
+returning **HTTP 200 `text/event-stream`** with a garbage body. Clients read
+the 200 as success and reconnected instantly on the immediate close — the
+observed storm (Issue #410: ~59k requests/day against 16 real `tools/call`
+calls) (S027, S028).
+
+**Fix, three coordinated parts, all required**:
+1. `Server.build` now passes explicit
+   `capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} }`
+   (`logging` kept — `logging/setLevel` is genuinely served). Needed because
+   the legacy `initialize` result serialises `capabilities` directly,
+   bypassing `discover_capabilities` (S027).
+2. `RedmineAiHelper::Mcp::Transport < MCP::Server::Transports::StreamableHTTPTransport`
+   overrides `serves_subscriptions_listen?` → `false` **and** the private
+   `handle_subscriptions_listen(body)` → a one-shot `404` / JSON-RPC `-32601`
+   response. Both are required: the gem's `handle_modern` intercepts
+   `subscriptions/listen` *before* consulting capabilities at all, so
+   capability honesty alone can't stop a client that ignores it (S027, S028).
+3. The controller no longer stringifies whatever the transport returns — a
+   body responding to `:call` (a streaming `Proc`) is logged via
+   `ai_helper_logger.error` and answered with HTTP 500 / JSON-RPC `-32603`,
+   replacing the silent-fallback `Array(...).join`. A value-shape check, not
+   a method-name allowlist, so it also catches a future gem version streaming
+   a different method (S027, S028).
+
+> **Gem-version coupling gotcha**: `serves_subscriptions_listen?` and
+> `handle_subscriptions_listen` are named `mcp` 1.3.0 internals, the latter
+> private. A gem upgrade that renames or restructures either regresses
+> **silently** — Ruby raises nothing for an unused same-named private method —
+> so the functional test suite (asserting the observable
+> 404/`-32601`/no-`listChanged` contract, not the override mechanism) is the
+> only safety net (ADR-031 Negative consequences; S027, S028). Per PR review,
+> there is still no dedicated unit test for `Transport` in isolation and no
+> `Gem::Version` smoke-test guard for an upgrade breaking the override —
+> both raised as optional follow-up, not required for this fix (S029).
+
+## Alternatives rejected
+
+- Real notification streaming (`ActionController::Live`, a subscription
+  registry): rejected — the plugin has no events to push and this endpoint is
+  deliberately per-request/stateless; would cost one thread + DB connection
+  per idle client forever, and wouldn't work across multi-process Redmine
+  without an external event bus (S027, S028).
+- Capability declaration only, no transport-level rejection: rejected — the
+  gem invokes `handle_subscriptions_listen` before checking capabilities
+  (S027, S028).
+- Transport-level rejection only, no capability declaration: rejected — the
+  legacy `initialize` path serialises `capabilities` directly and never
+  consults transport state (S027, S028).
+- Monkey-patching the gem's transport class in place: rejected in favor of a
+  local subclass — easier to grep, doesn't risk affecting `ruby_llm-mcp`
+  client code sharing the same process (S028).
+
+## Related
+
+- [MCP Server Endpoint](./mcp-server-endpoint.md) — the endpoint this decision
+  applies to.
+- [MCP Integration](./mcp-integration.md) — the plugin's overall two-capability
+  MCP split.

--- a/wiki/pages/mcp-server-endpoint.md
+++ b/wiki/pages/mcp-server-endpoint.md
@@ -1,0 +1,65 @@
+---
+title: MCP Server Endpoint
+type: component
+sources: [S002, S006, S007, S018, S028]
+updated: 2026-08-26
+---
+
+# MCP Server Endpoint
+
+How the plugin exposes Redmine itself as an MCP server (the other direction is
+[MCP Integration](./mcp-integration.md#consuming-external-mcp-servers)).
+
+Served by `AiHelperMcpController`, enabled via the "MCP Server" admin setting —
+the global `mcp_server_enabled` flag gates the entire endpoint (S002, S006).
+
+- **Endpoints**: `POST /ai_helper/mcp` carries JSON-RPC; `GET`/`DELETE` exist
+  only because the MCP spec requires them and are unused in stateless mode (S002).
+  The transport is **Streamable HTTP only** — no other transport is offered (S007).
+- **Mode**: MCP Streamable HTTP in **stateless, JSON-response** mode
+  (`stateless: true`, `enable_json_response: true`) — all traffic is POST +
+  JSON-RPC, no SSE streaming (S002). Sessions hold **no server-side state**; each
+  request re-authenticates by its API key (S007).
+- **Protocol methods** supported: `initialize`, `tools/list`, `tools/call`, and
+  the `notifications/initialized` message (S007).
+- **Auth gotcha**: every request needs the `X-Redmine-API-Key` header, validated
+  per-request (via `SessionStrategy`) against the user account. No/invalid key →
+  **HTTP 401**; MCP server disabled → **HTTP 403**, and both checks run *before*
+  any method-specific handling, including the
+  [`subscriptions/listen` rejection](./mcp-listen-rejection.md) (S002, S006, S007).
+- **Change notifications are not supported.** See
+  [MCP subscriptions/listen Rejection](./mcp-listen-rejection.md) (ADR-031) for
+  why, and the gem-version-coupling gotcha it left behind (S027, S028, S029).
+- **Permissions**: **all** tools are exposed by default; access is governed
+  entirely by Redmine's existing permission system, checked at **each tool
+  execution** against `User.current` (`view_ai_helper`, project membership, etc.)
+  (S007). Every call passes `tool_call_permitted?`, which checks **both** Redmine
+  permissions **and** plugin settings (e.g. whether the Vector DB is available)
+  (S006).
+- **No rate limiting** in the initial implementation — deliberately deferred as a
+  future extension (S007).
+- **Anonymous-endpoint pattern**: this controller established how the plugin
+  serves anonymous POSTs — `skip_before_action :verify_authenticity_token` plus
+  `skip_before_action :check_if_login_required, raise: false`, the latter being
+  the fix for 403s under `Setting.login_required` (Issue #304). The inbound chat
+  webhook endpoint reuses it verbatim — see
+  [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) (S018).
+
+Internal `RubyLLM::Tool` subclasses are converted into `MCP::Tool` instances by
+`ToolAdapter` (`lib/redmine_ai_helper/mcp/tool_adapter.rb`), with permission
+checks enforced in **both** the adapter and the server layer so unprivileged
+clients never see a tool (S006).
+
+Tool groups exposed: Issue, Project, Wiki, Repository, Board, User, Version,
+File (`analyze_content_files`), and Vector (`find_similar_issues`,
+`ask_with_filter` — requires [Vector Search](./vector-search.md) setup) (S002).
+
+## Related
+
+- [MCP subscriptions/listen Rejection](./mcp-listen-rejection.md) — ADR-031:
+  why change notifications are rejected, and the gem-coupling gotcha.
+- [MCP Integration](./mcp-integration.md) — the consuming-external-servers half
+  and the plugin's overall two-capability split.
+- [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — reuses this
+  controller's anonymous-endpoint pattern.
+- [Vector Search](./vector-search.md) — required for the Vector tool group.

--- a/wiki/pages/vector-search.md
+++ b/wiki/pages/vector-search.md
@@ -93,7 +93,7 @@ indexing, payload indexes, sync, and `ensure_indexes` (S010, S012).
 
 - [Vector Search Internals](./vector-search-internals.md) — the subsystem's
   components, hybrid content, and rake tasks.
-- [MCP Integration](./mcp-integration.md) — the Vector tool group
+- [MCP Server Endpoint](./mcp-server-endpoint.md) — the Vector tool group
   (`find_similar_issues`, `ask_with_filter`) requires this setup.
 - [Think Model](./think-model.md) — a related but *opposite* fallback policy.
 - [Plugin Overview](./plugin-overview.md)

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -31,3 +31,5 @@ Sources are immutable inputs — the wiki never edits them.
 | S024 | specs/046-js-quality-tooling (research.md + plan.md) | feature-artifact | 2026-08-22 | 2026-08-22 | js-quality-tooling.md, classic-script-testing-strategy.md, js-coverage-ratchet-policy.md, js-test-convention.md |
 | S025 | docs/adr/024-javascript-coverage-sent-to-codecov-informational-only.md | file | 2026-08-22 | 2026-08-22 | js-coverage-ratchet-policy.md |
 | S026 | specs/049-search-issues-optional-project (research.md + plan.md) | feature-artifact | 2026-08-24 | 2026-08-24 | search-issues-cross-project-scoping.md, tool-system.md |
+| S027 | specs/051-mcp-reject-subscriptions-listen (spec.md + plan.md) | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-integration.md |
+| S028 | docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md | file | 2026-08-26 | 2026-08-26 | mcp-integration.md |

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -31,5 +31,6 @@ Sources are immutable inputs — the wiki never edits them.
 | S024 | specs/046-js-quality-tooling (research.md + plan.md) | feature-artifact | 2026-08-22 | 2026-08-22 | js-quality-tooling.md, classic-script-testing-strategy.md, js-coverage-ratchet-policy.md, js-test-convention.md |
 | S025 | docs/adr/024-javascript-coverage-sent-to-codecov-informational-only.md | file | 2026-08-22 | 2026-08-22 | js-coverage-ratchet-policy.md |
 | S026 | specs/049-search-issues-optional-project (research.md + plan.md) | feature-artifact | 2026-08-24 | 2026-08-24 | search-issues-cross-project-scoping.md, tool-system.md |
-| S027 | specs/051-mcp-reject-subscriptions-listen (spec.md + plan.md) | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-integration.md |
-| S028 | docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md | file | 2026-08-26 | 2026-08-26 | mcp-integration.md |
+| S027 | specs/051-mcp-reject-subscriptions-listen (research.md + spec.md + plan.md) | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-integration.md, mcp-server-endpoint.md, mcp-listen-rejection.md |
+| S028 | docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md | file | 2026-08-26 | 2026-08-26 | mcp-integration.md, mcp-server-endpoint.md, mcp-listen-rejection.md |
+| S029 | specs/051-mcp-reject-subscriptions-listen/review-summary.md | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-listen-rejection.md |


### PR DESCRIPTION
## Changes

Fixes #410 

- reject `subscriptions/listen` requests on the MCP endpoint with a JSON-RPC "Method not found" error instead of opening a stream, stopping the reconnect storm from clients retrying an unsupported subscription
- stop declaring `tools`/`prompts`/`resources` change-notification capabilities (`listChanged`/`subscribe`) that the endpoint never actually fulfills
- add ADR-031 documenting the root cause and fix
- add functional/unit tests covering the rejection behavior and capability declaration
- split MCP server-endpoint documentation out of `mcp-integration.md` into dedicated wiki pages and fix citation gaps found by wiki lint