### PR TITLE
Fix AI Helper icon position and add legend entry

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/054-mcp-issue-data"
+  "feature_directory": "specs/055-fix-icon-and-legend"
 }

--- a/app/views/ai_helper/project/_index_legend.html.erb
+++ b/app/views/ai_helper/project/_index_legend.html.erb
@@ -1,0 +1,11 @@
+<%#
+  AI Helper legend item for the project list (projects#index).
+  Rendered hidden; ai_helper_project_legend.js moves it into the existing
+  legend <p> element (the one containing icon-bookmarked-project) when present.
+%>
+<% if controller_name == 'projects' && action_name == 'index' && User.current.logged? %>
+  <span id="ai-helper-index-legend-item" class="icon icon-only icon-ai-helper-module" hidden>
+    <%= sprite_icon('ai-helper-robot', l(:label_ai_helper), icon_only: true, plugin: :redmine_ai_helper) %>
+  </span>
+  <%= javascript_include_tag('project_legend/ai_helper_project_legend.js', plugin: :redmine_ai_helper) %>
+<% end %>

--- a/app/views/ai_helper/project/_index_legend.html.erb
+++ b/app/views/ai_helper/project/_index_legend.html.erb
@@ -4,8 +4,8 @@
   legend <p> element (the one containing icon-bookmarked-project) when present.
 %>
 <% if controller_name == 'projects' && action_name == 'index' && User.current.logged? %>
-  <span id="ai-helper-index-legend-item" class="icon icon-only icon-ai-helper-module" hidden>
-    <%= sprite_icon('ai-helper-robot', l(:label_ai_helper), icon_only: true, plugin: :redmine_ai_helper) %>
+  <span id="ai-helper-index-legend-item" class="icon icon-ai-helper-module" hidden>
+    <%= sprite_icon('ai-helper-robot', l(:label_ai_helper), plugin: :redmine_ai_helper) %>
   </span>
   <%= javascript_include_tag('project_legend/ai_helper_project_legend.js', plugin: :redmine_ai_helper) %>
 <% end %>

--- a/assets/javascripts/project_legend/ai_helper_project_legend.js
+++ b/assets/javascripts/project_legend/ai_helper_project_legend.js
@@ -1,0 +1,21 @@
+/**
+ * Moves the server-rendered (but hidden) AI Helper legend item into the
+ * project list's existing legend paragraph (the one containing the
+ * bookmarked-project icon), so the legend explains the AI Helper icon shown
+ * in the project list. Does nothing when either element is absent, e.g. on
+ * pages other than the logged-in projects#index (no legend paragraph) or
+ * when the AI Helper module has no legend item queued.
+ */
+document.addEventListener('DOMContentLoaded', function() {
+  const legendItem = document.getElementById('ai-helper-index-legend-item');
+  if (!legendItem) {return;}
+
+  const bookmarkIcon = document.querySelector('.icon-bookmarked-project');
+  if (!bookmarkIcon) {return;}
+
+  const legend = bookmarkIcon.parentElement;
+  if (!legend) {return;}
+
+  legendItem.hidden = false;
+  legend.appendChild(legendItem);
+});

--- a/docs/adr/035-project-index-legend-body-bottom-hook.md
+++ b/docs/adr/035-project-index-legend-body-bottom-hook.md
@@ -1,0 +1,91 @@
+# ADR-035: Add the AI Helper legend entry via view_layouts_base_body_bottom + JS relocation
+
+**Date**: 2026-08-31
+**Status**: Accepted
+
+## Context
+
+`app/views/projects/index.html.erb` (Redmine core) renders a legend at the bottom of the
+logged-in project list, explaining the "My projects" and "Bookmarked" icons shown next to
+project names:
+
+```erb
+<% if User.current.logged? %>
+<p style="text-align:right;">
+<span class="icon icon-user my-project">...</span>
+<span class="icon icon-bookmarked-project">...</span>
+</p>
+<% end %>
+```
+
+Feature 055 adds an AI Helper icon to the project list (both board and list display types) and
+needs to explain that icon in the same legend, for both display types, without touching list
+rendering. Unlike most extension points this plugin uses (`view_issues_show_details_bottom`,
+`view_projects_show_right`, etc.), Redmine core does not call any `Redmine::Hook` hook at this
+exact location in `index.html.erb`, so there is no `render_on` target that lands HTML directly
+inside that `<p>`.
+
+Constitution IV requires that HTML be generated server-side (ERB), and that JavaScript be
+limited to manipulating DOM elements ERB has already rendered — it must not assemble icon or
+label markup itself.
+
+## Decision
+
+Register a new partial, `ai_helper/project/_index_legend`, on the existing
+`view_layouts_base_body_bottom` hook (already used by this plugin for `wiki/textarea_overlay`
+and `shared/stuff_todo_modal_wrapper`, so it is a proven extension point). The partial:
+
+- Renders a `<span id="ai-helper-index-legend-item" hidden>` containing the same
+  `sprite_icon('ai-helper-robot', ...)` markup used for the in-list icon, only when
+  `controller_name == 'projects' && action_name == 'index' && User.current.logged?`.
+- Emits nothing otherwise (unauthenticated users, or any other controller/action).
+- Also includes `ai_helper_project_legend.js` under the same condition, so the script is only
+  loaded on the one page it applies to.
+
+`assets/javascripts/project_legend/ai_helper_project_legend.js` runs on `DOMContentLoaded` and:
+
+- Looks up the hidden `#ai-helper-index-legend-item` span and the existing legend `<p>` via
+  `document.querySelector('.icon-bookmarked-project')`'s parent.
+- If both exist, un-hides the span and appends it as a child of the existing legend `<p>`
+  (`Node.appendChild` moves an existing node — it does not clone or recreate it), leaving the
+  "My projects" and "Bookmarked" spans untouched.
+- If either is missing, does nothing — no error, no legend added.
+
+This way, all icon/label HTML is server-generated up front; the script only relocates and shows
+an element that already exists in the DOM.
+
+## Consequences
+
+**Positive**:
+- Satisfies Constitution IV: no HTML string assembly happens in JavaScript.
+- Reuses an already-integrated hook point (`view_layouts_base_body_bottom`) rather than adding a
+  new one.
+- Degrades safely: `#ai-helper-index-legend-item` and the legend `<p>` are each independently
+  optional in the DOM, so logged-out users, `projects#index` when the legend `<p>` itself is
+  absent, and any other controller/action are all no-ops.
+- Board and list display types share the same `index.html.erb` legend markup, so one hook
+  partial covers both (FR-005) without a `display_type` branch.
+
+**Negative**:
+- The legend now depends on a `document.querySelector('.icon-bookmarked-project')` DOM lookup
+  succeeding at `DOMContentLoaded` time; if a future Redmine core release restructures or removes
+  that legend `<p>`, the AI Helper legend entry would silently stop appearing (no error, but also
+  no explanation of the AI Helper icon) until this partial/script pair is updated to match.
+- Introduces one more small, page-scoped JS file to maintain, versus a purely server-side
+  solution.
+
+## Alternatives Considered
+
+- **Fully override `app/views/projects/index.html.erb` via `prepend_view_path`**: Would let the
+  legend `<p>` be edited directly in ERB with no JS involved, but requires shadowing the entire
+  core view. Any future Redmine core change to `index.html.erb` (columns, filters, other legend
+  items) would need to be manually re-applied to the override, and it risks conflicting with
+  other plugins that shadow the same view. Rejected as disproportionate maintenance cost for one
+  legend entry.
+- **Assemble the icon/label HTML directly in JavaScript**: Simpler (no server round trip
+  needed for the fragment), but violates Constitution IV, which requires HTML to be built in ERB
+  so `sprite_icon`/`l()` (i18n, icon assets) stay the single source of truth.
+- **Add a controller filter on `ProjectsController#index` that sets an instance variable, then
+  edit the core view to check it**: Still requires shadowing the core view to read the new
+  instance variable, with the same maintenance cost as full override, plus a new controller-level
+  patch. Rejected as broader surface area for no benefit over the hook + JS approach.

--- a/lib/redmine_ai_helper/projects_helper_patch.rb
+++ b/lib/redmine_ai_helper/projects_helper_patch.rb
@@ -29,8 +29,10 @@ module RedmineAiHelper
       projects.each do |project|
         next unless project.module_enabled?(:ai_helper)
 
-        # Find the link to the project in the rendered HTML
-        project_link = doc.search("a[href*='#{project_path(project)}']").first
+        # Find the link to the project in the rendered HTML. An exact match is required
+        # so that a project whose identifier is a prefix of another project's identifier
+        # (e.g. "sample" and "sample-2") is not confused with it.
+        project_link = doc.search("a[href='#{project_path(project)}']").first
         next unless project_link
 
         # Generate the icon HTML as a string
@@ -42,8 +44,15 @@ module RedmineAiHelper
         # Parse the icon HTML string into a Nokogiri element
         icon_element = Nokogiri::HTML::DocumentFragment.parse(icon_html_string).first_element_child
 
-        # Insert the icon as the last child of the project link's parent
-        project_link.parent.add_child(icon_element)
+        # Insert the icon right after the existing icons (my-project / bookmarked) and
+        # before the description, so its position does not depend on whether the
+        # project has a description.
+        description_element = project_link.parent.at_css("> div.wiki.description")
+        if description_element
+          description_element.add_previous_sibling(icon_element)
+        else
+          project_link.parent.add_child(icon_element)
+        end
       end
 
       doc.to_s.html_safe # rubocop:disable Rails/OutputSafety

--- a/lib/redmine_ai_helper/view_hook.rb
+++ b/lib/redmine_ai_helper/view_hook.rb
@@ -11,7 +11,12 @@ module RedmineAiHelper
     render_on :view_issues_form_details_bottom, partial: "ai_helper/shared/textarea_overlay"
     render_on :view_layouts_base_sidebar, partial: "ai_helper/wiki/summary"
     render_on :view_projects_show_right, partial: "ai_helper/project/health_report"
-    render_on :view_layouts_base_body_bottom, partial: "ai_helper/wiki/textarea_overlay"
-    render_on :view_layouts_base_body_bottom, partial: "ai_helper/shared/stuff_todo_modal_wrapper"
+    # NOTE: render_on defines a method named after the hook, so multiple calls for the
+    # same hook overwrite each other. All view_layouts_base_body_bottom partials must be
+    # passed together in a single call.
+    render_on :view_layouts_base_body_bottom,
+              { partial: "ai_helper/wiki/textarea_overlay" },
+              { partial: "ai_helper/shared/stuff_todo_modal_wrapper" },
+              { partial: "ai_helper/project/index_legend" }
   end
 end

--- a/test/functional/ai_helper_project_index_legend_test.rb
+++ b/test/functional/ai_helper_project_index_legend_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class AiHelperProjectIndexLegendTest < ActionController::TestCase
+  tests ProjectsController
+
+  fixtures :projects, :users, :members, :member_roles, :roles, :enabled_modules
+
+  setup do
+    @request.session[:user_id] = 1
+  end
+
+  test "board display shows the AI Helper legend item for a logged in user" do
+    get :index, params: { display_type: "board" }
+    assert_response :success
+
+    doc = Nokogiri::HTML(@response.body)
+    assert doc.at_css("#ai-helper-index-legend-item"), "expected the AI Helper legend item to be present"
+  end
+
+  test "list display shows the AI Helper legend item for a logged in user" do
+    get :index, params: { display_type: "list" }
+    assert_response :success
+
+    doc = Nokogiri::HTML(@response.body)
+    assert doc.at_css("#ai-helper-index-legend-item"), "expected the AI Helper legend item to be present"
+  end
+
+  test "no legend item is rendered for a logged out user" do
+    @request.session[:user_id] = nil
+
+    get :index
+    assert_response :success
+
+    doc = Nokogiri::HTML(@response.body)
+    assert_nil doc.at_css("#ai-helper-index-legend-item")
+  end
+end

--- a/test/javascript/project_legend/ai_helper_project_legend.test.js
+++ b/test/javascript/project_legend/ai_helper_project_legend.test.js
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { loadScriptAndFireDOMContentLoaded } from "../support/dom_content_loaded.js";
+
+describe("ai_helper_project_legend", () => {
+  let legendItem;
+  let legendParagraph;
+  let bookmarkIcon;
+
+  function addLegendItem() {
+    legendItem = document.createElement("span");
+    legendItem.id = "ai-helper-index-legend-item";
+    legendItem.hidden = true;
+    document.body.appendChild(legendItem);
+    return legendItem;
+  }
+
+  function addLegendParagraph() {
+    legendParagraph = document.createElement("p");
+    bookmarkIcon = document.createElement("span");
+    bookmarkIcon.className = "icon icon-bookmarked-project";
+    legendParagraph.appendChild(bookmarkIcon);
+    document.body.appendChild(legendParagraph);
+    return legendParagraph;
+  }
+
+  afterEach(() => {
+    legendItem?.remove();
+    legendParagraph?.remove();
+    legendItem = undefined;
+    legendParagraph = undefined;
+    bookmarkIcon = undefined;
+  });
+
+  it("unhides the legend item and appends it to the legend paragraph when both exist", async () => {
+    addLegendItem();
+    addLegendParagraph();
+
+    const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
+
+    expect(legendItem.hidden).toBe(false);
+    expect(legendItem.parentElement).toBe(legendParagraph);
+    expect(legendParagraph.lastElementChild).toBe(legendItem);
+    cleanup.removeRegisteredListeners();
+  });
+
+  it("does nothing when the legend item is absent", async () => {
+    addLegendParagraph();
+
+    const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
+
+    expect(bookmarkIcon.parentElement).toBe(legendParagraph);
+    expect(legendParagraph.children).toHaveLength(1);
+    cleanup.removeRegisteredListeners();
+  });
+
+  it("does nothing and leaves the legend item hidden when the legend paragraph is absent", async () => {
+    addLegendItem();
+
+    const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
+
+    expect(legendItem.hidden).toBe(true);
+    expect(legendItem.parentElement).toBe(document.body);
+    cleanup.removeRegisteredListeners();
+  });
+});

--- a/test/unit/projects_helper_test.rb
+++ b/test/unit/projects_helper_test.rb
@@ -34,4 +34,40 @@ class ProjectsHelperTest < ActionView::TestCase
     assert_no_match(/icon-ai-helper-module/, html)
     assert_no_match(/icon--ai-helper-robot/, html)
   end
+
+  should "place the AI Helper icon right after the existing icons and before the description" do
+    @project_with_module.update!(description: "This is a description")
+
+    html = render_project_hierarchy([ @project_with_module ])
+    doc = Nokogiri::HTML::DocumentFragment.parse(html)
+    container = doc.at_css("a[href='#{project_path(@project_with_module)}']").parent
+
+    ai_helper_index = container.children.index { |node| node["class"]&.include?("icon-ai-helper-module") }
+    description_node_index = container.children.index { |node| node.name == "div" && node["class"]&.include?("wiki") }
+
+    assert_not_nil ai_helper_index, "expected the AI Helper icon to be present"
+    assert_not_nil description_node_index, "expected the description div to be present"
+    assert_operator ai_helper_index, :<, description_node_index,
+                     "expected the AI Helper icon to appear before the description"
+  end
+
+  should "not append the AI Helper icon to a project whose identifier is a prefix match of another project's identifier" do
+    # sample-2 is created (and thus positioned in the tree) before sample, so a
+    # partial-match link search would incorrectly pick sample-2's link first.
+    sample2_project = Project.create!(name: "Sample 2", identifier: "sample-2")
+    sample_project = Project.create!(name: "Sample", identifier: "sample")
+    sample_project.enable_module!(:ai_helper)
+
+    html = render_project_hierarchy([ sample2_project, sample_project ])
+    doc = Nokogiri::HTML::DocumentFragment.parse(html)
+
+    sample_container = doc.at_css("a[href='#{project_path(sample_project)}']").parent
+    sample2_container = doc.at_css("a[href='#{project_path(sample2_project)}']").parent
+
+    assert_includes sample_container.to_s, "icon-ai-helper-module"
+    assert_not_includes sample2_container.to_s, "icon-ai-helper-module"
+  ensure
+    sample_project&.destroy if sample_project&.persisted?
+    sample2_project&.destroy if sample2_project&.persisted?
+  end
 end

--- a/test/unit/projects_helper_test.rb
+++ b/test/unit/projects_helper_test.rb
@@ -43,7 +43,9 @@ class ProjectsHelperTest < ActionView::TestCase
     container = doc.at_css("a[href='#{project_path(@project_with_module)}']").parent
 
     ai_helper_index = container.children.index { |node| node["class"]&.include?("icon-ai-helper-module") }
-    description_node_index = container.children.index { |node| node.name == "div" && node["class"]&.include?("wiki") }
+    description_node_index = container.children.index do |node|
+      node.name == "div" && node.matches?("div.wiki.description")
+    end
 
     assert_not_nil ai_helper_index, "expected the AI Helper icon to be present"
     assert_not_nil description_node_index, "expected the description div to be present"


### PR DESCRIPTION
## Changes

- Fix AI Helper icon insertion point on the project board so it appears right after the project name, regardless of whether the project has a description
- Uniquely match the target project by identifier (avoid false matches from prefix-matching project identifiers, e.g. `sample` vs `sample-2`)
- Add an AI Helper icon entry to the project list legend (board and list views)
- Add tests covering the board icon position and the legend icon addition