### PR TITLE
Fix projects helper test and add YARD comments

### DIFF
--- a/lib/redmine_ai_helper/projects_helper_patch.rb
+++ b/lib/redmine_ai_helper/projects_helper_patch.rb
@@ -5,6 +5,10 @@ require_dependency "projects_helper"
 module RedmineAiHelper
   # Adds the AI Helper status icon to the project board.
   module ProjectsHelperPatch
+    # Renders the project hierarchy and appends the AI Helper icon to
+    # every project that has the ai_helper module enabled.
+    # @param projects [Array<Project>] The projects to render
+    # @return [String] The rendered HTML with AI Helper icons added
     def render_project_hierarchy(projects)
       # Call the original render_project_hierarchy method to get the base HTML
       html = render_project_hierarchy_without_ai_helper(projects)
@@ -15,6 +19,10 @@ module RedmineAiHelper
 
     private
 
+    # Inserts the AI Helper icon into the rendered project hierarchy HTML.
+    # @param html [String] The HTML rendered by the original helper
+    # @param projects [Array<Project>] The projects contained in the HTML
+    # @return [String] The HTML with AI Helper icons added
     def add_ai_helper_icons_to_project_hierarchy(html, projects)
       doc = Nokogiri::HTML::DocumentFragment.parse(html.to_s)
 

--- a/lib/redmine_ai_helper/projects_queries_helper_patch.rb
+++ b/lib/redmine_ai_helper/projects_queries_helper_patch.rb
@@ -5,6 +5,12 @@ require_dependency "projects_queries_helper"
 module RedmineAiHelper
   # Adds the AI Helper status icon to the project list.
   module ProjectsQueriesHelperPatch
+    # Appends the AI Helper icon to the project name column when the
+    # project has the ai_helper module enabled.
+    # @param column [QueryColumn] The column being rendered
+    # @param item [Object] The row object being rendered
+    # @param value [Object] The raw value of the column
+    # @return [String] The rendered column value
     def column_value(column, item, value)
       return super unless item.is_a?(Project) && column.name == :name
 

--- a/test/unit/projects_helper_test.rb
+++ b/test/unit/projects_helper_test.rb
@@ -2,6 +2,7 @@ require_relative "../test_helper"
 
 class ProjectsHelperTest < ActionView::TestCase
   include ProjectsHelper
+  include ERB::Util
 
   Column = Struct.new(:name)
 


### PR DESCRIPTION
## Changes

- Include `ERB::Util` in `ProjectsHelperTest` so the helper under test can call `h()` and the unit test passes again
- Add YARD comments to `ProjectsHelperPatch#render_project_hierarchy` and `#add_ai_helper_icons_to_project_hierarchy` to satisfy the documentation coverage check
- Add YARD comments to `ProjectsQueriesHelperPatch#column_value` for the same reason

These restore a clean regression check (YARD coverage, RuboCop, test suite) for the projects helper patches introduced in #425.