### PR TITLE
Expose wiki page ID and support updating parent page

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/055-fix-icon-and-legend"
+  "feature_directory": "specs/056-wiki-parent-id"
 }

--- a/lib/redmine_ai_helper/tools/wiki_tools.rb
+++ b/lib/redmine_ai_helper/tools/wiki_tools.rb
@@ -40,7 +40,7 @@ module RedmineAiHelper
       def list_wiki_pages(project_id:)
         wiki = Wiki.find_by(project_id: project_id)
         raise("Wiki not found: project_id = #{project_id}") if !wiki || !wiki.visible?
-        pages = wiki.pages.filter(&:visible?)
+        pages = wiki.pages.includes(:parent, content: :author).filter(&:visible?)
         json = pages.map do |page|
           {
             id: page.id,

--- a/lib/redmine_ai_helper/tools/wiki_tools.rb
+++ b/lib/redmine_ai_helper/tools/wiki_tools.rb
@@ -30,7 +30,7 @@ module RedmineAiHelper
         wiki_data
       end
 
-      define_function :list_wiki_pages, description: "List all wiki pages in the project. It includes the title, author, created_on, and updated_on." do
+      define_function :list_wiki_pages, description: "List all wiki pages in the project. It includes the id, title, author, created_on, updated_on, and parent (id and title, or null if top-level)." do
         property :project_id, type: "integer", description: "The project ID of the wiki pages to list.", required: true
       end
       # List all wiki pages in the project.
@@ -43,13 +43,15 @@ module RedmineAiHelper
         pages = wiki.pages.filter(&:visible?)
         json = pages.map do |page|
           {
+            id: page.id,
             title: page.title,
             author: {
               id: page.content.author.id,
               name: page.content.author.name
             },
             created_on: page.created_on,
-            updated_on: page.updated_on
+            updated_on: page.updated_on,
+            parent: page.parent ? { id: page.parent.id, title: page.parent.title } : nil
           }
         end
         json

--- a/lib/redmine_ai_helper/tools/wiki_write_tools.rb
+++ b/lib/redmine_ai_helper/tools/wiki_write_tools.rb
@@ -57,30 +57,30 @@ module RedmineAiHelper
         )
         page.content = wiki_content
 
-        unless page.save
-          raise "Failed to create wiki page: #{page.errors.full_messages.join(", ")}"
-        end
+        save_or_raise!(page, "create wiki page")
 
         generate_wiki_data(page)
       end
 
-      define_function :wiki_update_page, description: "Update an existing wiki page's content and/or title.", write: true do
+      define_function :wiki_update_page, description: "Update an existing wiki page's content, title, and/or parent page.", write: true do
         property :project_id, type: "integer", description: "The project ID of the wiki.", required: true
         property :title, type: "string", description: "Current title of the page to update.", required: true
         property :content, type: "string", description: "New body text. Omit to leave content unchanged.", required: false
         property :new_title, type: "string", description: "New title for renaming. Omit to leave title unchanged.", required: false
         property :comment, type: "string", description: "Edit comment stored in version history.", required: false
+        property :parent_title, type: "string", description: "Title of the new parent page. Pass an empty string to clear the parent (make top-level). Omit to leave the parent unchanged.", required: false
       end
 
-      # Update an existing wiki page's content and/or title.
+      # Update an existing wiki page's content, title, and/or parent page.
       # @param project_id [Integer] The project ID.
       # @param title [String] Current title of the page to update.
       # @param content [String, nil] New body text. nil leaves content unchanged.
       # @param new_title [String, nil] New title for renaming. nil leaves title unchanged.
       # @param comment [String, nil] Optional edit comment.
+      # @param parent_title [String, nil] Title of the new parent page. Empty string clears the parent (top-level). nil leaves the parent unchanged.
       # @return [Hash] The updated wiki page data.
       # @raise [RuntimeError] If any precondition fails.
-      def wiki_update_page(project_id:, title:, content: nil, new_title: nil, comment: nil)
+      def wiki_update_page(project_id:, title:, content: nil, new_title: nil, comment: nil, parent_title: nil)
         raise "project_id is required" if project_id.nil?
         raise "title is required" if title.nil?
 
@@ -101,16 +101,27 @@ module RedmineAiHelper
             page.content.text = content
             page.content.author = User.current
             page.content.comments = comment unless comment.nil?
-            unless page.content.save
-              raise "Failed to update wiki content: #{page.content.errors.full_messages.join(", ")}"
-            end
+            save_or_raise!(page.content, "update wiki content")
           end
 
           unless new_title.nil?
             page.title = new_title
-            unless page.save
-              raise "Failed to rename wiki page: #{page.errors.full_messages.join(", ")}"
+            save_or_raise!(page, "rename wiki page")
+          end
+
+          unless parent_title.nil?
+            if parent_title.empty?
+              page.parent = nil
+            else
+              parent_page = wiki.find_page(parent_title)
+              raise "Parent page not found: title = #{parent_title}" unless parent_page
+              if parent_page == page || parent_page.ancestors.include?(page)
+                raise "Cannot set parent page: circular reference detected (title = #{parent_title})"
+              end
+
+              page.parent = parent_page
             end
+            save_or_raise!(page, "update wiki page parent")
           end
         end
 
@@ -147,6 +158,18 @@ module RedmineAiHelper
         page.destroy
 
         { deleted: true, title: title }
+      end
+
+      private
+
+      # Saves a wiki record or raises with its validation errors.
+      # @param record [ActiveRecord::Base] The record to save (a WikiPage or WikiContent).
+      # @param action [String] Short description of the action, used in the raised message.
+      # @raise [RuntimeError] If the record fails to save.
+      def save_or_raise!(record, action)
+        return if record.save
+
+        raise "Failed to #{action}: #{record.errors.full_messages.join(", ")}"
       end
     end
   end

--- a/lib/redmine_ai_helper/util/wiki_json.rb
+++ b/lib/redmine_ai_helper/util/wiki_json.rb
@@ -6,7 +6,8 @@ module RedmineAiHelper
       include RedmineAiHelper::Util::AttachmentFileHelper
       # Generates a JSON representation of a wiki page.
       # @param page [WikiPage] The wiki page to be represented in JSON.
-      # @return [Hash] A hash representing the wiki page in JSON format.
+      # @return [Hash] A hash representing the wiki page in JSON format. The `:parent` key is
+      #   `{ id:, title: }` when the page has a parent, or `nil` for a top-level page.
       def generate_wiki_data(page)
         {
           id: page.id,
@@ -25,7 +26,7 @@ module RedmineAiHelper
               title: child.title
             }
           end,
-          parent: page.parent ? { title: page.parent.title } : nil,
+          parent: page.parent ? { id: page.parent.id, title: page.parent.title } : nil,
           attachments: page.attachments.map do |attachment|
             {
               id: attachment.id,

--- a/test/unit/tools/wiki_tool_provider_test.rb
+++ b/test/unit/tools/wiki_tool_provider_test.rb
@@ -1,7 +1,7 @@
 require File.expand_path("../../../test_helper", __FILE__)
 
 class WikiToolsTest < ActiveSupport::TestCase
-  fixtures :projects, :wikis, :wiki_pages, :users
+  fixtures :projects, :wikis, :wiki_pages, :users, :enabled_modules
 
   def setup
     @provider = RedmineAiHelper::Tools::WikiTools.new
@@ -22,10 +22,53 @@ class WikiToolsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_read_wiki_page_returns_parent_as_id_and_title_for_child_page
+    child_page = @wiki.pages.find_by(title: "Page_with_an_inline_image")
+
+    response = @provider.read_wiki_page(project_id: @project.id, title: child_page.title)
+
+    assert_equal({ id: child_page.parent.id, title: child_page.parent.title }, response[:parent])
+  end
+
   def test_list_wiki_pages
     response = @provider.list_wiki_pages(project_id: @project.id)
 
     assert_equal @wiki.pages.count, response.size
+  end
+
+  def test_list_wiki_pages_includes_own_id_for_each_element
+    response = @provider.list_wiki_pages(project_id: @project.id)
+
+    response.each do |element|
+      page = @wiki.pages.find_by(title: element[:title])
+      assert_equal page.id, element[:id]
+    end
+  end
+
+  def test_list_wiki_pages_includes_parent_as_id_and_title_for_child_element
+    response = @provider.list_wiki_pages(project_id: @project.id)
+    child_page = @wiki.pages.find_by(title: "Page_with_an_inline_image")
+    element = response.find { |e| e[:title] == child_page.title }
+
+    assert_equal({ id: child_page.parent.id, title: child_page.parent.title }, element[:parent])
+  end
+
+  def test_list_wiki_pages_returns_nil_parent_for_top_level_element
+    response = @provider.list_wiki_pages(project_id: @project.id)
+    top_level_page = @wiki.pages.find_by(title: "CookBook_documentation")
+    element = response.find { |e| e[:title] == top_level_page.title }
+
+    assert_nil element[:parent]
+  end
+
+  def test_list_wiki_pages_raises_when_ai_helper_disabled_unchanged
+    # ai_helper module disabled state does not affect list_wiki_pages, which only
+    # checks wiki visibility; this asserts current wiki-not-found behavior is unchanged.
+    EnabledModule.where(project_id: 3, name: "ai_helper").delete_all
+
+    assert_raises(RuntimeError, "Wiki not found: project_id = 3") do
+      @provider.list_wiki_pages(project_id: 3)
+    end
   end
 
   def test_generate_url_for_wiki_page

--- a/test/unit/tools/wiki_write_tools_test.rb
+++ b/test/unit/tools/wiki_write_tools_test.rb
@@ -34,6 +34,7 @@ class WikiWriteToolsTest < ActiveSupport::TestCase
 
       assert_not_nil page.parent
       assert_equal "CookBook_documentation", page.parent.title
+      assert_equal({ id: page.parent.id, title: "CookBook_documentation" }, result[:parent])
     end
 
     should "raise error when permission denied (no :edit_wiki_pages)" do
@@ -184,6 +185,129 @@ class WikiWriteToolsTest < ActiveSupport::TestCase
       assert_raises(RuntimeError, "title is required") do
         @provider.wiki_update_page(project_id: 1, title: nil, content: "content")
       end
+    end
+
+    should "set parent to an existing page when parent_title is given" do
+      result = @provider.wiki_update_page(project_id: 1, title: "Another_page", parent_title: "CookBook_documentation")
+      page = WikiPage.find(result[:id])
+
+      assert_equal "CookBook_documentation", page.parent.title
+      assert_equal({ id: page.parent.id, title: "CookBook_documentation" }, result[:parent])
+    end
+
+    should "clear the parent (make top-level) when parent_title is an empty string" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Child_1")
+      assert_not_nil page.parent
+
+      result = @provider.wiki_update_page(project_id: 1, title: "Child_1", parent_title: "")
+      page.reload
+
+      assert_nil page.parent
+      assert_nil result[:parent]
+    end
+
+    should "leave the parent unchanged when parent_title is omitted" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Child_1")
+      original_parent_id = page.parent_id
+
+      result = @provider.wiki_update_page(project_id: 1, title: "Child_1", content: "updated content")
+      page.reload
+
+      assert_equal original_parent_id, page.parent_id
+      assert_equal({ id: original_parent_id, title: "Another_page" }, result[:parent])
+    end
+
+    should "raise error and leave parent unchanged when parent_title is not found" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Another_page")
+      original_parent_id = page.parent_id
+
+      error = assert_raises(RuntimeError) do
+        @provider.wiki_update_page(project_id: 1, title: "Another_page", parent_title: "NonExistentParent")
+      end
+      assert_equal "Parent page not found: title = NonExistentParent", error.message
+      page.reload
+      assert_nil original_parent_id
+      assert_nil page.parent_id
+    end
+
+    should "raise error and leave parent unchanged when parent_title is a self-reference" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Child_1")
+      original_parent_id = page.parent_id
+
+      error = assert_raises(RuntimeError) do
+        @provider.wiki_update_page(project_id: 1, title: "Child_1", parent_title: "Child_1")
+      end
+      assert_equal "Cannot set parent page: circular reference detected (title = Child_1)", error.message
+      page.reload
+      assert_equal original_parent_id, page.parent_id
+    end
+
+    should "raise error and leave parent unchanged when parent_title is a descendant page" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Child_1")
+      original_parent_id = page.parent_id
+
+      error = assert_raises(RuntimeError) do
+        @provider.wiki_update_page(project_id: 1, title: "Child_1", parent_title: "Child_1_1")
+      end
+      assert_equal "Cannot set parent page: circular reference detected (title = Child_1_1)", error.message
+      page.reload
+      assert_equal original_parent_id, page.parent_id
+    end
+
+    should "raise error when permission denied (no :edit_wiki_pages) and leave parent unchanged" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Another_page")
+      original_parent_id = page.parent_id
+
+      role = Role.find(1) # Manager
+      role.permissions = (role.permissions + [ :view_ai_helper ]).reject { |p| p == :edit_wiki_pages }
+      role.save!
+      User.current = User.find(2) # Jsmith has Manager role in project 1
+
+      assert_raises(RuntimeError, "Permission denied") do
+        @provider.wiki_update_page(project_id: 1, title: "Another_page", parent_title: "CookBook_documentation")
+      end
+      page.reload
+      assert_nil original_parent_id
+      assert_nil page.parent_id
+    end
+
+    should "apply both parent_title and new_title in one call" do
+      result = @provider.wiki_update_page(
+        project_id: 1,
+        title: "Another_page",
+        new_title: "RenamedPage3",
+        parent_title: "CookBook_documentation"
+      )
+      page = WikiPage.find(result[:id])
+
+      assert_equal "RenamedPage3", page.title
+      assert_equal "CookBook_documentation", page.parent.title
+      assert_equal "RenamedPage3", result[:title]
+      assert_equal({ id: page.parent.id, title: "CookBook_documentation" }, result[:parent])
+    end
+
+    should "roll back content changes when parent_title update fails" do
+      wiki = Wiki.find_by(project_id: 1)
+      page = wiki.find_page("Another_page")
+      original_text = page.content.text
+
+      assert_raises(RuntimeError) do
+        @provider.wiki_update_page(
+          project_id: 1,
+          title: "Another_page",
+          content: "should not persist",
+          parent_title: "NonExistentParent"
+        )
+      end
+
+      page.reload
+      assert_equal original_text, page.content.text
     end
   end
 

--- a/test/unit/util/wiki_json_test.rb
+++ b/test/unit/util/wiki_json_test.rb
@@ -80,6 +80,21 @@ class RedmineAiHelper::Util::WikiJsonTest < ActiveSupport::TestCase
           "Attachment data must not contain disk_path for security reasons"
       end
     end
+
+    should "return parent as { id:, title: } when the page has a parent" do
+      child_page = @wiki.pages.find_by(title: "Page_with_an_inline_image")
+
+      wiki_data = @test_class.generate_wiki_data(child_page)
+
+      assert_equal({ id: child_page.parent.id, title: child_page.parent.title }, wiki_data[:parent])
+    end
+
+    should "return parent as nil when the page has no parent" do
+      wiki_data = @test_class.generate_wiki_data(@page)
+
+      assert_nil @page.parent
+      assert_nil wiki_data[:parent]
+    end
   end
 
   class TestClass < RedmineAiHelper::BaseTools

--- a/wiki/INDEX.md
+++ b/wiki/INDEX.md
@@ -38,6 +38,7 @@ page files, not here.
 - [LLM Provider Layer](./pages/llm-provider-layer.md) — the `LlmProvider` factory, resolution paths, provider subclasses/quirks, profile config, and structured output.
 - [Vector Search Internals](./pages/vector-search-internals.md) — Qdrant subsystem components, hybrid content/embeddings, payload indexes, rake tasks, staleness sync, and project-selection scope/gating.
 - [JavaScript Quality Tooling](./pages/js-quality-tooling.md) — ESLint 10 flat config + Vitest 4/jsdom + `@vitest/coverage-v8`, Node.js/npm setup, and regression-check/CI wiring.
+- [Wiki Tools](./pages/wiki-tools.md) — `WikiTools`/`WikiWriteTools`: the unified `{id:, title:}` parent format, `wiki_update_page`'s `parent_title` semantics and validation, and why cross-wiki parents and N+1 eager-loading were left alone.
 
 ## reference
 - [Chat History APIs](./pages/chat-history-apis.md) — Slack/Discord message-retrieval APIs, scopes, display-name resolution, exclusion rules.

--- a/wiki/pages/tool-system.md
+++ b/wiki/pages/tool-system.md
@@ -1,8 +1,8 @@
 ---
 title: Tool System
 type: component
-sources: [S008, S016, S026]
-updated: 2026-08-24
+sources: [S008, S016, S026, S032]
+updated: 2026-09-01
 ---
 
 # Tool System
@@ -63,7 +63,7 @@ providers' functions it may call — a per-agent permission boundary (S008).
 | `IssueTools`, `IssueSearchTools` | Issue read/search; filter operators like `=`, `>=`, `><t+` |
 | `IssueUpdateTools` | Create/update issues (atomic, `parent_issue_id` hierarchy) |
 | `ProjectTools`, `VersionTools` | Metadata; `accessible_project?` checks |
-| `WikiTools`, `WikiWriteTools` | Wiki read / write |
+| `WikiTools`, `WikiWriteTools` | Wiki read / write — see [Wiki Tools](./wiki-tools.md) |
 | `VectorTools` | Semantic search over Qdrant |
 | `FileTools` | Document analysis via prompt templates |
 | `ImageTools` | Image-attachment handling |
@@ -81,3 +81,4 @@ providers' functions it may call — a per-agent permission boundary (S008).
   [MCP Integration](./mcp-integration.md) · [Vector Search](./vector-search.md)
 - [Agent Write-Capability Routing](./agent-write-capability-routing.md)
 - [search_issues Cross-Project Scoping](./search-issues-cross-project-scoping.md)
+- [Wiki Tools](./wiki-tools.md)

--- a/wiki/pages/wiki-tools.md
+++ b/wiki/pages/wiki-tools.md
@@ -1,0 +1,94 @@
+---
+title: Wiki Tools
+type: component
+sources: [S032]
+updated: 2026-09-01
+---
+
+# Wiki Tools
+
+`RedmineAiHelper::Tools::WikiTools` (read) and `WikiWriteTools` (write) are the
+[Tool System](./tool-system.md) providers registered on `wiki_agent`. Both
+share one serializer, `RedmineAiHelper::Util::WikiJson#generate_wiki_data`, for
+turning a `WikiPage` into the JSON handed to the LLM (S032).
+
+## Parent page output format
+
+Every tool that returns page data — `read_wiki_page`, `wiki_add_page`,
+`wiki_update_page` (all via `generate_wiki_data`) and `list_wiki_pages`
+(built independently) — reports the parent page the same way:
+
+```json
+"parent": { "id": 12, "title": "Parent Page" }   // or null for a top-level page
+```
+
+This is a non-breaking extension: the `title` key already existed, `id` was
+added alongside it. `list_wiki_pages` additionally gained its own `id` field
+per element, so a flat page list can be reassembled into a tree client-side
+without a second lookup (S032).
+
+## `wiki_update_page`'s `parent_title` parameter
+
+`parent_title` (optional, string) reparents an existing page in the same
+transaction as its `content`/`new_title` update — one failure rolls back the
+whole change:
+
+- **omitted** (`nil`) — parent is left untouched.
+- **empty string** (`""`) — the page is detached and becomes top-level.
+- **non-empty string** — the page's own wiki is searched for a page with that
+  title (`wiki.find_page(parent_title)`) and, if found and valid, becomes the
+  new parent.
+
+Validation is done with explicit checks and `raise` — the same style
+`wiki_add_page` already used — rather than by setting `page.parent_title=`
+and inspecting `page.errors`. The rejected alternative would have been
+shorter, but its error text comes from Rails i18n defaults (e.g. "Parent
+page is invalid") instead of the project's own specific, English `raise`
+messages, breaking consistency with the rest of `WikiWriteTools` (S032):
+
+| Condition | Error |
+|---|---|
+| No page with that title in this wiki | `"Parent page not found: title = {parent_title}"` |
+| Target is the page itself or one of its own descendants | `"Cannot set parent page: circular reference detected (title = {parent_title})"` |
+| Save fails after validation passes | `"Failed to update wiki page parent: {validation errors}"` |
+
+No new permission category was introduced — these checks run inside the
+same `:edit_wiki_pages` + ai_helper-module-enabled gate `wiki_update_page`
+already enforced (S032).
+
+## Cross-wiki parents are rejected implicitly
+
+`Wiki#find_page` only searches that wiki's own `pages` association, so a
+`parent_title` naming a page in a *different* project's wiki simply doesn't
+match — it surfaces as the ordinary "Parent page not found" error. No
+separate same-project check was added; Redmine core's `not_same_project`
+validation was deliberately not called from here (S032).
+
+## Circular-reference check reuses `acts_as_tree`
+
+Redmine core's `WikiPage` already provides `parent`/`children`/`ancestors`
+via `acts_as_tree` (no new gem). A candidate parent is rejected when it
+equals the target page or when `candidate.ancestors.include?(target)` —
+i.e. the candidate is a descendant of the page being reparented (S032).
+
+## No N+1 optimization added for `parent`
+
+`list_wiki_pages` now dereferences `page.parent` for every page returned,
+each a lazy-loaded `belongs_to` lookup (at most one query per page with a
+parent). No `includes(:parent)` eager-load was added: the existing
+`list_wiki_pages` already has the same shape of N+1 through
+`page.content.author`, and matching that existing pattern was preferred over
+a one-off optimization (S032).
+
+## No new migration
+
+Everything here reuses the existing `wiki_pages.parent_id` column and
+`acts_as_tree` relations — no schema change (S032).
+
+## Related
+
+- [Tool System](./tool-system.md) — the `BaseTools` DSL and `write:` tagging
+  these providers use.
+- [Agent Write-Capability Routing](./agent-write-capability-routing.md) —
+  how `WikiWriteTools`' `write_tool?` flag feeds `wiki_agent`'s
+  `can_write?`.

--- a/wiki/sources.md
+++ b/wiki/sources.md
@@ -36,3 +36,4 @@ Sources are immutable inputs — the wiki never edits them.
 | S029 | specs/051-mcp-reject-subscriptions-listen/review-summary.md | feature-artifact | 2026-08-26 | 2026-08-26 | mcp-listen-rejection.md |
 | S030 | specs/052-fix-mcp14-subscriptions-listen (research.md + plan.md) | feature-artifact | 2026-08-28 | 2026-08-28 | mcp-listen-rejection.md, mcp-listen-rejection-1-4-0-fix.md, mcp-server-endpoint.md |
 | S031 | docs/adr/032-mcp14-restore-subscriptions-listen-rejection.md | file | 2026-08-28 | 2026-08-28 | mcp-listen-rejection.md, mcp-listen-rejection-1-4-0-fix.md, mcp-server-endpoint.md |
+| S032 | specs/056-wiki-parent-id (research.md + plan.md) | feature-artifact | 2026-09-01 | 2026-09-01 | wiki-tools.md, tool-system.md |


### PR DESCRIPTION
## Changes

- Expose wiki page id in wiki tool results
- Support updating a wiki page's parent page via WikiWriteTools
- Add Wiki Tools documentation page

Related to #433