### PR TITLE
Fix legend placement by selecting the correct bookmark icon

### DIFF
--- a/assets/javascripts/project_legend/ai_helper_project_legend.js
+++ b/assets/javascripts/project_legend/ai_helper_project_legend.js
@@ -10,7 +10,8 @@ document.addEventListener('DOMContentLoaded', function() {
   const legendItem = document.getElementById('ai-helper-index-legend-item');
   if (!legendItem) {return;}
 
-  const bookmarkIcon = document.querySelector('.icon-bookmarked-project');
+  const bookmarkIcons = document.querySelectorAll('#content .icon-bookmarked-project');
+  const bookmarkIcon = bookmarkIcons[bookmarkIcons.length - 1];
   if (!bookmarkIcon) {return;}
 
   const legend = bookmarkIcon.parentElement;

--- a/assets/javascripts/project_legend/ai_helper_project_legend.js
+++ b/assets/javascripts/project_legend/ai_helper_project_legend.js
@@ -5,6 +5,9 @@
  * in the project list. Does nothing when either element is absent, e.g. on
  * pages other than the logged-in projects#index (no legend paragraph) or
  * when the AI Helper module has no legend item queued.
+ *
+ * Note: if another plugin adds the same bookmarked-project icon after the
+ * core legend inside #content, this selector can choose the wrong icon.
  */
 document.addEventListener('DOMContentLoaded', function() {
   const legendItem = document.getElementById('ai-helper-index-legend-item');

--- a/test/javascript/project_legend/ai_helper_project_legend.test.js
+++ b/test/javascript/project_legend/ai_helper_project_legend.test.js
@@ -15,16 +15,57 @@ describe("ai_helper_project_legend", () => {
     return legendItem;
   }
 
-  function addLegendParagraph() {
+  function addContentDiv() {
     contentDiv = document.createElement("div");
     contentDiv.id = "content";
+    document.body.appendChild(contentDiv);
+    return contentDiv;
+  }
 
+  function addProjectHierarchyWithMultipleBookmarks(contentDiv, bookmarkedProjectCount = 2) {
+    const projectBoard = document.createElement("ul");
+    for (let index = 0; index < bookmarkedProjectCount; index += 1) {
+      const projectItem = document.createElement("li");
+      const projectItemContent = document.createElement("div");
+      const projectLink = document.createElement("a");
+      projectLink.href = "#";
+      projectLink.textContent = `Project ${index + 1}`;
+      projectItemContent.appendChild(projectLink);
+      const bookmarkIcon = document.createElement("span");
+      bookmarkIcon.className = "icon icon-bookmarked-project";
+      projectItemContent.appendChild(bookmarkIcon);
+      projectItem.appendChild(projectItemContent);
+      projectBoard.appendChild(projectItem);
+    }
+    contentDiv.appendChild(projectBoard);
+    return projectBoard;
+  }
+
+  function addProjectListWithMultipleBookmarks(contentDiv, bookmarkedProjectCount = 2) {
+    const projectList = document.createElement("table");
+    for (let index = 0; index < bookmarkedProjectCount; index += 1) {
+      const projectRow = document.createElement("tr");
+      const projectNameCell = document.createElement("td");
+      const projectLink = document.createElement("a");
+      projectLink.href = "#";
+      projectLink.appendChild(document.createTextNode(`Project ${index + 1}`));
+      projectNameCell.appendChild(projectLink);
+      const bookmarkIcon = document.createElement("span");
+      bookmarkIcon.className = "icon icon-bookmarked-project";
+      projectNameCell.appendChild(bookmarkIcon);
+      projectRow.appendChild(projectNameCell);
+      projectList.appendChild(projectRow);
+    }
+    contentDiv.appendChild(projectList);
+    return projectList;
+  }
+
+  function addLegendParagraph(contentDiv) {
     legendParagraph = document.createElement("p");
     bookmarkIcon = document.createElement("span");
     bookmarkIcon.className = "icon icon-bookmarked-project";
     legendParagraph.appendChild(bookmarkIcon);
     contentDiv.appendChild(legendParagraph);
-    document.body.appendChild(contentDiv);
     return legendParagraph;
   }
 
@@ -40,7 +81,36 @@ describe("ai_helper_project_legend", () => {
 
   it("unhides the legend item and appends it to the legend paragraph when both exist", async () => {
     addLegendItem();
-    addLegendParagraph();
+    const content = addContentDiv();
+    addLegendParagraph(content);
+
+    const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
+
+    expect(legendItem.hidden).toBe(false);
+    expect(legendItem.parentElement).toBe(legendParagraph);
+    expect(legendParagraph.lastElementChild).toBe(legendItem);
+    cleanup.removeRegisteredListeners();
+  });
+
+  it("appends the legend item to the last bookmarked-project icon when multiple icons exist on the project board", async () => {
+    addLegendItem();
+    const content = addContentDiv();
+    addProjectHierarchyWithMultipleBookmarks(content, 2);
+    addLegendParagraph(content);
+
+    const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
+
+    expect(legendItem.hidden).toBe(false);
+    expect(legendItem.parentElement).toBe(legendParagraph);
+    expect(legendParagraph.lastElementChild).toBe(legendItem);
+    cleanup.removeRegisteredListeners();
+  });
+
+  it("appends the legend item to the last bookmarked-project icon when multiple icons exist on the project list", async () => {
+    addLegendItem();
+    const content = addContentDiv();
+    addProjectListWithMultipleBookmarks(content, 2);
+    addLegendParagraph(content);
 
     const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
 
@@ -51,7 +121,8 @@ describe("ai_helper_project_legend", () => {
   });
 
   it("does nothing when the legend item is absent", async () => {
-    addLegendParagraph();
+    const content = addContentDiv();
+    addLegendParagraph(content);
 
     const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
 
@@ -62,6 +133,7 @@ describe("ai_helper_project_legend", () => {
 
   it("does nothing and leaves the legend item hidden when the legend paragraph is absent", async () => {
     addLegendItem();
+    addContentDiv();
 
     const cleanup = await loadScriptAndFireDOMContentLoaded("assets/javascripts/project_legend/ai_helper_project_legend");
 

--- a/test/javascript/project_legend/ai_helper_project_legend.test.js
+++ b/test/javascript/project_legend/ai_helper_project_legend.test.js
@@ -5,6 +5,7 @@ describe("ai_helper_project_legend", () => {
   let legendItem;
   let legendParagraph;
   let bookmarkIcon;
+  let contentDiv;
 
   function addLegendItem() {
     legendItem = document.createElement("span");
@@ -15,20 +16,26 @@ describe("ai_helper_project_legend", () => {
   }
 
   function addLegendParagraph() {
+    contentDiv = document.createElement("div");
+    contentDiv.id = "content";
+    
     legendParagraph = document.createElement("p");
     bookmarkIcon = document.createElement("span");
     bookmarkIcon.className = "icon icon-bookmarked-project";
     legendParagraph.appendChild(bookmarkIcon);
-    document.body.appendChild(legendParagraph);
+    contentDiv.appendChild(legendParagraph);
+    document.body.appendChild(contentDiv);
     return legendParagraph;
   }
 
   afterEach(() => {
     legendItem?.remove();
     legendParagraph?.remove();
+    contentDiv?.remove();
     legendItem = undefined;
     legendParagraph = undefined;
     bookmarkIcon = undefined;
+    contentDiv = undefined;
   });
 
   it("unhides the legend item and appends it to the legend paragraph when both exist", async () => {

--- a/test/javascript/project_legend/ai_helper_project_legend.test.js
+++ b/test/javascript/project_legend/ai_helper_project_legend.test.js
@@ -18,7 +18,7 @@ describe("ai_helper_project_legend", () => {
   function addLegendParagraph() {
     contentDiv = document.createElement("div");
     contentDiv.id = "content";
-    
+
     legendParagraph = document.createElement("p");
     bookmarkIcon = document.createElement("span");
     bookmarkIcon.className = "icon icon-bookmarked-project";


### PR DESCRIPTION
This PR addresses an issue discovered in the implementation of PR #429.
The legend icon placement wasn't correct when one or more projects were bookmarked.

## Problem
When one or more projects are bookmarked, the AI Helper legend icon would be appended to the first bookmark icon found, causing incorrect positioning.

## Solution
Updated the selector logic to `querySelectorAll()`:

**Primary fix:** Uses `querySelectorAll('#content .icon-bookmarked-project')` to get all bookmark icons and selects the last one with `[length - 1]`, ensuring correct placement even with multiple bookmarked projects.

**Preventive measure:** `#content` scoping limits the search to the main content area, reducing the risk of selecting unintended elements.