### PR TITLE
Restore subscriptions/listen rejection under mcp gem 1.4.0

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/051-mcp-reject-subscriptions-listen"
+  "feature_directory": "specs/052-fix-mcp14-subscriptions-listen"
 }

--- a/docs/adr/032-mcp14-restore-subscriptions-listen-rejection.md
+++ b/docs/adr/032-mcp14-restore-subscriptions-listen-rejection.md
@@ -1,0 +1,89 @@
+# ADR-032: Restore subscriptions/listen Rejection Under mcp 1.4.0
+
+**Date**: 2026-08-28
+**Status**: Accepted
+
+## Context
+
+ADR-031 made the `/ai_helper/mcp` endpoint reject `subscriptions/listen` (SEP-2575) via two
+coordinated overrides on `RedmineAiHelper::Mcp::Transport < MCP::Server::Transports::StreamableHTTPTransport`:
+a public `serves_subscriptions_listen?` hardcoded to `false` (capability-declaration honesty,
+defence in depth), and a private `handle_subscriptions_listen` override returning a one-shot
+404/`-32601` response. Under `mcp` 1.3.0, `handle_modern` called `handle_subscriptions_listen`
+unconditionally on method-name match, without consulting `serves_subscriptions_listen?` at all.
+
+`mcp` 1.4.0 changed this: `serves_subscriptions_listen?` now doubles as the gate condition for
+whether `handle_modern` calls `handle_subscriptions_listen` in the first place
+(`body[:method] == Methods::SUBSCRIPTIONS_LISTEN && serves_subscriptions_listen?`). Because this
+plugin's override always returns `false`, upgrading to `mcp` 1.4.0 silently closes that gate: the
+plugin's 404 rejection logic is never reached, and a `subscriptions/listen` request without an
+`id` falls through to the gem's normal JSON-RPC notification handling, which returns an
+unanswered HTTP 202 — reproducing the request-storm-enabling behavior ADR-031 fixed, for the
+no-`id` case specifically (`research.md` §1–2 of
+`specs/052-fix-mcp14-subscriptions-listen/`).
+
+A prototype confirmed `discover_capabilities` is unaffected by this either way:
+`RedmineAiHelper::Mcp::Server.build` already passes an explicit
+`capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} }` to `MCP::Server.new`, which
+replaces rather than merges with the gem's defaults, so no `listChanged`/`subscribe` flags are
+ever present to strip (`research.md` §3). `serves_subscriptions_listen?` returning `true` or
+`false` makes no difference to the capability declaration under 1.4.0 — it now only controls the
+rejection gate.
+
+## Decision
+
+Delete the `serves_subscriptions_listen?` override from `RedmineAiHelper::Mcp::Transport`,
+letting it fall back to the gem's default (`true`, via the unset `serve_subscriptions_listen:`
+constructor keyword). This keeps the 1.4.0 gate open, so the unchanged private
+`handle_subscriptions_listen` override is reached again by method-name match alone, restoring the
+one-shot 404/`-32601` rejection for both `id`-bearing and `id`-less requests.
+
+The `handle_subscriptions_listen` override itself, and its docstring's grounding in the
+observable 404/`-32601`/no-`listChanged` contract, are unchanged — feature 051's functional test
+suite for `subscriptions/listen` passes against 1.4.0 with no test code changes, which is this
+fix's own regression evidence (`research.md` §5).
+
+## Consequences
+
+- **Positive**: the request-storm mitigation from ADR-031 is intact again under `mcp` 1.4.0 —
+  `id`-less `subscriptions/listen` requests get an immediate, observable 404 error instead of a
+  silent 202.
+- **Positive**: this removes one of the two gem-internal members ADR-031 recorded as a coupling
+  risk (`serves_subscriptions_listen?`), leaving only `handle_subscriptions_listen`. This
+  partially resolves the Negative consequence ADR-031 flagged about depending on two named
+  internals.
+- **Negative**: the plugin still overrides one private gem member
+  (`handle_subscriptions_listen`), so it remains exposed to a future gem restructuring of that
+  method; as before, this is only caught by running the functional test suite after a gem
+  upgrade, not by a static contract.
+- **Negative**: `serves_subscriptions_listen?` now silently means two different things across gem
+  versions the plugin has targeted (1.3.0: capability-declaration honesty only, no gating effect;
+  1.4.0: capability declaration plus the sole gate for `handle_subscriptions_listen`). Not
+  overriding it ties this plugin's rejection behavior to the gem's default for that keyword
+  remaining `true`; a future gem version flipping that default would reopen this exact regression
+  and would only be caught by the same functional test suite.
+
+## Alternatives Considered
+
+- **Override `serves_subscriptions_listen?` to explicitly return `true`**: behaviorally identical
+  to relying on the default, but leaves a no-op override in the code that merely echoes the gem's
+  own default — against YAGNI/KISS. Deleting the override is simpler and communicates the actual
+  intent more accurately: this plugin does not care about the value of
+  `serves_subscriptions_listen?` itself, only that `handle_subscriptions_listen` is reached.
+- **Pass `serve_subscriptions_listen: true` explicitly at the `Transport.new` call site**
+  (`app/controllers/ai_helper_mcp_controller.rb`): adds a file and a line to state the same value
+  the default already provides, with no gain in clarity over deleting the override.
+- **Adopt the gem's new `serve_subscriptions_listen: false` constructor option as the rejection
+  mechanism**, replacing the private `handle_subscriptions_listen` override: rejected. That option
+  only prevents the gate from calling `handle_subscriptions_listen`; it does not change how
+  `id`-less requests are dispatched, so they would still fall through to the notification path and
+  return an unanswered 202 — failing this feature's core requirement (FR-002, spec Assumptions).
+- **Leave `handle_subscriptions_listen` unoverridden and rely on the gem's standard 404
+  delegation**: rejected — does not solve the `id`-less request problem either, for the same
+  reason ADR-031 originally rejected it.
+
+## References
+
+- Supersedes the "override `serves_subscriptions_listen?`" element of ADR-031's Decision §2; does
+  not modify ADR-031 itself (append-only).
+- `specs/052-fix-mcp14-subscriptions-listen/research.md`, `contracts/transport-internal.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,3 +84,4 @@ Briefly describe alternatives that were rejected and why.
 | [029](./029-search-issues-cross-project-scoping.md) | search_issues cross-project scoping | Accepted |
 | [030](./030-list-project-activities-cross-project-scoping.md) | list_project_activities cross-project scoping | Accepted |
 | [031](./031-mcp-endpoint-rejects-subscriptions-listen.md) | MCP endpoint rejects subscriptions/listen | Accepted |
+| [032](./032-mcp14-restore-subscriptions-listen-rejection.md) | Restore subscriptions/listen rejection under mcp 1.4.0 | Accepted |

--- a/lib/redmine_ai_helper/mcp/transport.rb
+++ b/lib/redmine_ai_helper/mcp/transport.rb
@@ -4,7 +4,7 @@ require "mcp"
 
 module RedmineAiHelper
   module Mcp
-    # Subclass of the `mcp` gem's Streamable HTTP transport (gem version 1.3.0,
+    # Subclass of the `mcp` gem's Streamable HTTP transport (gem version 1.4.0,
     # +MCP::Server::Transports::StreamableHTTPTransport+) whose sole purpose is to
     # declare, honestly and at the transport layer, that this endpoint does not serve
     # `subscriptions/listen` (SEP-2575 change-notification streaming).
@@ -17,36 +17,23 @@ module RedmineAiHelper
     # long-lived SSE stream, which invites well-behaved clients to open a subscription
     # that is silently closed — see +docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md+.
     #
-    # Two overrides answer this:
-    # - {#serves_subscriptions_listen?} (capability-declaration honesty)
-    # - `handle_subscriptions_listen` (transport-level rejection of the method)
+    # A single override answers this: `handle_subscriptions_listen` (transport-level
+    # rejection of the method). As of gem 1.4.0, +serves_subscriptions_listen?+ (base
+    # class, defaults to `true` via the `serve_subscriptions_listen:` constructor
+    # keyword) doubles as the gate that decides whether `handle_modern` calls
+    # `handle_subscriptions_listen` at all; this class does not override it, so the
+    # gate stays open and the rejection below is always reached.
     class Transport < MCP::Server::Transports::StreamableHTTPTransport
-      # Declares that this endpoint does not serve `subscriptions/listen` (SEP-2575).
-      #
-      # Overrides the gem's hardcoded `true` (mcp 1.3.0,
-      # `streamable_http_transport.rb:265`). Consumed by
-      # `MCP::Server#discover_capabilities` (`server.rb:1188`), which strips the
-      # `listChanged`/`subscribe` capability flags from the `server/discover` result
-      # when this is falsey. This is defence in depth alongside the explicit
-      # `capabilities:` passed by {RedmineAiHelper::Mcp::Server.build}: even if a future
-      # gem version reintroduces a default `listChanged` promise, `server/discover`
-      # stays honest.
-      #
-      # @return [Boolean] always `false`
-      def serves_subscriptions_listen?
-        false
-      end
-
       private
 
       # Rejects `subscriptions/listen` (SEP-2575) as an unknown method instead of opening
       # the gem's default SSE notification stream.
       #
       # Overrides the private +StreamableHTTPTransport#handle_subscriptions_listen+
-      # (mcp 1.3.0, `streamable_http_transport.rb:824`), which +handle_modern+ calls
-      # unconditionally for this method, *without* consulting
-      # {#serves_subscriptions_listen?} — so this override is required in addition to
-      # that one (see `specs/051-mcp-reject-subscriptions-listen/contracts/transport-internal.md`).
+      # (mcp 1.4.0, `streamable_http_transport.rb:840`), which +handle_modern+ calls
+      # for this method whenever +serves_subscriptions_listen?+ is truthy — the base
+      # class default, left un-overridden by this class (see
+      # `specs/052-fix-mcp14-subscriptions-listen/contracts/transport-internal.md`).
       #
       # Only `body[:id]` is read; `body[:params]` (including any `notifications` filter)
       # is never inspected, no entry is added to `@listen_subscriptions`, and no thread is

--- a/wiki/INDEX.md
+++ b/wiki/INDEX.md
@@ -11,6 +11,7 @@ page files, not here.
 ## decision
 - [Agent Write-Capability Routing](./pages/agent-write-capability-routing.md) — why `can_write?`/`requires_write` guard write steps at dispatch time instead of being exposed to the router, and how skipped steps and the final-answer prompt stay consistent with what actually ran.
 - [MCP subscriptions/listen Rejection](./pages/mcp-listen-rejection.md) — ADR-031: the root cause (a streaming Proc body stringified into a fake 200), the three-part fix, alternatives rejected, and the gem-version-coupling gotcha it leaves behind.
+- [MCP subscriptions/listen 1.4.0 Fix](./pages/mcp-listen-rejection-1-4-0-fix.md) — ADR-032: how `mcp` 1.4.0 turned `serves_subscriptions_listen?` into the rejection gate itself, silently reopening the id-less request-storm case, and why deleting the override (not adopting the gem's new `serve_subscriptions_listen: false`) fixes it.
 - [Inbound Chat Webhook Ingest](./pages/inbound-chat-webhook-ingest.md) — why webhook events land on a Rails endpoint in Redmine, hand off through a DB table, and are polled by `InboundAdapter#start` so the gateway core stays unchanged.
 - [Public URL Scope for Chat Adapters](./pages/public-url-scope.md) — ADR-017's amendment to ADR-006: "no public URL required" is an outbound-adapter property, not a whole-plugin invariant.
 - [Completion Request Timeout Policy](./pages/completion-request-timeout-policy.md) — ADR-018: why completion LLM calls override RubyLLM's 300 s / 3-retry defaults per context, the injection path, and the alternatives rejected.

--- a/wiki/pages/mcp-integration.md
+++ b/wiki/pages/mcp-integration.md
@@ -57,7 +57,7 @@ transparent (S006). See [Multi-Agent Architecture](./multi-agent-architecture.md
 
 - [MCP Server Endpoint](./mcp-server-endpoint.md) — exposing Redmine as an MCP
   server: auth, permissions, tool groups, and the `subscriptions/listen`
-  rejection (ADR-031).
+  rejection (ADR-031, ADR-032).
 - [Multi-Agent Architecture](./multi-agent-architecture.md) — where generated MCP
   agents plug in, and the read-only mode they respect.
 - [Plugin Overview](./plugin-overview.md)

--- a/wiki/pages/mcp-listen-rejection-1-4-0-fix.md
+++ b/wiki/pages/mcp-listen-rejection-1-4-0-fix.md
@@ -1,0 +1,80 @@
+---
+title: MCP subscriptions/listen 1.4.0 Fix
+type: decision
+sources: [S030, S031]
+updated: 2026-08-28
+---
+
+# MCP `subscriptions/listen` 1.4.0 Fix (ADR-032)
+
+Follow-up to [MCP subscriptions/listen Rejection](./mcp-listen-rejection.md)
+(ADR-031). ADR-032 is append-only with respect to ADR-031 — it supersedes
+only the `serves_subscriptions_listen?` half of ADR-031's fix, not the ADR
+itself (S030, S031).
+
+**The regression**: upgrading the `mcp` gem from 1.3.0 to 1.4.0 silently
+broke ADR-031's part 2. `serves_subscriptions_listen?` changed from an inert
+capability-honesty flag into **the gate condition itself** for whether
+`handle_modern` calls `handle_subscriptions_listen`
+(`body[:method] == SUBSCRIPTIONS_LISTEN && serves_subscriptions_listen?`).
+Because the plugin's override hardcoded `false`, the gate stayed permanently
+closed under 1.4.0: `handle_subscriptions_listen` was never reached, and a
+`subscriptions/listen` request **without an `id`** fell through to the gem's
+normal JSON-RPC notification handling, returning an unanswered HTTP 202 —
+reproducing the request-storm-enabling behavior ADR-031 fixed, for the
+no-`id` case specifically. Requests *with* an `id` happened to still work,
+masking the regression (S030, S031).
+
+`discover_capabilities` was confirmed unaffected either way: `Server.build`
+already passes an explicit `capabilities:` hash that *replaces* rather than
+merges with the gem's defaults, so no `listChanged`/`subscribe` flags are
+ever present to strip regardless of `serves_subscriptions_listen?`'s value
+(S030, S031).
+
+**Fix**: delete the `serves_subscriptions_listen?` override entirely, letting
+it fall back to the gem's default (`true`, via the unset
+`serve_subscriptions_listen:` constructor keyword). This keeps the 1.4.0 gate
+open, so the unchanged private `handle_subscriptions_listen` override is
+reached again by method-name match alone — restoring the one-shot
+404/`-32601` rejection for both `id`-bearing and `id`-less requests, with no
+change to `handle_subscriptions_listen` itself or to feature 051's test suite
+(S030, S031).
+
+> **Gem-version coupling gotcha, updated**: only one gem-internal member is
+> now overridden (`handle_subscriptions_listen`, private) — down from two,
+> since `serves_subscriptions_listen?` is no longer touched. This partially
+> resolves ADR-031's Negative consequence about depending on two named
+> internals, but the 1.3.0→1.4.0 upgrade is itself the concrete case of the
+> risk ADR-031 warned about: a gem restructuring changed what
+> `serves_subscriptions_listen?` means with **no** Ruby-level error, caught
+> only by the functional test suite. Relying on the gem's default now also
+> means the plugin's rejection behavior is tied to that default remaining
+> `true`; a future gem version flipping it would reopen this exact regression
+> and, again, would only be caught by that same test suite (ADR-032
+> Consequences; S030, S031).
+
+## Alternatives rejected
+
+- Override `serves_subscriptions_listen?` to explicitly return `true` instead
+  of deleting it: behaviorally identical to the gem default, but leaves a
+  no-op override that only echoes the gem's own default — against YAGNI/KISS
+  (S030, S031).
+- Pass `serve_subscriptions_listen: true` explicitly at the `Transport.new`
+  call site instead: adds a file/line to state the same value the default
+  already provides, no clarity gain (S030, S031).
+- Adopt the gem's new `serve_subscriptions_listen: false` constructor option
+  as the rejection mechanism, replacing the `handle_subscriptions_listen`
+  override: rejected — that option only closes the gate; `id`-less requests
+  would still fall through to the notification path and return an unanswered
+  202, failing FR-002 (S030, S031).
+- Leave `handle_subscriptions_listen` unoverridden and rely on the gem's
+  standard 404 delegation: rejected — doesn't solve the `id`-less request
+  problem either, for the same reason ADR-031 originally rejected it (S030,
+  S031).
+
+## Related
+
+- [MCP subscriptions/listen Rejection](./mcp-listen-rejection.md) — ADR-031:
+  the original request-storm fix this one patches.
+- [MCP Server Endpoint](./mcp-server-endpoint.md) — the endpoint this
+  decision applies to.

--- a/wiki/pages/mcp-listen-rejection.md
+++ b/wiki/pages/mcp-listen-rejection.md
@@ -2,7 +2,7 @@
 title: MCP subscriptions/listen Rejection
 type: decision
 sources: [S027, S028, S029]
-updated: 2026-08-26
+updated: 2026-08-28
 ---
 
 # MCP `subscriptions/listen` Rejection (ADR-031)
@@ -11,6 +11,12 @@ Part of [MCP Server Endpoint](./mcp-server-endpoint.md). **Change
 notifications are not supported**, by design (ADR-031, S028). The endpoint
 does not implement `subscriptions/listen` (SEP-2575) or advertise
 `listChanged`/`subscribe` capabilities.
+
+> **mcp 1.4.0 update**: part 2 of the fix below (the
+> `serves_subscriptions_listen?` override) was later deleted to fix a
+> regression introduced by the `mcp` gem's 1.3.0→1.4.0 upgrade. See
+> [MCP subscriptions/listen 1.4.0 Fix](./mcp-listen-rejection-1-4-0-fix.md)
+> (ADR-032).
 
 **Root cause it fixed**: `Server.build` used to pass no explicit
 `capabilities:`, so the `mcp` gem's defaults advertised `listChanged: true`
@@ -24,7 +30,7 @@ the 200 as success and reconnected instantly on the immediate close — the
 observed storm (Issue #410: ~59k requests/day against 16 real `tools/call`
 calls) (S027, S028).
 
-**Fix, three coordinated parts, all required**:
+**Fix, three coordinated parts (mcp 1.3.0, as originally shipped)**:
 1. `Server.build` now passes explicit
    `capabilities: { tools: {}, prompts: {}, resources: {}, logging: {} }`
    (`logging` kept — `logging/setLevel` is genuinely served). Needed because
@@ -33,9 +39,11 @@ calls) (S027, S028).
 2. `RedmineAiHelper::Mcp::Transport < MCP::Server::Transports::StreamableHTTPTransport`
    overrides `serves_subscriptions_listen?` → `false` **and** the private
    `handle_subscriptions_listen(body)` → a one-shot `404` / JSON-RPC `-32601`
-   response. Both are required: the gem's `handle_modern` intercepts
-   `subscriptions/listen` *before* consulting capabilities at all, so
-   capability honesty alone can't stop a client that ignores it (S027, S028).
+   response. Both were required under 1.3.0: the gem's `handle_modern`
+   intercepted `subscriptions/listen` *before* consulting capabilities at all,
+   so capability honesty alone couldn't stop a client that ignored it (S027,
+   S028). **The `serves_subscriptions_listen?` half was later deleted — see
+   the 1.4.0 fix page linked above.**
 3. The controller no longer stringifies whatever the transport returns — a
    body responding to `:call` (a streaming `Proc`) is logged via
    `ai_helper_logger.error` and answered with HTTP 500 / JSON-RPC `-32603`,
@@ -43,16 +51,13 @@ calls) (S027, S028).
    a method-name allowlist, so it also catches a future gem version streaming
    a different method (S027, S028).
 
-> **Gem-version coupling gotcha**: `serves_subscriptions_listen?` and
-> `handle_subscriptions_listen` are named `mcp` 1.3.0 internals, the latter
-> private. A gem upgrade that renames or restructures either regresses
-> **silently** — Ruby raises nothing for an unused same-named private method —
-> so the functional test suite (asserting the observable
-> 404/`-32601`/no-`listChanged` contract, not the override mechanism) is the
-> only safety net (ADR-031 Negative consequences; S027, S028). Per PR review,
-> there is still no dedicated unit test for `Transport` in isolation and no
-> `Gem::Version` smoke-test guard for an upgrade breaking the override —
-> both raised as optional follow-up, not required for this fix (S029).
+> **Gem-version coupling gotcha (original)**: `serves_subscriptions_listen?`
+> and `handle_subscriptions_listen` were named `mcp` 1.3.0 internals, the
+> latter private. A gem upgrade that renames or restructures either regresses
+> **silently** — the functional test suite, not the override mechanism, is
+> the only safety net (ADR-031 Negative consequences; S027, S028). This is
+> exactly what happened at 1.4.0 — see the linked fix page for the updated
+> gotcha and outstanding follow-ups (S029).
 
 ## Alternatives rejected
 
@@ -73,6 +78,9 @@ calls) (S027, S028).
 
 ## Related
 
+- [MCP subscriptions/listen 1.4.0 Fix](./mcp-listen-rejection-1-4-0-fix.md) —
+  ADR-032: the regression this original fix suffered under `mcp` 1.4.0, and
+  what changed.
 - [MCP Server Endpoint](./mcp-server-endpoint.md) — the endpoint this decision
   applies to.
 - [MCP Integration](./mcp-integration.md) — the plugin's overall two-capability

--- a/wiki/pages/mcp-server-endpoint.md
+++ b/wiki/pages/mcp-server-endpoint.md
@@ -1,8 +1,8 @@
 ---
 title: MCP Server Endpoint
 type: component
-sources: [S002, S006, S007, S018, S028]
-updated: 2026-08-26
+sources: [S002, S006, S007, S018, S028, S030, S031]
+updated: 2026-08-28
 ---
 
 # MCP Server Endpoint
@@ -29,7 +29,10 @@ the global `mcp_server_enabled` flag gates the entire endpoint (S002, S006).
   [`subscriptions/listen` rejection](./mcp-listen-rejection.md) (S002, S006, S007).
 - **Change notifications are not supported.** See
   [MCP subscriptions/listen Rejection](./mcp-listen-rejection.md) (ADR-031) for
-  why, and the gem-version-coupling gotcha it left behind (S027, S028, S029).
+  why, and the gem-version-coupling gotcha it left behind — which materialized
+  once already, fixed in
+  [MCP subscriptions/listen 1.4.0 Fix](./mcp-listen-rejection-1-4-0-fix.md)
+  (ADR-032) (S027, S028, S029, S030, S031).
 - **Permissions**: **all** tools are exposed by default; access is governed
   entirely by Redmine's existing permission system, checked at **each tool
   execution** against `User.current` (`view_ai_helper`, project membership, etc.)
@@ -58,6 +61,8 @@ File (`analyze_content_files`), and Vector (`find_similar_issues`,
 
 - [MCP subscriptions/listen Rejection](./mcp-listen-rejection.md) — ADR-031:
   why change notifications are rejected, and the gem-coupling gotcha.
+- [MCP subscriptions/listen 1.4.0 Fix](./mcp-listen-rejection-1-4-0-fix.md) —
+  ADR-032: the `mcp` 1.4.0 regression that gotcha predicted, and the fix.
 - [MCP Integration](./mcp-integration.md) — the consuming-external-servers half
   and the plugin's overall two-capability split.
 - [Inbound Webhook Endpoint](./inbound-webhook-endpoint.md) — reuses this

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -34,3 +34,5 @@ Sources are immutable inputs — the wiki never edits them.
 | S027 | specs/051-mcp-reject-subscriptions-listen (research.md + spec.md + plan.md) | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-integration.md, mcp-server-endpoint.md, mcp-listen-rejection.md |
 | S028 | docs/adr/031-mcp-endpoint-rejects-subscriptions-listen.md | file | 2026-08-26 | 2026-08-26 | mcp-integration.md, mcp-server-endpoint.md, mcp-listen-rejection.md |
 | S029 | specs/051-mcp-reject-subscriptions-listen/review-summary.md | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-listen-rejection.md |
+| S030 | specs/052-fix-mcp14-subscriptions-listen (research.md + plan.md) | feature-artifact | 2026-08-28 | 2026-08-28 | mcp-listen-rejection.md, mcp-listen-rejection-1-4-0-fix.md, mcp-server-endpoint.md |
+| S031 | docs/adr/032-mcp14-restore-subscriptions-listen-rejection.md | file | 2026-08-28 | 2026-08-28 | mcp-listen-rejection.md, mcp-listen-rejection-1-4-0-fix.md, mcp-server-endpoint.md |


### PR DESCRIPTION
## Changes

- Remove the `serves_subscriptions_listen?` override in `RedmineAiHelper::Mcp::Transport`, letting it fall back to the gem's default so `mcp` 1.4.0's new gating condition no longer suppresses the plugin's `subscriptions/listen` rejection
- Restore the one-shot 404/`-32601` rejection for both `id`-bearing and `id`-less `subscriptions/listen` requests, fixing the silent HTTP 202 regression introduced by upgrading to `mcp` 1.4.0
- Add ADR-032 documenting the root cause and decision, and update related wiki pages (`mcp-integration.md`, `mcp-listen-rejection.md`, `mcp-server-endpoint.md`) and `wiki/sources.md`/`wiki/INDEX.md`