### PR TITLE
Add code size, Ruby test, and coverage reporting to CI summary

### DIFF
--- a/.github/build-scripts/build.sh
+++ b/.github/build-scripts/build.sh
@@ -18,6 +18,7 @@ bundle exec rake test:scm:setup:all
 
 # run tests
 # bundle exec rake TEST=test/unit/role_test.rb
-bundle exec rake redmine:plugins:test NAME=$NAME_OF_PLUGIN
+bundle exec rake redmine:plugins:test NAME=$NAME_OF_PLUGIN 2>&1 | tee $PATH_TO_PLUGIN/ruby-test-output.log
+test ${PIPESTATUS[0]} -eq 0
 
 cp -pr plugins/$NAME_OF_PLUGIN/coverage $PATH_TO_PLUGIN

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,19 @@ jobs:
       - name: RuboCop
         run: rubocop
 
+  size-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install cloc
+        run: sudo apt-get update && sudo apt-get install -y cloc
+      - name: Code size summary
+        continue-on-error: true
+        run: |
+          { echo "## 📊 Code size"; cloc --md app lib assets/javascripts; } >> "$GITHUB_STEP_SUMMARY"
+
   javascript:
     runs-on: ubuntu-latest
     permissions:
@@ -67,7 +80,18 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
-      - run: npm run test:coverage
+      - run: npm run test:coverage -- --reporter=default --reporter=json --outputFile=vitest-results.json
+      - name: JS test/coverage summary
+        if: always()
+        continue-on-error: true
+        run: |
+          {
+            echo "## 🧪 JavaScript test results"
+            jq -r '"- Test Files: \(.numTotalTestSuites) (failed: \(.numFailedTestSuites))\n- Tests: \(.numTotalTests) total (failed: \(.numFailedTests))"' vitest-results.json
+            echo ""
+            echo "## 📈 JavaScript coverage"
+            jq -r '.total | "- Lines: \(.lines.pct)%\n- Statements: \(.statements.pct)%\n- Functions: \(.functions.pct)%\n- Branches: \(.branches.pct)%"' coverage-js/coverage-summary.json
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: codecov/codecov-action@v7
         if: env.CODECOV_TOKEN != ''
         with:
@@ -149,6 +173,18 @@ jobs:
           fi
       - name: Clean
         run: bash -x ./.github/build-scripts/cleanup.sh
+      - name: Ruby test/coverage summary
+        if: matrix.ruby_version == '3.4' && matrix.redmine_version == '7.0-stable' && matrix.db == 'sqlite3'
+        continue-on-error: true
+        run: |
+          {
+            echo "## 🧪 Ruby test results (ruby 3.4 / redmine 7.0-stable / sqlite3)"
+            grep -E '^[0-9]+ runs, [0-9]+ assertions' ruby-test-output.log || echo "(summary line not found)"
+            echo ""
+            echo "## 📈 Ruby coverage"
+            line_rate=$(grep -oP '(?<=line-rate=")[^"]+' coverage/coverage.xml | head -1)
+            awk -v r="$line_rate" 'BEGIN { printf "- Lines: %.2f%%\n", r * 100 }'
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: codecov/codecov-action@v7
         if: env.CODECOV_TOKEN != ''
         with:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
       provider: "v8",
       include: ["assets/javascripts/**/*.js"],
       exclude: [],
-      reporter: ["text", "html", "lcov"],
+      reporter: ["text", "html", "lcov", "json-summary"],
       reportsDirectory: "coverage-js",
       // Ratchet: raised (never lowered) as each stage adds tests, rounded
       // down from the measured value for a safe margin. Target: 95.


### PR DESCRIPTION
## Changes

- Add a `size-report` job that publishes JS/Ruby code size (via cloc) to the GitHub Actions job summary
- Publish JavaScript test results and coverage percentages (from vitest JSON output) to the job summary
- Publish Ruby test results and coverage from a single representative build matrix leg (ruby 3.4 / redmine 7.0-stable / sqlite3) to the job summary
- Tee Ruby test output to a log file in build.sh so it can be parsed for the summary